### PR TITLE
Capture unexpected error and keep rejecting rule

### DIFF
--- a/apps/methodologies/bold/rule-processors/certificate/rewards-distribution/src/lib/rewards-distribution.processor.errors.ts
+++ b/apps/methodologies/bold/rule-processors/certificate/rewards-distribution/src/lib/rewards-distribution.processor.errors.ts
@@ -1,4 +1,5 @@
 import { logger } from '@carrot-fndn/shared/helpers';
+import { AWSLambda } from '@sentry/serverless';
 
 export class RewardsDistributionProcessorErrors {
   private readonly KNOWN_ERROR_PREFIX = String(Symbol('[KNOWN ERROR]: '));
@@ -31,6 +32,7 @@ export class RewardsDistributionProcessorErrors {
     }
 
     logger.error(error, 'Unexpected error on "processKnownError" method');
+    AWSLambda.captureException(error);
 
     return undefined;
   }

--- a/nx.json
+++ b/nx.json
@@ -140,6 +140,5 @@
       "{projectRoot}/jest.config.ts",
       "{projectRoot}/tsconfig.spec.json"
     ]
-  },
-  "nxCloudAccessToken": "Yjc4Mjk0MGYtNjI5MC00NjE2LTg4OTktZTkyZDY1ODA3MzI0fHJlYWQtd3JpdGU="
+  }
 }


### PR DESCRIPTION
### Summary

Improve sentry capturing exception to get rejected rules.

### Details

- capture unexpected exception to get rejected rules
- keep rejecting rule (do not explode error up)

### Related links

- https://app.clickup.com/t/3005225/CARROT-1113

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling with improved tracking and reporting of exceptions using Sentry's AWS Lambda integration.
- **Chores**
	- Removed the `nxCloudAccessToken` property from the configuration for improved security and potential updates to cloud access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->