### PR TITLE
fix: remove certificateValue from nft-metadata-selection

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
@@ -23,7 +23,6 @@ export interface CertificateMetadata {
 }
 
 export interface MethodologyMetadata {
-  certificateValueLabel: NonEmptyString;
   description: NonEmptyString;
   documentId: NonEmptyString;
   name: NonEmptyString;

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
@@ -45,7 +45,6 @@ import { stubMassDocument } from './nft-metadata-selection.stubs';
 
 const {
   ACTOR_TYPE,
-  CERTIFICATE_VALUE_LABEL,
   METHODOLOGY_DESCRIPTION,
   METHODOLOGY_NAME,
   RULE_PROCESSOR_CODE_VERSION,
@@ -178,7 +177,6 @@ describe('Helpers', () => {
           ...stubArray(stubDocumentEvent),
           stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
             [METHODOLOGY_DESCRIPTION, faker.lorem.sentence()],
-            [CERTIFICATE_VALUE_LABEL, faker.lorem.sentence()],
             [METHODOLOGY_NAME, faker.lorem.sentence()],
           ]),
         ],

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -171,14 +171,10 @@ export const mapMethodologyMetadata = (
     eventHasName(event, OPEN),
   );
 
-  const { CERTIFICATE_VALUE_LABEL, METHODOLOGY_DESCRIPTION, METHODOLOGY_NAME } =
+  const { METHODOLOGY_DESCRIPTION, METHODOLOGY_NAME } =
     DocumentEventAttributeName;
 
   return {
-    certificateValueLabel: getEventAttributeValue(
-      openEvent,
-      CERTIFICATE_VALUE_LABEL,
-    ) as string,
     description: getEventAttributeValue(
       openEvent,
       METHODOLOGY_DESCRIPTION,
@@ -302,7 +298,6 @@ export const mapNftMetadata = ({
         policy_version: rewardsDistribution.policyVersion,
       },
       summary: {
-        certificate_label: 'Organics Landfill Diversion',
         mass_certificate_count: certificates.length,
         mass_id_count: getCertificatesMassIdsCount(certificates),
         mass_origin_country: originCountry,

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.stubs.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.stubs.ts
@@ -19,7 +19,7 @@ import { faker } from '@faker-js/faker';
 import { random } from 'typia';
 
 const { OPEN, OUTPUT, RELATED } = DocumentEventName;
-const { CERTIFICATE_VALUE_LABEL, METHODOLOGY_DESCRIPTION, METHODOLOGY_NAME } =
+const { METHODOLOGY_DESCRIPTION, METHODOLOGY_NAME } =
   DocumentEventAttributeName;
 
 export const stubDocumentOutputEvent = (
@@ -48,7 +48,6 @@ export const stubMethodologyDefinitionDocument = (
     ...stubArray(stubDocumentEvent),
     stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
       [METHODOLOGY_DESCRIPTION, faker.lorem.sentence()],
-      [CERTIFICATE_VALUE_LABEL, faker.lorem.sentence()],
       [METHODOLOGY_NAME, faker.lorem.word()],
     ]),
     ...(partialDocument?.externalEvents ?? []),

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
@@ -41,7 +41,6 @@ export interface NftMetadataMethodology {
 }
 
 interface NftMetadataSummary {
-  certificate_label: NonEmptyString;
   mass_certificate_count: NonZeroPositive;
   mass_id_count: NonZeroPositive;
   mass_origin_country: NonEmptyString;

--- a/libs/methodologies/bold/types/src/enum.types.ts
+++ b/libs/methodologies/bold/types/src/enum.types.ts
@@ -78,7 +78,6 @@ export enum DocumentEventAttributeName {
   ACTOR_TYPE = 'actor-type',
   APP_GPS_LATITUDE = 'app-gps-latitude',
   APP_GPS_LONGITUDE = 'app-gps-longitude',
-  CERTIFICATE_VALUE_LABEL = 'certificate-value-label',
   DRIVER_INTERNAL_ID = 'driver-internal-id',
   EVENT_VALUE = 'event-value',
   HAS_CDF = 'has-cdf',


### PR DESCRIPTION
### Summary

Remove the `certificateValue` from `metadata-selection` rule.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified metadata structures by removing unnecessary fields related to certificate values.
  
- **Bug Fixes**
	- Addressed potential issues by eliminating references to removed properties, ensuring smoother data handling.

- **Refactor**
	- Streamlined functions and interfaces to enhance clarity and reduce complexity in metadata processing.

- **Chores**
	- Updated test cases and stubs to align with the new metadata structure, removing obsolete constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->