### PR TITLE
fix: remove unnecessary config [CARROT-488]

### DIFF
--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -60,7 +60,5 @@ export const wrapRuleIntoLambdaHandler = (
     }
   };
 
-  return AWSLambda.wrapHandler(handler, {
-    captureTimeoutWarning: true,
-  });
+  return AWSLambda.wrapHandler(handler);
 };

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -62,6 +62,5 @@ export const wrapRuleIntoLambdaHandler = (
 
   return AWSLambda.wrapHandler(handler, {
     captureTimeoutWarning: true,
-    timeoutWarningLimit: 30_000,
   });
 };


### PR DESCRIPTION
### Summary

_Remove timeoutWarningLimit._

### Related links

_https://app.clickup.com/t/3005225/CARROT-488_

---

- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed timeout warning options from the handler wrapping process, simplifying functionality but potentially affecting timeout issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->