### PR TITLE
chore: redefine repository name reference [CARROT-1318]

### DIFF
--- a/apps/methodologies/bold/rule-processors/certificate/mass-document-type/README.md
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-document-type/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if all masses that make up the certificate have 'Organic' declared in the
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/certificate/mass-recycler-actor/README.md
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-recycler-actor/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the participant declared as Recycler is the same in all masses, as req
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/README.md
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-validation-document-status/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if all mass validation documents that make up the certificate have an app
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/certificate/mass-validation-document/README.md
+++ b/apps/methodologies/bold/rule-processors/certificate/mass-validation-document/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if all mass validation documents that make up the certificate are linked t
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/certificate/rewards-distribution/README.md
+++ b/apps/methodologies/bold/rule-processors/certificate/rewards-distribution/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Calculate rewards percentage rights for the participants that contributed to the
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/README.md
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Collect and aggregate information that is added to the NFT metadata.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/credit/rewards-distribution/README.md
+++ b/apps/methodologies/bold/rule-processors/credit/rewards-distribution/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Calculate rewards rights, in USDC, for the participants that contributed to the 
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/cdf-address/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-address/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ When a report is identified as `CDF`, verify if the declared addresses for the p
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/cdf-attachment-name/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-attachment-name/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ If the CDF exists for the End event, check if there is an attachment named `CDF`
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/cdf-attachment-verification/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-attachment-verification/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ If an MTR is declared in an event, check if the event contains a mandatory attac
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/cdf-fields/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-fields/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ In an event, when there is a report identified as CDF, verify if the `report-num
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/cdf-reason-dismissal/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/cdf-reason-dismissal/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ If the CDF does not exist for any event, check if the justification field for di
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/document-category/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/document-category/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the document category is declared as `Mass`.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/document-measurement-unit/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/document-measurement-unit/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the unit of measurement declared in the document is KG
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/document-subtype/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/document-subtype/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the document's subtype is allowed by the BOLD Methodology.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/document-type/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/document-type/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the document type is declared as Organic.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/document-value/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/document-value/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the document value is greater than 0.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/driver-internal-id/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/driver-internal-id/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the internal driver identification is declared in an event when the `m
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/drop-off-geolocation-precision/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/drop-off-geolocation-precision/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Ensure that the address of the `MOVE` event, with `move-type` declared as `Drop-
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/drop-off-move/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/drop-off-move/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Confirm if at least one `MOVE` event has the `move-type` metadata field declared
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/event-value/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/event-value/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the declared value in the first event found with the `event-value='CDF'
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/events-time-span/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/events-time-span/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the time interval between the Event with the metadata `move-type` equa
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/has-cdf/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/has-cdf/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if there is a CDF in the Document.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/has-mtr/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/has-mtr/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check in the `OPEN` event if there is an MTR for that event.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/invoice-fields/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/invoice-fields/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check, in a `MOVE` event, when there is metadata declared as `invoice-number`, i
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/mandatory-metadata/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/mandatory-metadata/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if at least one `OPEN` event has the `move type` metadata field declared a
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/maximum-distance/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/maximum-distance/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the geolocation distance between the event with `move-type` declared a
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/move-type/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/move-type/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the `move-type` metadata field is declared in all events labeled as `M
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/mtr-attachment-name/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/mtr-attachment-name/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ If the MTR exists for the `OPEN` event, check if there is an attachment named `M
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/mtr-attachment-verification/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/mtr-attachment-verification/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ If an MTR is declared in an event, check if the event contains a mandatory attac
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/mtr-reason-dismissal/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/mtr-reason-dismissal/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ If the `MTR` does not exist for the `OPEN` event, check if the justification fie
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/net-weight-verification/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/net-weight-verification/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Perform the function [`net-cargo-weight` = `vehicle-gross-weight` - `vehicle-tar
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/numeric-weight-values/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/numeric-weight-values/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if all the values declared in a `MOVE` event, with the `move-type` declar
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/pick-up-geolocation-precision/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/pick-up-geolocation-precision/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Ensure that the address of the event with `move-type` declared as `Pick-up` is t
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/primary-participant-address/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/primary-participant-address/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the addresses declared for the `SOURCE` type actor and the Primary Par
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/primary-participant/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/primary-participant/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the participant declared as `SOURCE` is the same participant listed as 
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/recycler-actor/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/recycler-actor/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Ensure there is one and only one actor identified as `RECYCLER`.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/same-recycler-and-drop-off-addresses/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/same-recycler-and-drop-off-addresses/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Verify if the address of the participant identified in the `MOVE` event with `mo
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/same-source-and-pick-up-addresses/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Ensure that the address of the event with `move-type` declared as `Pick-up` is t
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/source-actor/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/source-actor/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Ensure there is one and only one actor identified as `SOURCE`.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-description/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-description/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ In the case of the vehicle type indicated as `Other` in any event, when the `mov
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-license-plate/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ When the vehicle type is different from `Sludge Pipes`, `Cart`, or `Bicycle`, ch
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/vehicle-type/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/vehicle-type/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the vehicle type is identified in events when the `move-type` is identi
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/waste-origin-identified/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/waste-origin-identified/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check if the mass origin identification field is declared as true or false.
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold/rule-processors/mass/weighing-fields/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/weighing-fields/README.md
@@ -4,7 +4,7 @@
 
 Methodology: **Bold**
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/audit-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
 
 </div>
 
@@ -28,4 +28,4 @@ Check in a `MOVE` event, with the`movet-ype` declared as `Weighing`, if it has a
 
 ## 🔑 License
 
-[License](https://github.com/carrot-foundation/audit-rules/blob/main/LICENSE)
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "carrot-audit-rules",
+  "name": "carrot-methodology-rules",
   "version": "0.0.0",
   "license": "LGPL-3.0",
   "scripts": {


### PR DESCRIPTION
### Summary

Redefine repository name reference 

### Details

* [chore: redefine repository name reference [CARROT-1318]](https://github.com/carrot-foundation/methodology-rules/commit/a567ae704a65a0feea25ae4353efcbb1397b4663)

### Related links

Task: https://app.clickup.com/t/3005225/CARROT-1318

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated GitHub Actions workflow badge and license links across multiple README files for the Bold methodology to reflect the new repository structure.
	- Renamed the package from "carrot-audit-rules" to "carrot-methodology-rules" in `package.json`.

- **Documentation**
	- Enhanced accuracy of the documentation by ensuring all links direct users to the correct resources related to the Bold methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->