### PR TITLE
feat(rule): get evaluateEvent from events with valid move-type [CARROT-1032]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Verify if the address of the participant identified in an event with 'move type' declared as 'Pick-up' or 'Shipment-request' is the same as the address declared for the participant pointed as SOURCE.</td>
+        <td>Verify if the address of the participant identified in an event with 'move-type' declared as 'Pick-up' or 'Shipment-request' is the same as the address declared for the participant pointed as SOURCE.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Verify if the address of the participant identified in the OPEN or MOVE event with 'move type' declared as 'Pick-up' is the same as the address declared for the participant pointed as SOURCE.</td>
+        <td>Verify if the address of the participant identified in an event with 'move type' declared as 'Pick-up' or 'Shipment-request' is the same as the address declared for the participant pointed as SOURCE.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/src/lib/same-source-and-pick-up-addresses.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/src/lib/same-source-and-pick-up-addresses.processor.e2e.spec.ts
@@ -20,7 +20,6 @@ import {
 import { faker } from '@faker-js/faker';
 
 import { handler } from '../lambda';
-import { SameSourceAndPickUpAddressesProcessor } from './same-source-and-pick-up-addresses.processor';
 
 testRuleProcessorWithMassDocuments(
   {
@@ -71,7 +70,7 @@ testRuleProcessorWithMassDocuments(
         ]);
       });
 
-      it('should return returnValue true when neither OPEN nor move event is present', async () => {
+      it('should REJECTE when the address ids do not match', async () => {
         const response = await handler(
           stubRuleInput({
             documentKeyPrefix,
@@ -82,8 +81,6 @@ testRuleProcessorWithMassDocuments(
         );
 
         expect(response).toMatchObject({
-          resultComment:
-            SameSourceAndPickUpAddressesProcessor.resultComments.doNotMatch,
           resultStatus: RuleOutputStatus.REJECTED,
         });
       });

--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/src/lib/same-source-and-pick-up-addresses.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/src/lib/same-source-and-pick-up-addresses.processor.ts
@@ -1,90 +1,80 @@
-import { loadParentDocument } from '@carrot-fndn/methodologies/bold/io-helpers';
+import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
+
 import {
-  and,
-  eventNameIsAnyOf,
   isActorEventWithSourceActorType,
   metadataAttributeValueIsAnyOf,
 } from '@carrot-fndn/methodologies/bold/predicates';
+import { ParentDocumentRuleProcessor } from '@carrot-fndn/methodologies/bold/processors';
 import {
+  type Document,
+  type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventMoveType,
-  DocumentEventName,
 } from '@carrot-fndn/methodologies/bold/types';
-import { DOCUMENT_NOT_FOUND_RESULT_COMMENT } from '@carrot-fndn/methodologies/bold/utils';
-import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
-import { isNonEmptyArray, toDocumentKey } from '@carrot-fndn/shared/helpers';
-import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
-import {
-  type RuleInput,
-  type RuleOutput,
-  RuleOutputStatus,
-} from '@carrot-fndn/shared/rule/types';
+import { isNil } from '@carrot-fndn/shared/helpers';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-export class SameSourceAndPickUpAddressesProcessor extends RuleDataProcessor {
-  static resultComments = {
-    doNotMatch: 'Source and pick-up addresses do not match',
-    noSourceActorEvent: 'No actor event with source actor type found',
-    ruleNotApplicable:
+interface RuleSubject {
+  evaluateEvent?: DocumentEvent | undefined;
+  sourceActorEvent?: DocumentEvent | undefined;
+}
+
+export class SameSourceAndPickUpAddressesProcessor extends ParentDocumentRuleProcessor<RuleSubject> {
+  private ResultComments = {
+    DO_NOT_MATCH: 'Source and pick-up addresses do not match',
+    NO_SOURCE_ACTOR_EVENT: 'No actor event with source actor type found',
+    RULE_NOT_APPLICABLE:
       'Rule not applicable: No move event with pick-up move type found',
   };
 
-  async process(ruleInput: RuleInput): Promise<RuleOutput> {
-    const document = await loadParentDocument(
-      this.context.documentLoaderService,
-      toDocumentKey({
-        documentId: ruleInput.parentDocumentId,
-        documentKeyPrefix: ruleInput.documentKeyPrefix,
+  protected override evaluateResult({
+    evaluateEvent,
+    sourceActorEvent,
+  }: RuleSubject): EvaluateResultOutput | Promise<EvaluateResultOutput> {
+    if (isNil(evaluateEvent)) {
+      return {
+        resultComment: this.ResultComments.RULE_NOT_APPLICABLE,
+        resultStatus: RuleOutputStatus.APPROVED,
+      };
+    }
+
+    if (!sourceActorEvent) {
+      return {
+        resultComment: this.ResultComments.NO_SOURCE_ACTOR_EVENT,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    const resultStatus =
+      evaluateEvent.address.id === sourceActorEvent.address.id
+        ? RuleOutputStatus.APPROVED
+        : RuleOutputStatus.REJECTED;
+
+    return {
+      resultStatus,
+      ...(resultStatus === RuleOutputStatus.REJECTED && {
+        resultComment: this.ResultComments.DO_NOT_MATCH,
       }),
-    );
+    };
+  }
 
-    if (!document) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
-        resultComment: DOCUMENT_NOT_FOUND_RESULT_COMMENT,
-      });
-    }
-
-    const { MOVE, OPEN } = DocumentEventName;
+  protected override getRuleSubject(
+    document: Document,
+  ): RuleSubject | undefined {
     const { MOVE_TYPE } = DocumentEventAttributeName;
-    const { PICK_UP } = DocumentEventMoveType;
+    const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
-    const openOrMoveEvents = document.externalEvents?.filter(
-      and(
-        eventNameIsAnyOf([OPEN, MOVE]),
-        metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP]),
-      ),
+    const evaluateEvent = document.externalEvents?.find(
+      metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP, SHIPMENT_REQUEST]),
     );
-
-    if (!isNonEmptyArray(openOrMoveEvents)) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.APPROVED, {
-        resultComment:
-          SameSourceAndPickUpAddressesProcessor.resultComments
-            .ruleNotApplicable,
-      });
-    }
 
     const sourceActorEvent = document.externalEvents?.find(
       isActorEventWithSourceActorType,
     );
 
-    if (!sourceActorEvent) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
-        resultComment:
-          SameSourceAndPickUpAddressesProcessor.resultComments
-            .noSourceActorEvent,
-      });
-    }
-
-    const resultStatus = openOrMoveEvents.every(
-      (event) => event.address.id === sourceActorEvent.address.id,
-    )
-      ? RuleOutputStatus.APPROVED
-      : RuleOutputStatus.REJECTED;
-
-    return mapToRuleOutput(ruleInput, resultStatus, {
-      ...(resultStatus === RuleOutputStatus.REJECTED && {
-        resultComment:
-          SameSourceAndPickUpAddressesProcessor.resultComments.doNotMatch,
-      }),
-    });
+    return {
+      evaluateEvent,
+      sourceActorEvent,
+    };
   }
 }

--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/src/lib/same-source-and-pick-up-addresses.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/src/lib/same-source-and-pick-up-addresses.processor.ts
@@ -24,7 +24,7 @@ export class SameSourceAndPickUpAddressesProcessor extends ParentDocumentRulePro
     DO_NOT_MATCH: 'Source and pick-up addresses do not match',
     NO_SOURCE_ACTOR_EVENT: 'No actor event with source actor type found',
     RULE_NOT_APPLICABLE:
-      'Rule not applicable: No move event with pick-up move type found',
+      'Rule not applicable: No event with pick-up or Shipment-request move-type found',
   };
 
   protected override evaluateResult({


### PR DESCRIPTION
### Summary

Get rule subject from events with move-type metadata defined.

### Related links

https://app.clickup.com/t/3005225/CARROT-1032

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded event types to include 'Shipment-request' in addition to 'Pick-up' for address verification.

- **Refactor**
  - Enhanced `SameSourceAndPickUpAddressesProcessor` for better functionality and readability.
  - Updated initialization of constants and event creation logic to support new event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->