### PR TITLE
feat(rule): update rule to get events with a valid move-type value [CARROT-1034]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/maximum-distance/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/maximum-distance/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Verify if the geolocation distance between the OPEN or MOVE event with ‘move-type’ declared as ‘Pick-up’ and the MOVE event with ‘move-type’ declared as ‘Drop-off’, is less than or equal to 200km.</td>
+        <td>Verify if the geolocation distance between the event with ‘move-type’ declared as ‘Pick-up’ or ‘Shipment-request’ and the event with ‘move-type’ declared as ‘Drop-off’, is less than or equal to 200km.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/maximum-distance/src/lib/maximum-distance.processor.constants.ts
+++ b/apps/methodologies/bold/rule-processors/mass/maximum-distance/src/lib/maximum-distance.processor.constants.ts
@@ -1,6 +1,0 @@
-export const MAXIMUM_DISTANCE_RESULT_COMMENT = {
-  drop_off_not_found:
-    'Move event with metadata attribute name move-type and value Drop-off was not found',
-  pick_up_not_found:
-    'Open or Move event with metadata attribute name move-type and value Pick-up was not found',
-} as const;

--- a/apps/methodologies/bold/rule-processors/mass/maximum-distance/src/lib/maximum-distance.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/maximum-distance/src/lib/maximum-distance.processor.ts
@@ -32,11 +32,16 @@ export class MaximumDistanceProcessor extends ParentDocumentRuleProcessor<Subjec
     dropOffEvent,
     pickUpOrShipmentRequestEvent,
   }: Subject): EvaluateResultOutput {
-    if (isNil(dropOffEvent) || isNil(pickUpOrShipmentRequestEvent)) {
+    if (isNil(dropOffEvent)) {
       return {
-        resultComment: pickUpOrShipmentRequestEvent
-          ? this.ResultComment.DROP_OFF_NOT_FOUND
-          : this.ResultComment.PICK_UP_NOT_FOUND,
+        resultComment: this.ResultComment.DROP_OFF_NOT_FOUND,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    if (isNil(pickUpOrShipmentRequestEvent)) {
+      return {
+        resultComment: this.ResultComment.PICK_UP_NOT_FOUND,
         resultStatus: RuleOutputStatus.REJECTED,
       };
     }

--- a/apps/methodologies/bold/rule-processors/mass/maximum-distance/src/lib/maximum-distance.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/maximum-distance/src/lib/maximum-distance.processor.ts
@@ -1,76 +1,71 @@
-import { loadParentDocument } from '@carrot-fndn/methodologies/bold/io-helpers';
+import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
+
+import { metadataAttributeValueIsAnyOf } from '@carrot-fndn/methodologies/bold/predicates';
+import { ParentDocumentRuleProcessor } from '@carrot-fndn/methodologies/bold/processors';
 import {
-  and,
-  eventNameIsAnyOf,
-  metadataAttributeValueIsAnyOf,
-} from '@carrot-fndn/methodologies/bold/predicates';
-import {
+  type Document,
+  type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventMoveType,
-  DocumentEventName,
 } from '@carrot-fndn/methodologies/bold/types';
-import {
-  DOCUMENT_NOT_FOUND_RESULT_COMMENT,
-  calculateDistanceBetweenTwoEvents,
-} from '@carrot-fndn/methodologies/bold/utils';
-import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
-import { toDocumentKey } from '@carrot-fndn/shared/helpers';
-import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
-import {
-  type RuleInput,
-  type RuleOutput,
-  RuleOutputStatus,
-} from '@carrot-fndn/shared/rule/types';
+import { calculateDistanceBetweenTwoEvents } from '@carrot-fndn/methodologies/bold/utils';
+import { isNil } from '@carrot-fndn/shared/helpers';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-import { MAXIMUM_DISTANCE_RESULT_COMMENT } from './maximum-distance.processor.constants';
+const { MOVE_TYPE } = DocumentEventAttributeName;
+const { DROP_OFF, PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
-export class MaximumDistanceProcessor extends RuleDataProcessor {
-  async process(ruleInput: RuleInput): Promise<RuleOutput> {
-    const document = await loadParentDocument(
-      this.context.documentLoaderService,
-      toDocumentKey({
-        documentId: ruleInput.parentDocumentId,
-        documentKeyPrefix: ruleInput.documentKeyPrefix,
-      }),
-    );
+interface Subject {
+  dropOffEvent?: DocumentEvent | undefined;
+  pickUpOrShipmentRequestEvent?: DocumentEvent | undefined;
+}
 
-    if (!document) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
-        resultComment: DOCUMENT_NOT_FOUND_RESULT_COMMENT,
-      });
-    }
+export class MaximumDistanceProcessor extends ParentDocumentRuleProcessor<Subject> {
+  private ResultComment = {
+    DROP_OFF_NOT_FOUND:
+      'Event with metadata attribute name move-type and value Drop-off was not found',
+    PICK_UP_NOT_FOUND:
+      'Event with metadata attribute name move-type and value Pick-up or Shipment-request was not found',
+  };
 
-    const { MOVE, OPEN } = DocumentEventName;
-    const { MOVE_TYPE } = DocumentEventAttributeName;
-    const { DROP_OFF, PICK_UP } = DocumentEventMoveType;
-
-    const pickUpEvent = document.externalEvents?.find(
-      and(
-        eventNameIsAnyOf([OPEN, MOVE]),
-        metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP]),
-      ),
-    );
-
-    const dropOffEvent = document.externalEvents?.find(
-      and(
-        eventNameIsAnyOf([MOVE]),
-        metadataAttributeValueIsAnyOf(MOVE_TYPE, [DROP_OFF]),
-      ),
-    );
-
-    if (!pickUpEvent || !dropOffEvent) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
-        resultComment: pickUpEvent
-          ? MAXIMUM_DISTANCE_RESULT_COMMENT.drop_off_not_found
-          : MAXIMUM_DISTANCE_RESULT_COMMENT.pick_up_not_found,
-      });
+  protected override evaluateResult({
+    dropOffEvent,
+    pickUpOrShipmentRequestEvent,
+  }: Subject): EvaluateResultOutput {
+    if (isNil(dropOffEvent) || isNil(pickUpOrShipmentRequestEvent)) {
+      return {
+        resultComment: pickUpOrShipmentRequestEvent
+          ? this.ResultComment.DROP_OFF_NOT_FOUND
+          : this.ResultComment.PICK_UP_NOT_FOUND,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
     }
 
     const resultStatus =
-      calculateDistanceBetweenTwoEvents(pickUpEvent, dropOffEvent) <= 200
+      calculateDistanceBetweenTwoEvents(
+        pickUpOrShipmentRequestEvent,
+        dropOffEvent,
+      ) <= 200
         ? RuleOutputStatus.APPROVED
         : RuleOutputStatus.REJECTED;
 
-    return mapToRuleOutput(ruleInput, resultStatus);
+    return {
+      resultStatus,
+    };
+  }
+
+  protected override getRuleSubject(document: Document): Subject | undefined {
+    const pickUpOrShipmentRequestEvent = document.externalEvents?.find(
+      metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP, SHIPMENT_REQUEST]),
+    );
+
+    const dropOffEvent = document.externalEvents?.find(
+      metadataAttributeValueIsAnyOf(MOVE_TYPE, [DROP_OFF]),
+    );
+
+    return {
+      dropOffEvent,
+      pickUpOrShipmentRequestEvent,
+    };
   }
 }


### PR DESCRIPTION
### Summary

Update maximum-distance rule to get events based on move-type value instead the name.

### Related links

https://app.clickup.com/t/3005225/CARROT-1034

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated geolocation distance verification criteria in the README for move events.

- **New Features**
  - Enhanced `MaximumDistanceProcessor` logic to check specific event types and calculate distances more accurately.

- **Refactor**
  - Refactored internal class structure for improved maintainability and performance.
  - Updated method to extract events based on metadata attributes.

- **Tests**
  - Improved test scenarios and setups to better handle different event scenarios and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->