### PR TITLE
feat(rule): update rule to get events with a valid move-type value [CARROT-1035]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/src/lib/vehicle-license-plate.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/src/lib/vehicle-license-plate.processor.e2e.spec.ts
@@ -40,7 +40,7 @@ testRuleProcessorWithMassDocuments(
       const document = stubDocument({
         externalEvents: [
           stubDocumentEventWithMetadataAttributes(
-            { name: random<DocumentEventName.MOVE | DocumentEventName.OPEN>() },
+            { name: random<DocumentEventName>() },
             [
               [MOVE_TYPE, PICK_UP],
               [VEHICLE_TYPE, OTHERS],
@@ -62,7 +62,7 @@ testRuleProcessorWithMassDocuments(
         ]);
       });
 
-      it('should return REJECTED when OPEN or MOVE event has metadata attribute vehicle-license-plate with a value equal to empty string', async () => {
+      it('should return REJECTED when the event has metadata attribute vehicle-license-plate with a value equal to empty string', async () => {
         const response = await handler(
           stubRuleInput({
             documentKeyPrefix,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/src/lib/vehicle-license-plate.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/src/lib/vehicle-license-plate.processor.spec.ts
@@ -26,7 +26,7 @@ jest.mock('@carrot-fndn/shared/document/loader');
 describe('VehicleLicensePlateProcessor', () => {
   const { OTHERS } = DocumentEventVehicleType;
   const { MOVE_TYPE, VEHICLE_TYPE } = DocumentEventAttributeName;
-  const { PICK_UP } = DocumentEventMoveType;
+  const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
   const ruleDataProcessor = new VehicleLicensePlateProcessor();
   const documentLoaderService = jest.mocked(DocumentLoaderService.prototype);
 
@@ -43,21 +43,20 @@ describe('VehicleLicensePlateProcessor', () => {
       resultComment: ruleDataProcessor['ResultComment'].NOT_APPLICABLE,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'does not have OPEN or MOVE event with metadata attribute move-type with a value equal to Pick-up',
+        'does not have an event with metadata attribute move-type with a value equal to Pick-up or Shipment-request',
     },
     {
       document: stubDocument({
         externalEvents: [
           stubDocumentEventWithMetadataAttributes(
             { name: random<DocumentEventName.MOVE | DocumentEventName.OPEN>() },
-            [[MOVE_TYPE, PICK_UP]],
+            [[MOVE_TYPE, random<typeof PICK_UP | typeof SHIPMENT_REQUEST>()]],
           ),
         ],
       }),
       resultComment: ruleDataProcessor['ResultComment'].NOT_APPLICABLE,
       resultStatus: RuleOutputStatus.APPROVED,
-      scenario:
-        'does not have OPEN or MOVE event with metadata attribute vehicle-type',
+      scenario: 'does not have an event with metadata attribute vehicle-type',
     },
   ])(
     `should return "$resultStatus" when the document $scenario`,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/src/lib/vehicle-license-plate.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/src/lib/vehicle-license-plate.processor.ts
@@ -3,7 +3,6 @@ import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-dat
 import {
   and,
   eventHasNonEmptyStringAttribute,
-  eventNameIsAnyOf,
   metadataAttributeNameIsAnyOf,
   metadataAttributeValueIsAnyOf,
   not,
@@ -14,13 +13,11 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventMoveType,
-  DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-const { MOVE, OPEN } = DocumentEventName;
-const { PICK_UP } = DocumentEventMoveType;
+const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 const { MOVE_TYPE, VEHICLE_LICENSE_PLATE, VEHICLE_TYPE } =
   DocumentEventAttributeName;
 const { BICYCLE, CART, SLUDGE_PIPES } = DocumentEventVehicleType;
@@ -29,7 +26,7 @@ export class VehicleLicensePlateProcessor extends ParentDocumentRuleProcessor<Do
   private ResultComment = {
     APPROVED: 'The vehicle-license-plate attribute is a non-empty string',
     NOT_APPLICABLE:
-      'Rule not applicable: The OPEN or MOVE event with attribute move-type with Pick-up value and vehicle-type with a value not in [Sludge Pipes, Cart, Bicycle] was not found',
+      'Rule not applicable: An event with attribute move-type with Pick-up value and vehicle-type with a value not in [Sludge Pipes, Cart, Bicycle] was not found',
     REJECTED: 'The vehicle-license-plate attribute is not a non-empty string',
   };
 
@@ -60,8 +57,7 @@ export class VehicleLicensePlateProcessor extends ParentDocumentRuleProcessor<Do
     document: Document,
   ): DocumentEvent | undefined {
     const findEventCondition = and(
-      eventNameIsAnyOf([MOVE, OPEN]),
-      metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP]),
+      metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP, SHIPMENT_REQUEST]),
       metadataAttributeNameIsAnyOf([VEHICLE_TYPE]),
       not(
         metadataAttributeValueIsAnyOf(VEHICLE_TYPE, [


### PR DESCRIPTION
### Summary

Update the rule to get events based on move-type value instead event name.

### Related links

https://app.clickup.com/t/3005225/CARROT-1035

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `SHIPMENT_REQUEST` in the vehicle license plate processing rules.

- **Improvements**
  - Enhanced metadata attribute checks for better clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->