### PR TITLE
feat(rule): :sparkles: update geolocation-precision rule to validate app-gps values

### DIFF
--- a/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
@@ -441,7 +441,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
       resultComment:
         ruleDataProcessor['ResultComment'].METADATA_GEOLOCATION_INVALID,
       scenario:
-        'should return REKECTED when the app-gps-latitude and app-gps-longitude are invalid data types',
+        'should return REJECTED when the app-gps-latitude and app-gps-longitude are invalid data types',
     },
     {
       documents: [

--- a/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
@@ -407,6 +407,73 @@ describe('GeolocationPrecisionRuleProcessor', () => {
       scenario:
         'should return REJECTED when the app-gps-latitude and app-gps-longitude are found and the geolocation precision is not valid',
     },
+    {
+      documents: [
+        {
+          ...massDocumentStub,
+          externalEvents: [
+            {
+              ...pickUpEvent,
+              metadata: {
+                attributes: [
+                  ...(pickUpEvent.metadata?.attributes ?? []),
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LATITUDE,
+                    value: faker.string.uuid(),
+                  },
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LONGITUDE,
+                    value: faker.string.uuid(),
+                  },
+                ],
+              },
+            },
+            stubDocumentEvent({
+              name: DocumentEventName.OUTPUT,
+              relatedDocument: massValidationReference,
+            }),
+          ],
+        },
+        recyclerHomologationDocumentStub,
+      ],
+      resultComment:
+        ruleDataProcessor['ResultComment'].METADATA_GEOLOCATION_INVALID,
+      scenario:
+        'should return REKECTED when the app-gps-latitude and app-gps-longitude are invalid data types',
+    },
+    {
+      documents: [
+        {
+          ...massDocumentStub,
+          externalEvents: [
+            {
+              ...pickUpEvent,
+              metadata: {
+                attributes: [
+                  ...(pickUpEvent.metadata?.attributes ?? []),
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LATITUDE,
+                    value: faker.location.latitude(),
+                  },
+                ],
+              },
+            },
+            stubDocumentEvent({
+              name: DocumentEventName.OUTPUT,
+              relatedDocument: massValidationReference,
+            }),
+          ],
+        },
+        recyclerHomologationDocumentStub,
+      ],
+      resultComment:
+        ruleDataProcessor['ResultComment'].METADATA_GEOLOCATION_INVALID,
+      scenario:
+        'should return REJECTED when the app-gps-latitude is found but the app-gps-longitude is not',
+    },
   ])('$scenario', async ({ documents, resultComment }) => {
     spyOnDocumentQueryServiceLoad(stubDocument(), [
       massValidationDocumentStub,

--- a/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
@@ -169,6 +169,39 @@ describe('GeolocationPrecisionRuleProcessor', () => {
       scenario:
         'should return APPROVED when the homologation address is equal and the geolocation precision is valid',
     },
+    {
+      documents: [
+        {
+          ...massDocumentStub,
+          externalEvents: [
+            {
+              ...pickUpEvent,
+              metadata: {
+                attributes: [
+                  ...(pickUpEvent.metadata?.attributes ?? []),
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LATITUDE,
+                    value: pickUpEvent.address.latitude,
+                  },
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LONGITUDE,
+                    value: pickUpEvent.address.longitude,
+                  },
+                ],
+              },
+            },
+            stubDocumentEvent({
+              name: DocumentEventName.OUTPUT,
+              relatedDocument: massValidationReference,
+            }),
+          ],
+        },
+      ],
+      scenario:
+        'should return APPROVED when the app-gps-latitude and app-gps-longitude are found and the geolocation precision is valid',
+    },
   ])('$scenario', async ({ documents, resultComment }) => {
     spyOnDocumentQueryServiceLoad(stubDocument(), [
       massValidationDocumentStub,
@@ -198,7 +231,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
 
   it.each([
     {
-      documents: [],
+      documents: [massDocumentStub],
       resultComment:
         ruleDataProcessor['ResultComment'].HOMOLOGATION_DOCUMENT_NOT_FOUND,
       scenario:
@@ -206,6 +239,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
     },
     {
       documents: [
+        massDocumentStub,
         {
           ...recyclerHomologationDocumentStub,
           externalEvents: stubArray(stubDocumentEvent),
@@ -240,6 +274,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
     },
     {
       documents: [
+        massDocumentStub,
         {
           ...recyclerHomologationDocumentStub,
           externalEvents: [
@@ -258,6 +293,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
     },
     {
       documents: [
+        massDocumentStub,
         {
           ...recyclerHomologationDocumentStub,
           externalEvents: [
@@ -277,6 +313,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
     },
     {
       documents: [
+        massDocumentStub,
         {
           ...recyclerHomologationDocumentStub,
           externalEvents: [
@@ -296,6 +333,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
     },
     {
       documents: [
+        massDocumentStub,
         {
           ...recyclerHomologationDocumentStub,
           externalEvents: [
@@ -314,6 +352,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
     },
     {
       documents: [
+        massDocumentStub,
         {
           ...recyclerHomologationDocumentStub,
           externalEvents: [
@@ -334,9 +373,42 @@ describe('GeolocationPrecisionRuleProcessor', () => {
       scenario:
         'should return REJECTED when the homologation address is equal but the distance is greater than 2',
     },
+    {
+      documents: [
+        {
+          ...massDocumentStub,
+          externalEvents: [
+            {
+              ...pickUpEvent,
+              metadata: {
+                attributes: [
+                  ...(pickUpEvent.metadata?.attributes ?? []),
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LATITUDE,
+                    value: faker.location.latitude(),
+                  },
+                  {
+                    isPublic: false,
+                    name: DocumentEventAttributeName.APP_GPS_LONGITUDE,
+                    value: faker.location.longitude(),
+                  },
+                ],
+              },
+            },
+            stubDocumentEvent({
+              name: DocumentEventName.OUTPUT,
+              relatedDocument: massValidationReference,
+            }),
+          ],
+        },
+        recyclerHomologationDocumentStub,
+      ],
+      scenario:
+        'should return REJECTED when the app-gps-latitude and app-gps-longitude are found and the geolocation precision is not valid',
+    },
   ])('$scenario', async ({ documents, resultComment }) => {
     spyOnDocumentQueryServiceLoad(stubDocument(), [
-      massDocumentStub,
       massValidationDocumentStub,
       methodologyDocumentStub,
       participantHomologationGroupDocumentStub,

--- a/libs/methodologies/bold/processors/src/geolocation-precision-processor.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision-processor.ts
@@ -38,6 +38,7 @@ import {
   compareAddresses,
   getParticipantHomologationDocument,
   homologationIsNotExpired,
+  mapMassDocumentAddress,
   participantHomologationCriteria,
 } from './geolocation-precision.helpers';
 
@@ -148,7 +149,7 @@ export abstract class GeolocationPrecisionRuleProcessor extends RuleDataProcesso
 
     return {
       homologationDocument: participantHomologationDocument,
-      massDocumentAddress: massDocumentEvent.address,
+      massDocumentAddress: mapMassDocumentAddress(massDocumentEvent),
     };
   }
 

--- a/libs/methodologies/bold/processors/src/geolocation-precision.helpers.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision.helpers.ts
@@ -1,5 +1,9 @@
 import type { DocumentCriteria } from '@carrot-fndn/methodologies/bold/io-helpers';
-import type { NonEmptyString } from '@carrot-fndn/shared/types';
+import type {
+  Latitude,
+  Longitude,
+  NonEmptyString,
+} from '@carrot-fndn/shared/types';
 
 import { getEventAttributeValue } from '@carrot-fndn/methodologies/bold/getters';
 import {
@@ -109,6 +113,23 @@ export const compareAddresses = (
   );
 };
 
+export const isMetadataGeolocationValid = (event: DocumentEvent): boolean => {
+  const gpsLatitude = getEventAttributeValue(
+    event,
+    DocumentEventAttributeName.APP_GPS_LATITUDE,
+  );
+  const gpsLongitude = getEventAttributeValue(
+    event,
+    DocumentEventAttributeName.APP_GPS_LONGITUDE,
+  );
+
+  if (isNil(gpsLatitude) && isNil(gpsLongitude)) {
+    return true;
+  }
+
+  return is<Latitude>(gpsLatitude) && is<Longitude>(gpsLongitude);
+};
+
 export const mapMassDocumentAddress = (event: DocumentEvent): Address => {
   const gpsLatitude = getEventAttributeValue(
     event,
@@ -119,13 +140,9 @@ export const mapMassDocumentAddress = (event: DocumentEvent): Address => {
     DocumentEventAttributeName.APP_GPS_LONGITUDE,
   );
 
-  if (is<number>(gpsLatitude) && is<number>(gpsLongitude)) {
-    return {
-      ...event.address,
-      latitude: gpsLatitude,
-      longitude: gpsLongitude,
-    };
-  }
-
-  return event.address;
+  return {
+    ...event.address,
+    latitude: (gpsLatitude ?? event.address.latitude) as Latitude,
+    longitude: (gpsLongitude ?? event.address.longitude) as Longitude,
+  };
 };

--- a/libs/methodologies/bold/processors/src/geolocation-precision.helpers.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision.helpers.ts
@@ -14,6 +14,7 @@ import {
 import {
   type Address,
   type Document,
+  type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
   type DocumentSubtype,
@@ -106,4 +107,25 @@ export const compareAddresses = (
     pick(addressA, 'latitude', 'longitude'),
     pick(addressB, 'latitude', 'longitude'),
   );
+};
+
+export const mapMassDocumentAddress = (event: DocumentEvent): Address => {
+  const gpsLatitude = getEventAttributeValue(
+    event,
+    DocumentEventAttributeName.APP_GPS_LATITUDE,
+  );
+  const gpsLongitude = getEventAttributeValue(
+    event,
+    DocumentEventAttributeName.APP_GPS_LONGITUDE,
+  );
+
+  if (is<number>(gpsLatitude) && is<number>(gpsLongitude)) {
+    return {
+      ...event.address,
+      latitude: gpsLatitude,
+      longitude: gpsLongitude,
+    };
+  }
+
+  return event.address;
 };

--- a/libs/methodologies/bold/types/src/enum.types.ts
+++ b/libs/methodologies/bold/types/src/enum.types.ts
@@ -75,6 +75,8 @@ export enum DocumentEventName {
 
 export enum DocumentEventAttributeName {
   ACTOR_TYPE = 'actor-type',
+  APP_GPS_LATITUDE = 'app-gps-latitude',
+  APP_GPS_LONGITUDE = 'app-gps-longitude',
   CERTIFICATE_VALUE_LABEL = 'certificate-value-label',
   DRIVER_INTERNAL_ID = 'driver-internal-id',
   EVENT_VALUE = 'event-value',

--- a/libs/shared/types/src/number.types.ts
+++ b/libs/shared/types/src/number.types.ts
@@ -3,3 +3,13 @@ import type { tags } from 'typia';
 export type NonZeroPositive = number &
   tags.ExclusiveMinimum<0> &
   tags.Type<'float'>;
+
+export type Latitude = number &
+  tags.Maximum<90> &
+  tags.Minimum<-90> &
+  tags.Type<'float'>;
+
+export type Longitude = number &
+  tags.Maximum<180> &
+  tags.Minimum<-180> &
+  tags.Type<'float'>;


### PR DESCRIPTION
### Summary

Update the geolocation-precision-processor to validate the app-gps values that are passed in metadata.


### Related links

https://app.clickup.com/t/3005225/CARROT-957

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced test scenarios for validating geolocation precision, affecting approval/rejection outcomes based on latitude and longitude attributes.
  
- **Bug Fixes**
  - Added latitude and longitude attributes to enhance the precision of geolocation metadata validation.

- **Documentation**
  - Updated test cases to include scenarios for geolocation precision processing.

- **Refactor**
  - Improved geolocation metadata checks and mapping functions for better accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->