### PR TITLE
docs(rule): :memo: update the rule description in README.md [CARROT-1191]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/cdf-reason-dismissal/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-reason-dismissal/README.md
@@ -10,7 +10,7 @@ Methodology: **Bold**
 
 ## 📄 Description
 
-If the CDF does not exist for the `END` event, check if the justification field for dispensing with the CDF is declared.
+If the CDF does not exist for some event, check if the justification field for dispensing with the CDF is declared.
 
 ## 📂 Implementation
 

--- a/apps/methodologies/bold/rule-processors/mass/cdf-reason-dismissal/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-reason-dismissal/README.md
@@ -10,7 +10,7 @@ Methodology: **Bold**
 
 ## 📄 Description
 
-If the CDF does not exist for some event, check if the justification field for dispensing with the CDF is declared.
+If the CDF does not exist for any event, check if the justification field for dispensing with the CDF is declared.
 
 ## 📂 Implementation
 

--- a/apps/methodologies/bold/rule-processors/mass/drop-off-geolocation-precision/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/drop-off-geolocation-precision/README.md
@@ -10,7 +10,7 @@ Methodology: **Bold**
 
 ## 📄 Description
 
-Ensure that the address of the `MOVE` event with `move-type` declared as `Drop-off` is the same address of the Recycler participant homologation process and consider a 2km radius as the precision limit margin between the homologated and reported geolocations.
+Ensure that the address of the `MOVE` event, with `move-type` declared as `Drop-off`, is the same address as the participant's homologation process, and consider a radius of 2km as the limit margin of accuracy between the approved and reported geolocations either at the address or in the `gps-app` fields declared in the metadata.
 
 ### 📂 Implementation
 

--- a/apps/methodologies/bold/rule-processors/mass/event-value/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/event-value/README.md
@@ -10,7 +10,7 @@ Methodology: **Bold**
 
 ## 📄 Description
 
-Check if the declared value in the first event found with the `event-value` attribute, corresponding to the completion of the composting process, equals the value declared in the document.
+Check if the declared value in the first event found with the `event-value='CDF'` attribute, corresponding to the completion of the composting process, equals the value declared in the document.
 
 ## 📂 Implementation
 

--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
@@ -10,7 +10,7 @@ Methodology: **Bold**
 
 ## 📄 Description
 
-Verify if the address of the participant identified in an event with `move-type` declared as `Pick-up` or `Shipment-request` is the same as the address declared for the participant pointed as `SOURCE`.
+Ensure that the address of the event with `move-type` declared as `Pick-up` is the same address of the `SOURCE` participant homologation process and consider a 2km radius as the precision limit margin between the homologated and reported geolocations.
 
 ## 📂 Implementation
 


### PR DESCRIPTION
### Summary

Update rules readme.

### Related links

https://app.clickup.com/t/3005225/CARROT-1191

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the "Bold" methodology to clarify precision requirements for the "MOVE" event with a "Drop-off" move-type, emphasizing the importance of address and GPS accuracy.
	- Modified the description for the "event-value" check to specify that it explicitly references the `event-value='CDF'` attribute, enhancing clarity.
	- Revised address verification process for "Pick-up" events to specify alignment with the SOURCE participant's homologation process, including a 2km accuracy limit.
	- Generalized the conditions for checking the justification field for dispensing with the CDF, applying it to multiple events beyond just the `END` event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->