### PR TITLE
feat: add collection name and mass origin city in NFT metadata

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
@@ -9,6 +9,7 @@ import type { tags } from 'typia';
 export interface MassMetadata {
   documentId: NonEmptyString;
   measurementUnit: NonEmptyString;
+  originCity: NonEmptyString;
   originCountry: NonEmptyString;
   originCountryState: NonEmptyString;
   recyclerName: NonEmptyString;

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -270,7 +270,7 @@ export const mapNftMetadata = ({
         value: originCountryState,
       },
       {
-        trait_type: 'Mass City',
+        trait_type: 'Mass Origin (City)',
         value: originCity,
       },
       {

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -51,6 +51,7 @@ export const getCarrotExplorePageUrl = (documentId: string) =>
 export const mapMassMetadata = (document: Document): MassMetadata => ({
   documentId: document.id,
   measurementUnit: document.measurementUnit,
+  originCity: document.primaryAddress.city,
   originCountry: document.primaryAddress.countryCode,
   originCountryState: document.primaryAddress.countryState,
   recyclerName: document.externalEvents?.find(
@@ -245,8 +246,14 @@ export const mapNftMetadata = ({
   methodology,
   rewardsDistribution,
 }: MethodologyCreditNftMetadataDto): NftMetadata => {
-  const { originCountry, originCountryState, recyclerName, subtype, type } =
-    massCertificates[0].masses[0];
+  const {
+    originCity,
+    originCountry,
+    originCountryState,
+    recyclerName,
+    subtype,
+    type,
+  } = massCertificates[0].masses[0];
 
   return {
     attributes: [
@@ -263,12 +270,20 @@ export const mapNftMetadata = ({
         value: originCountryState,
       },
       {
+        trait_type: 'Mass City',
+        value: originCity,
+      },
+      {
         trait_type: 'Recycler',
         value: recyclerName,
       },
       {
         trait_type: 'Credit Type',
         value: 'Recycling Credit',
+      },
+      {
+        trait_type: 'Collection Name',
+        value: 'BOLD Innovators Collection',
       },
       {
         trait_type: 'Amount in Kg',


### PR DESCRIPTION
### Summary

Add the `Origin City` and `Collection Name` in `nft-metadata-selection` rule.

### Related links

https://app.clickup.com/t/3005225/CARROT-1379

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `originCity`, to enhance NFT metadata with geographical information.
	- Added a new attribute for 'Mass Origin (City)' and 'Collection Name' in the NFT metadata, improving detail and context.
  
These updates enrich the metadata, providing users with more comprehensive insights into the NFTs and their origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->