### PR TITLE
feat(rule): add PROD and TEST dataSetNames in CARROT_PARTICIPANT_BY_ENVIRONMENT

### DIFF
--- a/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/src/lib/mass-validation-document-status.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/src/lib/mass-validation-document-status.processor.e2e.spec.ts
@@ -5,6 +5,7 @@ import {
   stubMassValidationDocument,
 } from '@carrot-fndn/methodologies/bold/testing';
 import {
+  DataSetName,
   DocumentEventAttributeName,
   DocumentEventName,
   MethodologyEvaluationResult,
@@ -20,6 +21,7 @@ import {
   stubRuleResponse,
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
+import { random } from 'typia';
 
 import { handler } from '../lambda';
 
@@ -30,15 +32,24 @@ describe('MassValidationDocumentStatusProcessor E2E', () => {
   const { CLOSE } = DocumentEventName;
   const { METHODOLOGY_EVALUATION_RESULT } = DocumentEventAttributeName;
   const { APPROVED } = MethodologyEvaluationResult;
+  const dataSetName = random<DataSetName>();
+
+  const document = stubDocument({
+    dataSetName,
+    parentDocumentId,
+  });
 
   const relatedDocumentsOfParentDocument = stubArray(() =>
     stubMassValidationDocument({
+      dataSetName,
       externalEvents: [
         stubDocumentEventWithMetadataAttributes(
           {
             name: CLOSE,
             participant: {
-              id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development.id,
+              id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development[
+                document.dataSetName
+              ].id,
             },
           },
           [[METHODOLOGY_EVALUATION_RESULT, APPROVED]],
@@ -47,11 +58,8 @@ describe('MassValidationDocumentStatusProcessor E2E', () => {
     }),
   );
 
-  const document = stubDocument({
-    parentDocumentId,
-  });
-
   const parentDocument = stubDocument({
+    dataSetName,
     externalEvents: relatedDocumentsOfParentDocument.map((value) =>
       stubDocumentEvent({
         relatedDocument: {

--- a/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/src/lib/mass-validation-document-status.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/src/lib/mass-validation-document-status.processor.spec.ts
@@ -6,6 +6,7 @@ import {
   stubMassValidationDocument,
 } from '@carrot-fndn/methodologies/bold/testing';
 import {
+  DataSetName,
   DocumentEventAttributeName,
   DocumentEventName,
   MethodologyEvaluationResult,
@@ -34,12 +35,13 @@ describe('MassValidationDocumentStatusProcessor', () => {
 
     const relatedDocumentsOfParentDocument = stubArray(() =>
       stubMassValidationDocument({
+        dataSetName: DataSetName.TEST,
         externalEvents: [
           stubDocumentEventWithMetadataAttributes(
             {
               name: CLOSE,
               participant: {
-                id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development.id,
+                id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development.TEST.id,
               },
             },
             [[METHODOLOGY_EVALUATION_RESULT, APPROVED]],

--- a/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/src/lib/mass-validation-document-status.processor.ts
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/src/lib/mass-validation-document-status.processor.ts
@@ -44,7 +44,7 @@ export class MassValidationDocumentStatusProcessor extends RuleDataProcessor {
           metadataAttributeValueIsAnyOf(METHODOLOGY_EVALUATION_RESULT, [
             APPROVED,
           ]),
-          eventHasCarrotParticipant,
+          (event) => eventHasCarrotParticipant(event, document.dataSetName),
         ),
       ),
     );

--- a/libs/methodologies/bold/predicates/src/event.predicates.spec.ts
+++ b/libs/methodologies/bold/predicates/src/event.predicates.spec.ts
@@ -4,6 +4,7 @@ import {
   stubDocumentEventWithMetadata,
 } from '@carrot-fndn/methodologies/bold/testing';
 import {
+  DataSetName,
   type DocumentEvent,
   DocumentEventActorType,
   DocumentEventAttributeName,
@@ -496,14 +497,30 @@ describe('Event Predicates', () => {
 
 describe('eventHasCarrotParticipant', () => {
   it.each([
-    { expected: true, id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development.id },
-    { expected: true, id: CARROT_PARTICIPANT_BY_ENVIRONMENT.production.id },
-    { expected: false, id: faker.string.uuid() },
-  ])('should return $expected if id is $id', ({ expected, id }) => {
-    const event = stubDocumentEvent({ participant: { id } });
+    {
+      dataSetName: DataSetName.PROD,
+      expected: true,
+      id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development.PROD.id,
+    },
+    {
+      dataSetName: DataSetName.TEST,
+      expected: true,
+      id: CARROT_PARTICIPANT_BY_ENVIRONMENT.production.TEST.id,
+    },
+    {
+      dataSetName: DataSetName.PROD_SIMULATION,
+      expected: true,
+      id: CARROT_PARTICIPANT_BY_ENVIRONMENT.production.PROD_SIMULATION.id,
+    },
+    { dataSetName: DataSetName.PROD, expected: false, id: faker.string.uuid() },
+  ])(
+    'should return $expected if id is $id',
+    ({ dataSetName, expected, id }) => {
+      const event = stubDocumentEvent({ participant: { id } });
 
-    const result = eventHasCarrotParticipant(event);
+      const result = eventHasCarrotParticipant(event, dataSetName);
 
-    expect(result).toBe(expected);
-  });
+      expect(result).toBe(expected);
+    },
+  );
 });

--- a/libs/methodologies/bold/predicates/src/event.predicates.ts
+++ b/libs/methodologies/bold/predicates/src/event.predicates.ts
@@ -1,5 +1,6 @@
 import { getEventAttributeValue } from '@carrot-fndn/methodologies/bold/getters';
 import {
+  DataSetName,
   type DocumentEvent,
   DocumentEventActorType,
   DocumentEventAttributeName,
@@ -109,6 +110,11 @@ export const eventHasMetadataAttribute = (options: {
   return isValidMetadataName && isValidName && isValidValue;
 };
 
-export const eventHasCarrotParticipant = (event: DocumentEvent): boolean =>
-  event.participant.id === CARROT_PARTICIPANT_BY_ENVIRONMENT.development.id ||
-  event.participant.id === CARROT_PARTICIPANT_BY_ENVIRONMENT.production.id;
+export const eventHasCarrotParticipant = (
+  event: DocumentEvent,
+  dataSetName: DataSetName,
+): boolean =>
+  event.participant.id ===
+    CARROT_PARTICIPANT_BY_ENVIRONMENT.development[dataSetName].id ||
+  event.participant.id ===
+    CARROT_PARTICIPANT_BY_ENVIRONMENT.production[dataSetName].id;

--- a/libs/methodologies/bold/types/src/enum.types.ts
+++ b/libs/methodologies/bold/types/src/enum.types.ts
@@ -9,6 +9,7 @@ export enum DocumentCategory {
 
 export enum DataSetName {
   PROD = 'PROD',
+  PROD_SIMULATION = 'PROD_SIMULATION',
   TEST = 'TEST',
 }
 

--- a/libs/methodologies/bold/utils/src/rule-processors.constants.ts
+++ b/libs/methodologies/bold/utils/src/rule-processors.constants.ts
@@ -1,14 +1,38 @@
+import { DataSetName } from '@carrot-fndn/methodologies/bold/types';
+
 export const DOCUMENT_NOT_FOUND_RESULT_COMMENT =
   'The mass document was not found';
+
+const CARROT_PARTICIPANT_NAME = 'Carrot Fndn';
 
 // TODO: remove when environment variable is implemented
 export const CARROT_PARTICIPANT_BY_ENVIRONMENT = {
   development: {
-    id: 'f5746bcf-8510-46ca-96d8-d4081bda9410',
-    name: 'Carrot Foundation',
+    [DataSetName.PROD]: {
+      id: 'e710790f-5909-4a54-ab89-6a59819472ee',
+      name: CARROT_PARTICIPANT_NAME,
+    },
+    [DataSetName.PROD_SIMULATION]: {
+      id: 'e710790f-5909-4a54-ab89-6a59819472ee',
+      name: CARROT_PARTICIPANT_NAME,
+    },
+    [DataSetName.TEST]: {
+      id: 'f5746bcf-8510-46ca-96d8-d4081bda9410',
+      name: CARROT_PARTICIPANT_NAME,
+    },
   },
   production: {
-    id: 'aabf119f-6b1e-409a-91fa-521b0f5f0a33',
-    name: 'Carrot Foundation',
+    [DataSetName.PROD]: {
+      id: 'b20a7caf-3e55-42f7-86f5-9bde362a4b0f',
+      name: CARROT_PARTICIPANT_NAME,
+    },
+    [DataSetName.PROD_SIMULATION]: {
+      id: 'b20a7caf-3e55-42f7-86f5-9bde362a4b0f',
+      name: CARROT_PARTICIPANT_NAME,
+    },
+    [DataSetName.TEST]: {
+      id: 'aabf119f-6b1e-409a-91fa-521b0f5f0a33',
+      name: CARROT_PARTICIPANT_NAME,
+    },
   },
-};
+} as const;


### PR DESCRIPTION
### Summary

Add `dataSetName` value in `CARROT_PARTICIPANT_BY_ENVIRONMENT`

### Related links

https://app.clickup.com/t/3005225/CARROT-928

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `eventHasCarrotParticipant` function to support dataset name differentiation.
  - Added `PROD_SIMULATION` value to the `DataSetName` enum.

- **Bug Fixes**
  - Adjusted test cases for `eventHasCarrotParticipant` to accommodate the new `dataSetName` parameter.

- **Refactor**
  - Updated the structure of `CARROT_PARTICIPANT_BY_ENVIRONMENT` to use dataset-specific keys.

- **Tests**
  - Introduced new test cases and imports to validate `dataSetName` functionality in `mass-validation-document-status.processor.e2e.spec.ts`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->