### PR TITLE
Revert deployment isolation

### DIFF
--- a/.github/workflows/check-and-deploy.yaml
+++ b/.github/workflows/check-and-deploy.yaml
@@ -3,9 +3,9 @@ name: Check and Deploy
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +29,7 @@ jobs:
 
       - id: affected
         run: |
-          echo "backend=$([ $(pnpm nx show projects -t lint ts test --affected --json) = '[]' ] && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
+          echo "backend=$([ $(pnpm nx show projects -t lint ts --affected --json) = '[]' ] && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
           echo "upload-lambda=$([ $(pnpm nx show projects -t upload-lambda --affected --json) = '[]' ] && echo 'false' || echo 'true')" >> $GITHUB_OUTPUT
 
   backend-check:
@@ -43,6 +43,6 @@ jobs:
   deploy:
     name: Deploy
     needs: [affected, backend-check]
-    if: ${{ github.ref_name == 'main' && needs.affected.outputs.upload-lambda == 'true' }}
+    if: ${{ github.ref_name == 'main' && needs.affected.outputs.upload-lambda == 'true' && (needs.backend-check.result == 'success' || needs.backend-check.result == 'skipped') }}
     uses: ./.github/workflows/deploy.yaml
     secrets: inherit

--- a/nx.json
+++ b/nx.json
@@ -81,13 +81,14 @@
     },
     "upload-lambda": {
       "executor": "nx:run-commands",
+      "cache": true,
       "inputs": [
         "build",
         "^production",
         "{workspaceRoot}/scripts/package-lambda.sh",
         "{workspaceRoot}/scripts/upload-lambda.sh"
       ],
-      "dependsOn": ["ts", "lint", "test", "package-lambda"],
+      "dependsOn": ["package-lambda"],
       "options": {
         "commands": [
           "{workspaceRoot}/scripts/upload-lambda.sh {projectRoot} {args.zipPath} {args.environment}",


### PR DESCRIPTION
This reverts commit b587e3ed0bf0fac1e26fed57f3a14f0fd938476f.

### Summary

The deployment time almost tripled as the tests were executed being executed 3x (backend check, development and production)

### Details

We need to implement a better way to handle independent deployment

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated branch filtering patterns and deployment conditions in the CI/CD workflow.
  - Modified the `upload-lambda` task configuration for better caching and dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->