### PR TITLE
feat(rule): update vehicle-type rule [CARROT-1038]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/README.md
@@ -17,7 +17,8 @@
     </thead>
     <tbody>
       <tr>
-        <td>Check if the vehicle type is identified in OPEN or MOVE events when the 'move type' is identified as 'Pick-up'.</td>
+        <td>Check if the vehicle type is identified in events when the 'move type' is identified as 'Pick-up' or 
+        'Shipment-request'.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.e2e.spec.ts
@@ -31,6 +31,7 @@ testRuleProcessorWithMassDocuments(
     describe('VehicleTypeProcessor E2E', () => {
       const documentKeyPrefix = faker.string.uuid();
       const parentDocumentId = faker.string.uuid();
+      const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
       const document = stubDocument({
         externalEvents: [
@@ -40,7 +41,7 @@ testRuleProcessorWithMassDocuments(
                 {
                   isPublic: true,
                   name: DocumentEventAttributeName.MOVE_TYPE,
-                  value: DocumentEventMoveType.PICK_UP,
+                  value: random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
                 },
                 {
                   isPublic: true,
@@ -49,7 +50,7 @@ testRuleProcessorWithMassDocuments(
                 },
               ],
             },
-            name: random<DocumentEventName.MOVE | DocumentEventName.OPEN>(),
+            name: random<DocumentEventName>(),
           }),
         ],
       });
@@ -66,7 +67,7 @@ testRuleProcessorWithMassDocuments(
         ]);
       });
 
-      it('should return the resultStatus REJECTED if the OPEN or MOVE events does not satisfy the vehicle-type', async () => {
+      it('should return the resultStatus REJECTED if the events does not satisfy the vehicle-type', async () => {
         const response = await handler(
           stubRuleInput({
             documentKeyPrefix,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.e2e.spec.ts
@@ -1,13 +1,7 @@
 import {
   stubDocument,
-  stubDocumentEvent,
   testRuleProcessorWithMassDocuments,
 } from '@carrot-fndn/methodologies/bold/testing';
-import {
-  DocumentEventAttributeName,
-  DocumentEventMoveType,
-  DocumentEventName,
-} from '@carrot-fndn/methodologies/bold/types';
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
@@ -17,9 +11,9 @@ import {
   stubRuleResponse,
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
-import { random } from 'typia';
 
 import { handler } from '../lambda';
+import { stubEventWithVehicleType } from './vehicle-type.stubs';
 
 testRuleProcessorWithMassDocuments(
   {
@@ -33,28 +27,7 @@ testRuleProcessorWithMassDocuments(
       const parentDocumentId = faker.string.uuid();
 
       const document = stubDocument({
-        externalEvents: [
-          stubDocumentEvent({
-            metadata: {
-              attributes: [
-                {
-                  isPublic: true,
-                  name: DocumentEventAttributeName.MOVE_TYPE,
-                  value: random<
-                    | DocumentEventMoveType.PICK_UP
-                    | DocumentEventMoveType.SHIPMENT_REQUEST
-                  >(),
-                },
-                {
-                  isPublic: true,
-                  name: DocumentEventAttributeName.VEHICLE_TYPE,
-                  value: faker.string.sample(),
-                },
-              ],
-            },
-            name: random<DocumentEventName>(),
-          }),
-        ],
+        externalEvents: [stubEventWithVehicleType(faker.string.sample())],
       });
 
       beforeAll(() => {
@@ -69,7 +42,7 @@ testRuleProcessorWithMassDocuments(
         ]);
       });
 
-      it('should return the resultStatus REJECTED if the events does not satisfy the vehicle-type', async () => {
+      it('should return REJECTED if the events does not satisfy the vehicle-type', async () => {
         const response = await handler(
           stubRuleInput({
             documentKeyPrefix,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.e2e.spec.ts
@@ -31,7 +31,6 @@ testRuleProcessorWithMassDocuments(
     describe('VehicleTypeProcessor E2E', () => {
       const documentKeyPrefix = faker.string.uuid();
       const parentDocumentId = faker.string.uuid();
-      const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
       const document = stubDocument({
         externalEvents: [
@@ -41,7 +40,10 @@ testRuleProcessorWithMassDocuments(
                 {
                   isPublic: true,
                   name: DocumentEventAttributeName.MOVE_TYPE,
-                  value: random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
+                  value: random<
+                    | DocumentEventMoveType.PICK_UP
+                    | DocumentEventMoveType.SHIPMENT_REQUEST
+                  >(),
                 },
                 {
                   isPublic: true,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
@@ -66,15 +66,7 @@ describe('VehicleTypeProcessor', () => {
         random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
       ),
       scenario:
-        'should return the resultStatus REJECTED if move-type is Pick-up but the vehicle-type attribute value does not exist',
-    },
-    {
-      ...generateTestScenario(
-        random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
-        '',
-      ),
-      scenario:
-        'should return the resultStatus REJECTED if move-type is Pick-up but the vehicle-type attribute value is an empty string',
+        'should return the resultStatus REJECTED if move-type is Pick-up or Shipment-Request but the vehicle-type attribute value does not exist or is an empty string',
     },
   ])('$scenario', async ({ document, resultComment, resultStatus }) => {
     const ruleInput = random<Required<RuleInput>>();

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
@@ -4,7 +4,6 @@ import {
   stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/methodologies/bold/testing';
 import {
-  type Document,
   DocumentEventAttributeName,
   DocumentEventMoveType,
   DocumentEventVehicleType,
@@ -18,6 +17,7 @@ import { stubEnumValue } from '@carrot-fndn/shared/testing';
 import { random } from 'typia';
 
 import { VehicleTypeProcessor } from './vehicle-type.processor';
+import { stubEventWithVehicleType } from './vehicle-type.stubs';
 
 jest.mock('@carrot-fndn/methodologies/bold/io-helpers');
 
@@ -25,48 +25,46 @@ describe('VehicleTypeProcessor', () => {
   const ruleDataProcessor = new VehicleTypeProcessor();
   const documentLoaderService = jest.mocked(loadParentDocument);
 
-  const { MOVE_TYPE, VEHICLE_TYPE } = DocumentEventAttributeName;
-  const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
-
-  const generateCommonEvents = (vehicleType?: string) => [
-    stubDocumentEventWithMetadataAttributes({}, [
-      [MOVE_TYPE, random<typeof PICK_UP | typeof SHIPMENT_REQUEST>()],
-      [VEHICLE_TYPE, vehicleType || ''],
-    ]),
-  ];
-
   it.each([
     {
-      document: random<Omit<Document, 'externalEvents'>>(),
+      externalEvents: [],
       resultComment: ruleDataProcessor['ResultComment'].NOT_APPLICABLE,
       resultStatus: RuleOutputStatus.APPROVED,
-      scenario:
-        'should return the resultStatus APPROVED if there is no move-type attribute',
+      scenario: 'should return APPROVED if there is no move-type attribute',
     },
     {
-      document: stubDocument({
-        externalEvents: generateCommonEvents(
-          stubEnumValue(DocumentEventVehicleType),
-        ),
-      }),
+      externalEvents: [
+        stubEventWithVehicleType(stubEnumValue(DocumentEventVehicleType)),
+      ],
       resultComment: ruleDataProcessor['ResultComment'].APPROVED,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
-        'should return the resultStatus APPROVED if vehicle-type attribute value matches a value from DocumentEventVehicleType enum',
+        'should return APPROVED if vehicle-type attribute value matches a value from DocumentEventVehicleType enum',
     },
     {
-      document: stubDocument({
-        externalEvents: generateCommonEvents(),
-      }),
+      externalEvents: [stubEventWithVehicleType('')],
       resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       resultStatus: RuleOutputStatus.REJECTED,
       scenario:
-        'should return the resultStatus REJECTED if move-type is Pick-up or Shipment-Request but the vehicle-type attribute value does not exist or is an empty string',
+        'should return REJECTED if move-type is Pick-up or Shipment-Request but the vehicle-type attribute value is an empty string',
     },
-  ])('$scenario', async ({ document, resultComment, resultStatus }) => {
+    {
+      externalEvents: [
+        stubDocumentEventWithMetadataAttributes({}, [
+          [DocumentEventAttributeName.MOVE_TYPE, DocumentEventMoveType.PICK_UP],
+        ]),
+      ],
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED if move-type is Pick-up or Shipment-Request but the vehicle-type attribute does not exist',
+    },
+  ])('$scenario', async ({ externalEvents, resultComment, resultStatus }) => {
     const ruleInput = random<Required<RuleInput>>();
 
-    documentLoaderService.mockResolvedValueOnce(document);
+    documentLoaderService.mockResolvedValueOnce(
+      stubDocument({ externalEvents }),
+    );
 
     const expectedRuleOutput: RuleOutput = {
       requestId: ruleInput.requestId,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
@@ -28,9 +28,9 @@ describe('VehicleTypeProcessor', () => {
   const { MOVE_TYPE, VEHICLE_TYPE } = DocumentEventAttributeName;
   const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
-  const generateCommonEvents = (moveType: string, vehicleType?: string) => [
+  const generateCommonEvents = (vehicleType?: string) => [
     stubDocumentEventWithMetadataAttributes({}, [
-      [MOVE_TYPE, moveType],
+      [MOVE_TYPE, random<typeof PICK_UP | typeof SHIPMENT_REQUEST>()],
       [VEHICLE_TYPE, vehicleType || ''],
     ]),
   ];
@@ -46,7 +46,6 @@ describe('VehicleTypeProcessor', () => {
     {
       document: stubDocument({
         externalEvents: generateCommonEvents(
-          random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
           stubEnumValue(DocumentEventVehicleType),
         ),
       }),
@@ -57,10 +56,7 @@ describe('VehicleTypeProcessor', () => {
     },
     {
       document: stubDocument({
-        externalEvents:
-          generateCommonEvents(
-            random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
-          ),
+        externalEvents: generateCommonEvents(),
       }),
       resultComment: ruleDataProcessor['ResultComment'].REJECTED,
       resultStatus: RuleOutputStatus.REJECTED,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.spec.ts
@@ -28,22 +28,12 @@ describe('VehicleTypeProcessor', () => {
   const { MOVE_TYPE, VEHICLE_TYPE } = DocumentEventAttributeName;
   const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
 
-  const generateTestScenario = (moveType: string, vehicleType?: string) => ({
-    document: stubDocument({
-      externalEvents: [
-        stubDocumentEventWithMetadataAttributes({}, [
-          [MOVE_TYPE, moveType],
-          [VEHICLE_TYPE, vehicleType || ''],
-        ]),
-      ],
-    }),
-    resultComment: vehicleType
-      ? ruleDataProcessor['ResultComment'].APPROVED
-      : ruleDataProcessor['ResultComment'].REJECTED,
-    resultStatus: vehicleType
-      ? RuleOutputStatus.APPROVED
-      : RuleOutputStatus.REJECTED,
-  });
+  const generateCommonEvents = (moveType: string, vehicleType?: string) => [
+    stubDocumentEventWithMetadataAttributes({}, [
+      [MOVE_TYPE, moveType],
+      [VEHICLE_TYPE, vehicleType || ''],
+    ]),
+  ];
 
   it.each([
     {
@@ -54,17 +44,26 @@ describe('VehicleTypeProcessor', () => {
         'should return the resultStatus APPROVED if there is no move-type attribute',
     },
     {
-      ...generateTestScenario(
-        random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
-        stubEnumValue(DocumentEventVehicleType),
-      ),
+      document: stubDocument({
+        externalEvents: generateCommonEvents(
+          random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
+          stubEnumValue(DocumentEventVehicleType),
+        ),
+      }),
+      resultComment: ruleDataProcessor['ResultComment'].APPROVED,
+      resultStatus: RuleOutputStatus.APPROVED,
       scenario:
         'should return the resultStatus APPROVED if vehicle-type attribute value matches a value from DocumentEventVehicleType enum',
     },
     {
-      ...generateTestScenario(
-        random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
-      ),
+      document: stubDocument({
+        externalEvents:
+          generateCommonEvents(
+            random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
+          ),
+      }),
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
+      resultStatus: RuleOutputStatus.REJECTED,
       scenario:
         'should return the resultStatus REJECTED if move-type is Pick-up or Shipment-Request but the vehicle-type attribute value does not exist or is an empty string',
     },

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.ts
@@ -1,24 +1,18 @@
 import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
 
-import {
-  and,
-  eventNameIsAnyOf,
-  metadataAttributeValueIsAnyOf,
-} from '@carrot-fndn/methodologies/bold/predicates';
+import { metadataAttributeValueIsAnyOf } from '@carrot-fndn/methodologies/bold/predicates';
 import { ParentDocumentRuleProcessor } from '@carrot-fndn/methodologies/bold/processors';
 import {
   type Document,
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventMoveType,
-  DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-const { MOVE, OPEN } = DocumentEventName;
-const { PICK_UP } = DocumentEventMoveType;
-const { MOVE_TYPE } = DocumentEventAttributeName;
+const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
+const { MOVE_TYPE, VEHICLE_TYPE } = DocumentEventAttributeName;
 
 export class VehicleTypeProcessor extends ParentDocumentRuleProcessor<
   DocumentEvent[]
@@ -36,7 +30,7 @@ export class VehicleTypeProcessor extends ParentDocumentRuleProcessor<
   ): EvaluateResultOutput {
     const resultStatus = events.every(
       metadataAttributeValueIsAnyOf(
-        DocumentEventAttributeName.VEHICLE_TYPE,
+        VEHICLE_TYPE,
         Object.values(DocumentEventVehicleType),
       ),
     )
@@ -60,10 +54,7 @@ export class VehicleTypeProcessor extends ParentDocumentRuleProcessor<
     document: Document,
   ): DocumentEvent[] | undefined {
     return document.externalEvents?.filter(
-      and(
-        eventNameIsAnyOf([MOVE, OPEN]),
-        metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP]),
-      ),
+      metadataAttributeValueIsAnyOf(MOVE_TYPE, [PICK_UP, SHIPMENT_REQUEST]),
     );
   }
 }

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.ts
@@ -54,10 +54,6 @@ export class VehicleTypeProcessor extends ParentDocumentRuleProcessor<
     };
   }
 
-  protected override getMissingRuleSubjectResultComment(): string {
-    return this.ResultComment.NOT_APPLICABLE;
-  }
-
   protected override getRuleSubject(
     document: Document,
   ): DocumentEvent[] | undefined {

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.processor.ts
@@ -9,6 +9,7 @@ import {
   DocumentEventMoveType,
   DocumentEventVehicleType,
 } from '@carrot-fndn/methodologies/bold/types';
+import { isNonEmptyArray } from '@carrot-fndn/shared/helpers';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
@@ -28,6 +29,13 @@ export class VehicleTypeProcessor extends ParentDocumentRuleProcessor<
   protected override evaluateResult(
     events: DocumentEvent[],
   ): EvaluateResultOutput {
+    if (!isNonEmptyArray(events)) {
+      return {
+        resultComment: this.ResultComment.NOT_APPLICABLE,
+        resultStatus: RuleOutputStatus.APPROVED,
+      };
+    }
+
     const resultStatus = events.every(
       metadataAttributeValueIsAnyOf(
         VEHICLE_TYPE,

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.stubs.ts
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/src/lib/vehicle-type.stubs.ts
@@ -1,0 +1,23 @@
+import type { PartialDeep } from 'type-fest';
+
+import { stubDocumentEventWithMetadataAttributes } from '@carrot-fndn/methodologies/bold/testing';
+import {
+  type DocumentEvent,
+  DocumentEventAttributeName,
+  DocumentEventMoveType,
+} from '@carrot-fndn/methodologies/bold/types';
+import { random } from 'typia';
+
+const { PICK_UP, SHIPMENT_REQUEST } = DocumentEventMoveType;
+
+export const stubEventWithVehicleType = (
+  vehicleType: string,
+  partialEvent?: PartialDeep<DocumentEvent>,
+): DocumentEvent =>
+  stubDocumentEventWithMetadataAttributes(partialEvent, [
+    [
+      DocumentEventAttributeName.MOVE_TYPE,
+      random<typeof PICK_UP | typeof SHIPMENT_REQUEST>(),
+    ],
+    [DocumentEventAttributeName.VEHICLE_TYPE, vehicleType],
+  ]);


### PR DESCRIPTION
### Summary

This PR updates the business rule to verify metadata for events.

### Details

**Before**: Check whether the vehicle type is identified in the OPEN or MOVE events when the `MOVE_TYPE`is identified as `Pick-up`.
**After**: Checks whether the vehicle type is identified in any event when the `MOVE_TYPE` is identified as `Pick-up` or `Shipment-request`.

### Related links

Task: https://app.clickup.com/t/3005225/CARROT-1038

---

- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of vehicle types in event processing for 'Pick-up' and 'Shipment-request' move types.

- **Refactor**
  - Streamlined constants and imports for better code maintainability and clarity.

- **Tests**
  - Enhanced test scenarios to ensure accurate validation of the changes.
  - Introduced stub functions to generate document events with specified attributes.

- **Documentation**
  - Updated documentation to reflect the new vehicle type processing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->