### PR TITLE
Improve formatWeight helper

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
@@ -106,7 +106,11 @@ describe('Helpers', () => {
       (weight) => {
         const result = formatWeight(weight);
 
-        expect(result).toBe(`${weight}kg`);
+        expect(result).toBe(
+          `${Intl.NumberFormat('en-US', {
+            maximumFractionDigits: 2,
+          }).format(weight)}kg`,
+        );
       },
     );
   });

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -66,7 +66,10 @@ export const mapMassMetadata = (document: Document): MassMetadata => ({
 
 export const getMassValue = (mass: MassMetadata): number => mass.value;
 
-export const formatWeight = (weight: number): string => `${weight}kg`;
+export const formatWeight = (weight: number, fractionDigits = 2): string =>
+  `${Intl.NumberFormat('en-US', {
+    maximumFractionDigits: fractionDigits,
+  }).format(weight)}kg`;
 
 export const findMassValidationId = (
   massDocument: Document,


### PR DESCRIPTION
### Summary

Improve `formatWeight` helper to handle fractional weights.
Example:

1kg -> 1kg
100000kg -> 100,000kg
0.1kg -> 0.1kg

### Details

- use Intl.NumberFormat to format the weight

### Related links

- https://app.clickup.com/t/3005225/CARROT-1354

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced weight formatting functionality to allow customizable decimal precision in weight display.
	- Improved user-friendly output with standardized formatting for weight values.

- **Bug Fixes**
	- Updated test cases to validate the new weight formatting, ensuring accurate representation of weights with up to two decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->