### PR TITLE
feat: add origin_state and recycler_name in summary [CARROT-1336]

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -299,6 +299,8 @@ export const mapNftMetadata = ({
         mass_subtype: subtype,
         mass_type: type,
         origin_country: originCountry,
+        origin_state: originCountryState,
+        recycler_name: recyclerName,
       },
     },
     external_id: creditDocumentId,

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
@@ -48,6 +48,8 @@ interface NftMetadataSummary {
   mass_subtype: NonEmptyString;
   mass_type: NonEmptyString;
   origin_country: NonEmptyString;
+  origin_state: NonEmptyString;
+  recycler_name: NonEmptyString;
 }
 
 export interface NftMetadataRewardsDistribution {


### PR DESCRIPTION
### Summary

_Add origin_state and recycler_name in summary ._

### Related links
https://app.clickup.com/t/3005225/CARROT-1336

---

- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced NFT metadata structure by adding `origin_state` and `recycler_name` properties for improved geographical and recycling information.
- **Improvements**
	- Expanded the `NftMetadataSummary` interface to include new fields, allowing for more detailed tracking of NFT origins and recycling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->