### PR TITLE
fix(shared): remove lastEventExternalCreatedAt from Document type

### DIFF
--- a/libs/methodologies/bold/testing/src/documents/approved-mass-document.ts
+++ b/libs/methodologies/bold/testing/src/documents/approved-mass-document.ts
@@ -550,7 +550,6 @@ export const approvedMassDocument: Document = {
   initialValue: 0,
   isPublic: true,
   isPubliclySearchable: true,
-  lastProcessedEventDate: lastEventExternalCreatedAt,
   measurementUnit: 'KG',
   permissions: [
     {

--- a/libs/methodologies/bold/testing/src/documents/rejected-mass-document.ts
+++ b/libs/methodologies/bold/testing/src/documents/rejected-mass-document.ts
@@ -542,7 +542,6 @@ export const rejectedMassDocument: Document = {
   initialValue: 0,
   isPublic: true,
   isPubliclySearchable: true,
-  lastProcessedEventDate: lastEventExternalCreatedAt,
   measurementUnit: 'HG',
   permissions: [
     {

--- a/libs/methodologies/bold/types/src/document.types.ts
+++ b/libs/methodologies/bold/types/src/document.types.ts
@@ -31,7 +31,6 @@ export interface Document {
   initialValue: number & tags.Minimum<0> & tags.Type<'float'>;
   isPublic?: boolean | undefined;
   isPubliclySearchable: boolean;
-  lastProcessedEventDate: string & tags.Format<'date-time'>;
   measurementUnit: string;
   parentDocumentId?: string | undefined;
   permissions?: Array<UnknownObject> | undefined;


### PR DESCRIPTION
### Summary

Remove lastEventExternalCreatedAt from Document type

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**
