### PR TITLE
Adjust net weight verification rule [CARROT-930]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.processor.spec.ts
@@ -41,6 +41,19 @@ describe('NetWeightVerificationProcessor', () => {
         externalEvents: [
           replaceMetadataAttributeValue(
             stubWeighingMoveEvent(),
+            DocumentEventAttributeName.LOAD_NET_WEIGHT,
+            '',
+          ),
+        ],
+      }),
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario: 'no load-net-weight attribute',
+    },
+    {
+      document: stubDocument({
+        externalEvents: [
+          replaceMetadataAttributeValue(
+            stubWeighingMoveEvent(),
             DocumentEventAttributeName.VEHICLE_GROSS_WEIGHT,
             '12.00 KG',
           ),

--- a/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.processor.ts
@@ -52,7 +52,7 @@ export class NetWeightVerificationProcessor extends RuleDataProcessor {
       const attributes = extractWeightAttributes(event);
 
       if (!attributes) {
-        return false;
+        return true;
       }
 
       const { loadNetWeight, vehicleGrossWeight, vehicleWeight } = attributes;

--- a/libs/methodologies/bold/testing/src/documents/rejected-mass-document.ts
+++ b/libs/methodologies/bold/testing/src/documents/rejected-mass-document.ts
@@ -378,17 +378,17 @@ export const rejectedMassDocument: Document = {
           {
             isPublic: true,
             name: 'vehicle-gross-weight',
-            value: '128900.00 HG',
+            value: '128900.00 KG',
           },
           {
             isPublic: true,
             name: 'vehicle-weight',
-            value: '19700.00 HG',
+            value: '19700.00 KG',
           },
           {
             isPublic: true,
             name: 'load-net-weight',
-            value: '109200.00 HG',
+            value: '1092000.00 KG',
           },
         ],
       },


### PR DESCRIPTION
### Summary

Adjust net weight check rule

### Details

**We have to adjust the Net Weight Verification rule to be more flexible.**
When there is a MOVE event with move-type = weighing we have to check if we have all the metadata to pass the rule:
- if yes, apply the check;
- if there is none, approve the mass for the specific rule.

### Related links

Task; https://app.clickup.com/t/3005225/CARROT-930
Methodology Rule ajusted: https://www.notion.so/carrot-fndn/0fe8093c45aa4c3fad0791697b3900f4?v=f8b5ae29a8b74bc28243a0a533c65e79&p=229513de78be41f5824ca82253ebaf30&pm=s

---

- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**
