### PR TITLE
feat: add collection name and mass origin city in NFT summary

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -325,6 +325,7 @@ export const mapNftMetadata = ({
       summary: {
         mass_certificate_count: massCertificates.length,
         mass_id_count: getMassCertificatesMassIdsCount(massCertificates),
+        mass_origin_city: originCity,
         mass_origin_country: originCountry,
         mass_origin_state: originCountryState,
         mass_subtype: subtype,

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
@@ -43,6 +43,7 @@ export interface NftMetadataMethodology {
 interface NftMetadataSummary {
   mass_certificate_count: NonZeroPositive;
   mass_id_count: NonZeroPositive;
+  mass_origin_city: NonEmptyString;
   mass_origin_country: NonEmptyString;
   mass_origin_state: NonEmptyString;
   mass_subtype: NonEmptyString;


### PR DESCRIPTION
### Summary

Add `mass_origin_city` in NFT metadata Summary.

---

- [x]  **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**
