### PR TITLE
refactor: remove hard coded DocumentSubtype

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/document-subtype/src/lib/document-subtype.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass/document-subtype/src/lib/document-subtype.processor.ts
@@ -13,10 +13,9 @@ export class DocumentSubtypeProcessor extends ParentDocumentRuleProcessor<string
   };
 
   protected override evaluateResult(ruleSubject: string): EvaluateResultOutput {
-    const resultStatus = [
-      'Wood and Wood Products',
-      ...Object.values<string>(DocumentSubtype),
-    ].includes(ruleSubject)
+    const resultStatus = Object.values<string>(DocumentSubtype).includes(
+      ruleSubject,
+    )
       ? RuleOutputStatus.APPROVED
       : RuleOutputStatus.REJECTED;
 


### PR DESCRIPTION
### Summary

Remove unnecessary hard coded subtype from Document Subtype rule.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the evaluation logic for document subtypes, enhancing clarity and maintainability. 

This change streamlines how results are determined, ensuring a more efficient processing experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->