### PR TITLE
Make rules deployment independent

### DIFF
--- a/.github/workflows/check-and-deploy.yaml
+++ b/.github/workflows/check-and-deploy.yaml
@@ -3,9 +3,9 @@ name: Check and Deploy
 on:
   push:
     branches:
-      - "**"
+      - '**'
     tags-ignore:
-      - "**"
+      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +29,7 @@ jobs:
 
       - id: affected
         run: |
-          echo "backend=$([ $(pnpm nx show projects -t lint ts --affected --json) = '[]' ] && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
+          echo "backend=$([ $(pnpm nx show projects -t lint ts test --affected --json) = '[]' ] && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
           echo "upload-lambda=$([ $(pnpm nx show projects -t upload-lambda --affected --json) = '[]' ] && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
 
   backend-check:
@@ -43,6 +43,6 @@ jobs:
   deploy:
     name: Deploy
     needs: [affected, backend-check]
-    if: ${{ github.ref_name == 'main' && needs.affected.outputs.upload-lambda == 'true' && (needs.backend-check.result == 'success' || needs.backend-check.result == 'skipped') }}
+    if: ${{ github.ref_name == 'main' && needs.affected.outputs.upload-lambda == 'true' }}
     uses: ./.github/workflows/deploy.yaml
     secrets: inherit

--- a/nx.json
+++ b/nx.json
@@ -81,14 +81,13 @@
     },
     "upload-lambda": {
       "executor": "nx:run-commands",
-      "cache": true,
       "inputs": [
         "build",
         "^production",
         "{workspaceRoot}/scripts/package-lambda.sh",
         "{workspaceRoot}/scripts/upload-lambda.sh"
       ],
-      "dependsOn": ["package-lambda"],
+      "dependsOn": ["ts", "lint", "test", "package-lambda"],
       "options": {
         "commands": [
           "{workspaceRoot}/scripts/upload-lambda.sh {projectRoot} {args.zipPath} {args.environment}",


### PR DESCRIPTION
### Summary

Instead of requiring all of the rules tests, lint and typescript check to pass for the deployment to occur, each rule deployment now only require its own tests, lint and typescript check to pass

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated branch filtering and deployment conditions in the workflow configuration to streamline the CI/CD process.
  - Simplified dependencies for the `upload-lambda` task to ensure it runs only when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->