### PR TITLE
feat(rule): update rule to get events with a valid move-type value [CARROT-1037]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/vehicle-description/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-description/README.md
@@ -17,7 +17,7 @@
     </thead>
     <tbody>
       <tr>
-        <td>In the case of the vehicle type indicated as 'other' in the OPEN or MOVE event, when the 'move type' is identified as 'Pick-up,' verify if the vehicle description field is declared</td>
+        <td>In the case of the vehicle type indicated as 'other' in any event, when the 'move type' is identified as 'Pick-up' or 'Shipment-request,' verify if the vehicle description field is declared</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-description/src/lib/vehicle-description.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-description/src/lib/vehicle-description.processor.e2e.spec.ts
@@ -63,7 +63,7 @@ testRuleProcessorWithMassDocuments(
         ]);
       });
 
-      it('should return REJECTED when OPEN or MOVE event has metadata attribute vehicle-description with a value equal to empty string', async () => {
+      it('should return REJECTED when any event has metadata attribute vehicle-description with a value equal to empty string', async () => {
         const response = await handler(
           stubRuleInput({
             documentKeyPrefix,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-description/src/lib/vehicle-description.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-description/src/lib/vehicle-description.processor.spec.ts
@@ -25,7 +25,7 @@ import { VehicleDescriptionProcessor } from './vehicle-description.processor';
 jest.mock('@carrot-fndn/shared/document/loader');
 
 describe('VehicleDescriptionProcessor', () => {
-  const { PICK_UP } = DocumentEventMoveType;
+  const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
   const { OTHERS } = DocumentEventVehicleType;
   const { MOVE_TYPE, VEHICLE_DESCRIPTION, VEHICLE_TYPE } =
     DocumentEventAttributeName;
@@ -38,9 +38,9 @@ describe('VehicleDescriptionProcessor', () => {
       document: stubDocument({
         externalEvents: [
           stubDocumentEventWithMetadataAttributes(
-            { name: random<DocumentEventName.MOVE | DocumentEventName.OPEN>() },
+            { name: random<DocumentEventName>() },
             [
-              [MOVE_TYPE, PICK_UP],
+              [MOVE_TYPE, random<typeof PICK_UP | typeof SHIPMENT_REQUEST>()],
               [VEHICLE_TYPE, OTHERS],
               [VEHICLE_DESCRIPTION, faker.string.sample()],
             ],
@@ -50,13 +50,13 @@ describe('VehicleDescriptionProcessor', () => {
       resultComment: ruleDataProcessor['ResultComment'].APPROVED,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'has the vehicle-description metadata attribute and the value is a non-empty string',
+        'should return APPROVED when has the vehicle-description metadata attribute and the value is a non-empty string',
     },
     {
       document: stubDocument({
         externalEvents: [
           stubDocumentEventWithMetadataAttributes(
-            { name: random<DocumentEventName.MOVE | DocumentEventName.OPEN>() },
+            { name: random<DocumentEventName>() },
             [[VEHICLE_TYPE, OTHERS]],
           ),
         ],
@@ -64,21 +64,21 @@ describe('VehicleDescriptionProcessor', () => {
       resultComment: ruleDataProcessor['ResultComment'].NOT_APPLICABLE,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'only has metadata attribute vehicle-type with value equal to Others',
+        'should return APPROVED when only has metadata attribute vehicle-type with value equal to Others',
     },
     {
       document: stubDocument({
         externalEvents: [
           stubDocumentEventWithMetadataAttributes(
-            { name: random<DocumentEventName.MOVE | DocumentEventName.OPEN>() },
-            [[MOVE_TYPE, PICK_UP]],
+            { name: random<DocumentEventName>() },
+            [[MOVE_TYPE, random<typeof PICK_UP | typeof SHIPMENT_REQUEST>()]],
           ),
         ],
       }),
       resultComment: ruleDataProcessor['ResultComment'].NOT_APPLICABLE,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'only has metadata attribute move-type with value equal to Pick-up',
+        'should return APPROVED when only has metadata attribute move-type with value equal to Pick-up or Shipment-request',
     },
   ])(
     `should return "$resultStatus" when the document $scenario`,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-description/src/lib/vehicle-description.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-description/src/lib/vehicle-description.processor.ts
@@ -3,7 +3,6 @@ import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-dat
 import {
   and,
   eventHasNonEmptyStringAttribute,
-  eventNameIsAnyOf,
   metadataAttributeValueIsAnyOf,
 } from '@carrot-fndn/methodologies/bold/predicates';
 import { ParentDocumentRuleProcessor } from '@carrot-fndn/methodologies/bold/processors';
@@ -12,13 +11,11 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventMoveType,
-  DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-const { MOVE, OPEN } = DocumentEventName;
-const { PICK_UP } = DocumentEventMoveType;
+const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 const { OTHERS } = DocumentEventVehicleType;
 const { MOVE_TYPE, VEHICLE_DESCRIPTION, VEHICLE_TYPE } =
   DocumentEventAttributeName;
@@ -59,8 +56,7 @@ export class VehicleDescriptionProcessor extends ParentDocumentRuleProcessor<Doc
   ): DocumentEvent | undefined {
     return document.externalEvents?.find(
       and(
-        eventNameIsAnyOf([MOVE, OPEN]),
-        metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP]),
+        metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP, SHIPMENT_REQUEST]),
         metadataAttributeValueIsAnyOf(VEHICLE_TYPE, [OTHERS]),
       ),
     );


### PR DESCRIPTION
### Summary

Update the rule to get the event based on move-type values intead event names.

### Related links

https://app.clickup.com/t/3005225/CARROT-1037

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**
