### PR TITLE
feat: add new subtype to document-subtype rule

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/document-subtype/src/lib/document-subtype.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/document-subtype/src/lib/document-subtype.processor.ts
@@ -13,9 +13,10 @@ export class DocumentSubtypeProcessor extends ParentDocumentRuleProcessor<string
   };
 
   protected override evaluateResult(ruleSubject: string): EvaluateResultOutput {
-    const resultStatus = Object.values<string>(DocumentSubtype).includes(
-      ruleSubject,
-    )
+    const resultStatus = [
+      'Wood and Wood Products',
+      ...Object.values<string>(DocumentSubtype),
+    ].includes(ruleSubject)
       ? RuleOutputStatus.APPROVED
       : RuleOutputStatus.REJECTED;
 


### PR DESCRIPTION
### Summary

_Summarize the suggested changes with this PR._

### Details

_Add more context to describe the changes and screenshots if appropriate._

### Related links

_Insert links related to this change, such as Notion pages, ClickUp tasks, or any other relevant sources._

---

- [ ] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced evaluation criteria to include 'Wood and Wood Products' for document subtype approvals.
  
- **Bug Fixes**
	- Improved logic in the evaluation process, potentially leading to more accurate outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->