### PR TITLE
feature/update driver internal id rule [CARROT-1036]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/driver-internal-id/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/driver-internal-id/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>Verify if the internal driver identification is declared in a OPEN or MOVE event when the 'move type' is identified as 'Pick-up'.</td>
+        <td>Verify if the internal driver identification is declared in an event when the 'move type' is identified as 'Pick-up' or 'Shipment-request'.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/driver-internal-id/src/lib/driver-internal-id.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/driver-internal-id/src/lib/driver-internal-id.processor.ts
@@ -2,7 +2,6 @@ import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-dat
 
 import {
   and,
-  eventNameIsAnyOf,
   metadataAttributeValueIsAnyOf,
   metadataAttributeValueIsNotEmpty,
   not,
@@ -13,7 +12,6 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventMoveType,
-  DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -57,13 +55,10 @@ export class DriverInternalIdProcessor extends ParentDocumentRuleProcessor<
     externalEvents,
   }: Document): DocumentEvent[] | undefined {
     const { MOVE_TYPE } = DocumentEventAttributeName;
-    const { PICK_UP } = DocumentEventMoveType;
+    const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
     return externalEvents?.filter(
-      and(
-        eventNameIsAnyOf([DocumentEventName.OPEN, DocumentEventName.MOVE]),
-        metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP]),
-      ),
+      metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP, SHIPMENT_REQUEST]),
     );
   }
 }


### PR DESCRIPTION
- **feat(rule): update rule to get events with a valid move-type value [CARROT-1036]**
- **chore: update driver-internal-id rule README.md**

### Summary

Update the rule to get event based on move-type values instead the event name. 

### Related links

https://app.clickup.com/t/3005225/CARROT-1036

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced move type processing by including 'Shipment-request' along with 'Pick-up' for driver identification events.

- **Bug Fixes**
  - Adjusted the logic for handling document events to ensure accurate status and comments based on the new move types.

- **Tests**
  - Updated test cases to cover the addition of 'Shipment-request' and improved event handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->