### PR TITLE
feat(rule): update has-cdf rule [CARROT-1039]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Check if 'has-cdf' is false or 'report-type' is CDF in any event.</td>
+        <td>Check if there is a CDF in the Document.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Check in the End event if there is a CDF for that event.</td>
+        <td>Check if 'has-cdf' is false or 'report-type' is CDF in any event.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.spec.ts
@@ -35,7 +35,7 @@ describe('HasCdfProcessor', () => {
       resultComment: undefined,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'should return the returnValue equal to true when has-cdf is false and report-type is CDF',
+        'should return APPROVED when has-cdf is false and report-type is CDF',
     },
     {
       hasCdf: true,
@@ -43,7 +43,7 @@ describe('HasCdfProcessor', () => {
       resultComment: undefined,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'should return the returnValue equal to true when has-cdf is true and report-type is CDF',
+        'should return APPROVED when has-cdf is true and report-type is CDF',
     },
     {
       hasCdf: true,
@@ -51,7 +51,7 @@ describe('HasCdfProcessor', () => {
       resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       resultStatus: RuleOutputStatus.REJECTED,
       scenario:
-        'should return the returnValue equal to false when report-type is MTR and has-cdf is true',
+        'should return REJECTED when report-type is MTR and has-cdf is true',
     },
     {
       hasCdf: undefined,
@@ -59,7 +59,7 @@ describe('HasCdfProcessor', () => {
       resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       resultStatus: RuleOutputStatus.REJECTED,
       scenario:
-        'should return the return value equal to false when neither has-cdf nor report-type are present',
+        'should return REJECTED when neither has-cdf nor report-type are present',
     },
   ];
 

--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.spec.ts
@@ -25,51 +25,46 @@ describe('HasCdfProcessor', () => {
   const ruleDataProcessor = new HasCdfProcessor();
   const documentLoaderService = jest.mocked(loadParentDocument);
 
-  const { HAS_CDF, HAS_MTR, REPORT_TYPE } = DocumentEventAttributeName;
+  const { HAS_CDF, REPORT_TYPE } = DocumentEventAttributeName;
   const { CDF, MTR } = ReportType;
-  const { END } = DocumentEventName;
 
   it.each([
     {
-      event: stubDocumentEventWithMetadataAttributes({ name: END }, [
-        [HAS_CDF, false],
-        [REPORT_TYPE, CDF],
-      ]),
+      event: stubDocumentEventWithMetadataAttributes(
+        { name: random<DocumentEventName>() },
+        [
+          [HAS_CDF, false],
+          [REPORT_TYPE, CDF],
+        ],
+      ),
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
         'should return the returValue equal to true when has-cdf is false and report-type is CDF',
     },
     {
-      event: stubDocumentEventWithMetadataAttributes({ name: END }, [
-        [HAS_CDF, true],
-        [REPORT_TYPE, CDF],
-      ]),
-      resultStatus: RuleOutputStatus.APPROVED,
-      scenario:
-        'should return the returValue equal to true when has-cdf is true and report-type is CDF',
-    },
-    {
-      event: stubDocumentEventWithMetadataAttributes({ name: END }, [
-        [HAS_MTR, true],
-        [REPORT_TYPE, MTR],
-      ]),
-      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
-      resultStatus: RuleOutputStatus.REJECTED,
-      scenario:
-        'should return the returValue equal to false when the END event has-mtr equal to true and report-type is MTR',
-    },
-    {
       event: stubDocumentEventWithMetadataAttributes(
-        { name: random<Omit<DocumentEventName, 'END'>>() },
+        { name: random<DocumentEventName>() },
         [
           [HAS_CDF, true],
           [REPORT_TYPE, CDF],
         ],
       ),
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario:
+        'should return the returValue equal to true when has-cdf is true and report-type is CDF',
+    },
+    {
+      event: stubDocumentEventWithMetadataAttributes(
+        { name: random<DocumentEventName>() },
+        [
+          [HAS_CDF, true],
+          [REPORT_TYPE, MTR],
+        ],
+      ),
       resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       resultStatus: RuleOutputStatus.REJECTED,
       scenario:
-        'should return the returValue equal to false when there is no END event',
+        'should return the returValue equal to false when there is no event with report-type equal to CDF or has-cdf equal to false',
     },
   ])(`$scenario`, async ({ event, resultComment, resultStatus }) => {
     const ruleInput = random<Required<RuleInput>>();

--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.ts
@@ -13,29 +13,30 @@ import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 const { HAS_CDF, REPORT_TYPE } = DocumentEventAttributeName;
 const { CDF } = ReportType;
-const { END } = DocumentEventName;
 
 export class HasCdfProcessor extends ParentDocumentRuleProcessor<
   DocumentEvent[]
 > {
   private ResultComment = {
     REJECTED:
-      'The END event does not have attribute has-cdf with value equal to false or report-type with value equal to CDF',
+      'No event has attribute report-type equal to CDF or has-cdf equal to false',
   };
 
   protected override evaluateResult(
     events: DocumentEvent[],
   ): EvaluateResultOutput {
-    const resultStatus = events.some((event) =>
+    const hasRequiredMetadata = events.some((event) =>
       [HAS_CDF, REPORT_TYPE].some((attributeName) =>
         eventHasMetadataAttribute({
           event,
-          eventNames: [END],
+          eventNames: Object.values(DocumentEventName),
           metadataName: attributeName,
           metadataValues: attributeName === HAS_CDF ? false : CDF,
         }),
       ),
-    )
+    );
+
+    const resultStatus = hasRequiredMetadata
       ? RuleOutputStatus.APPROVED
       : RuleOutputStatus.REJECTED;
 

--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/src/lib/has-cdf.processor.ts
@@ -6,7 +6,6 @@ import {
   type Document,
   type DocumentEvent,
   DocumentEventAttributeName,
-  DocumentEventName,
   ReportType,
 } from '@carrot-fndn/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -29,7 +28,6 @@ export class HasCdfProcessor extends ParentDocumentRuleProcessor<
       [HAS_CDF, REPORT_TYPE].some((attributeName) =>
         eventHasMetadataAttribute({
           event,
-          eventNames: Object.values(DocumentEventName),
           metadataName: attributeName,
           metadataValues: attributeName === HAS_CDF ? false : CDF,
         }),


### PR DESCRIPTION
Summary
This PR updates the business rule to verify metadata for events.

Details

Before: report-type=CDF or has-cdf=false metadata is declared in the END event. 
After: It is mandatory that the report-type=CDF or has-cdf=false metadata is declared.

Related links
Task: https://app.clickup.com/t/3005225/CARROT-1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event stubbing logic in test cases for better coverage and accuracy in various scenarios.

- **Documentation**
  - Updated README to reflect changes in CDF and report-type checking logic.

- **Refactor**
  - Refined evaluation logic to check for specific metadata attributes in events, leading to more precise rejection comments and evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->