### PR TITLE
feat(rule): :sparkles: update the result comment in evaluteResult method

### DIFF
--- a/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision-processor.spec.ts
@@ -346,7 +346,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
           ],
         },
       ],
-      resultComment: undefined,
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       scenario:
         'should return REJECTED when the homologation address is different from the mass document address',
     },
@@ -369,7 +369,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
           ],
         },
       ],
-      resultComment: undefined,
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       scenario:
         'should return REJECTED when the homologation address is equal but the distance is greater than 2',
     },
@@ -404,6 +404,7 @@ describe('GeolocationPrecisionRuleProcessor', () => {
         },
         recyclerHomologationDocumentStub,
       ],
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       scenario:
         'should return REJECTED when the app-gps-latitude and app-gps-longitude are found and the geolocation precision is not valid',
     },

--- a/libs/methodologies/bold/processors/src/geolocation-precision-processor.ts
+++ b/libs/methodologies/bold/processors/src/geolocation-precision-processor.ts
@@ -61,14 +61,6 @@ export abstract class GeolocationPrecisionRuleProcessor extends RuleDataProcesso
     REJECTED: 'The address geolocation precision is greater than 2',
   } as const;
 
-  private createResultOutput(isValid: boolean) {
-    return {
-      resultStatus: isValid
-        ? RuleOutputStatus.APPROVED
-        : RuleOutputStatus.REJECTED,
-    };
-  }
-
   private evaluateResult({
     homologationDocument,
     massDocumentEvent,
@@ -118,7 +110,12 @@ export abstract class GeolocationPrecisionRuleProcessor extends RuleDataProcesso
       homologationAddress,
     );
 
-    return this.createResultOutput(isSameAddress);
+    return {
+      resultComment: isSameAddress ? undefined : this.ResultComment.REJECTED,
+      resultStatus: isSameAddress
+        ? RuleOutputStatus.APPROVED
+        : RuleOutputStatus.REJECTED,
+    };
   }
 
   private async getRuleSubject(


### PR DESCRIPTION
### Summary

Add the result comment in evaluteResult from geolocation-precision-rule.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved geolocation precision validation by using specific result comments in various scenarios, ensuring more accurate address comparisons.

- **Refactor**
  - Streamlined the geolocation precision rule processor by integrating result output construction directly into the evaluation method.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->