### PR TITLE
Get NFT image from the Credit document metadata

### DIFF
--- a/.env-files/.env.test
+++ b/.env-files/.env.test
@@ -1,4 +1,4 @@
 ARTIFACT_CHECKSUM=0
 SOURCE_CODE_URL=https://carrot.eco
 SOURCE_CODE_VERSION=0
-SENTRY_DSN=https://public.sentry.io/test
+SENTRY_DSN=https://0@o0.ingest.sentry.io/0

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
@@ -2,6 +2,7 @@ import type { CertificateReward } from '@carrot-fndn/methodologies/bold/types';
 import type {
   NonEmptyArray,
   NonEmptyString,
+  Uri,
   Url,
 } from '@carrot-fndn/shared/types';
 import type { tags } from 'typia';
@@ -43,6 +44,7 @@ export interface RewardsDistributionMetadata {
 
 export interface MethodologyCreditNftMetadataDto {
   creditDocumentId: NonEmptyString;
+  image?: Uri | undefined;
   massCertificates: NonEmptyArray<MassCertificateMetadata>;
   methodology: MethodologyMetadata;
   rewardsDistribution: RewardsDistributionMetadata;

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
@@ -2,6 +2,7 @@ import type { NonEmptyArray, UnknownObject } from '@carrot-fndn/shared/types';
 import type { RequiredDeep } from 'type-fest';
 
 import {
+  stubDocument,
   stubDocumentEvent,
   stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/methodologies/bold/testing';
@@ -32,6 +33,7 @@ import {
   formatCeritificatesMassValue,
   formatWeight,
   getCarrotExplorePageUrl,
+  getImageFromMetadata,
   getMassCertificatesMassIdsCount,
   getMassCertificatesMassValue,
   getMassValue,
@@ -47,6 +49,7 @@ const {
   ACTOR_TYPE,
   METHODOLOGY_DESCRIPTION,
   METHODOLOGY_NAME,
+  NFT_IMAGE,
   RULE_PROCESSOR_CODE_VERSION,
   RULE_PROCESSOR_RESULT_CONTENT,
   RULE_PROCESSOR_SOURCE_CODE_URL,
@@ -62,6 +65,47 @@ describe('Helpers', () => {
       const expected = `https://explore.carrot.eco/document/${documentId}`;
 
       expect(getCarrotExplorePageUrl(documentId)).toBe(expected);
+    });
+  });
+
+  describe('getImageFromMetadata', () => {
+    it('should return undefined if the open event does not have the NFT_IMAGE attribute', () => {
+      const documentStub = stubDocument({
+        externalEvents: [stubDocumentEvent({ name: OPEN })],
+      });
+
+      const result = getImageFromMetadata(documentStub);
+
+      expect(result).toBe(undefined);
+    });
+
+    it('should return undefined if the metadata value is not a valid Uri', () => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
+            [NFT_IMAGE, faker.string.sample()],
+          ]),
+        ],
+      });
+
+      const result = getImageFromMetadata(documentStub);
+
+      expect(result).toBe(undefined);
+    });
+
+    it('should return the metadata value if it is a valid Uri', () => {
+      const image = faker.internet.url();
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
+            [NFT_IMAGE, image],
+          ]),
+        ],
+      });
+
+      const result = getImageFromMetadata(documentStub);
+
+      expect(result).toBe(image);
     });
   });
 

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -1,7 +1,10 @@
 import type { RuleInput } from '@carrot-fndn/shared/rule/types';
-import type { NonEmptyArray } from '@carrot-fndn/shared/types';
+import type { NonEmptyArray, Uri } from '@carrot-fndn/shared/types';
 
-import { getEventAttributeValue } from '@carrot-fndn/methodologies/bold/getters';
+import {
+  getEventAttributeValue,
+  getOpenEvent,
+} from '@carrot-fndn/methodologies/bold/getters';
 import {
   MASS_AUDIT,
   MASS_CERTIFICATE,
@@ -22,7 +25,7 @@ import {
   type RewardDistributionResultContent,
 } from '@carrot-fndn/methodologies/bold/types';
 import { isNil, isNonEmptyArray } from '@carrot-fndn/shared/helpers';
-import { assert } from 'typia';
+import { assert, is } from 'typia';
 
 import type {
   MassCertificateMetadata,
@@ -40,13 +43,23 @@ import type {
 
 const { RECYCLER } = DocumentEventActorType;
 const { ACTOR, OPEN, RULE_EXECUTION } = DocumentEventName;
-const { ACTOR_TYPE } = DocumentEventAttributeName;
+const { ACTOR_TYPE, NFT_IMAGE } = DocumentEventAttributeName;
 const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
 
 const logger = console;
 
 export const getCarrotExplorePageUrl = (documentId: string) =>
   `https://explore.carrot.eco/document/${documentId}`;
+
+export const getImageFromMetadata = (
+  document: Document | undefined,
+): Uri | undefined => {
+  const openEvent = getOpenEvent(document);
+
+  const uri = getEventAttributeValue(openEvent, NFT_IMAGE);
+
+  return is<Uri>(uri) ? uri : undefined;
+};
 
 export const mapMassMetadata = (document: Document): MassMetadata => ({
   documentId: document.id,
@@ -242,6 +255,7 @@ export const mapNftMetadataDto = (
 
 export const mapNftMetadata = ({
   creditDocumentId,
+  image,
   massCertificates,
   methodology,
   rewardsDistribution,
@@ -339,6 +353,7 @@ export const mapNftMetadata = ({
     external_id: creditDocumentId,
     external_url: getCarrotExplorePageUrl(creditDocumentId),
     image:
+      image ??
       'ipfs://bafybeiaxb5dwhmai4waltapfxrtf7rzmhulgigy4t27vynvzqtrowktyzi/image.png',
     name: 'BOLD',
   };

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.e2e.spec.ts
@@ -2,6 +2,7 @@ import type { UnknownObject } from '@carrot-fndn/shared/types';
 
 import {
   stubDocumentEvent,
+  stubDocumentEventAttribute,
   stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/methodologies/bold/testing';
 import {
@@ -48,7 +49,7 @@ import {
 
 const { RECYCLER } = DocumentEventActorType;
 const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
-const { ACTOR, LINK, RULE_EXECUTION } = DocumentEventName;
+const { ACTOR, LINK, OPEN, RULE_EXECUTION } = DocumentEventName;
 const {
   ACTOR_TYPE,
   RULE_PROCESSOR_CODE_VERSION,
@@ -67,6 +68,7 @@ const {
 describe('NftMetadataSelection E2E', () => {
   const documentKeyPrefix = faker.string.uuid();
   const creditDocumentId = faker.string.uuid();
+  const image = faker.internet.url();
 
   // TODO: Refac this test to use a builder or a stub that prepares the documents https://app.clickup.com/t/86a36ut5a
   const creditDocumentReference: DocumentReference = {
@@ -120,6 +122,19 @@ describe('NftMetadataSelection E2E', () => {
 
   const creditDocumentStub = stubCreditDocument({
     externalEvents: [
+      stubDocumentEvent({
+        metadata: {
+          attributes: [
+            stubDocumentEventAttribute({
+              name: DocumentEventAttributeName.NFT_IMAGE,
+              value: image,
+            }),
+          ],
+        },
+        name: OPEN,
+        referencedDocument: undefined,
+        relatedDocument: undefined,
+      }),
       stubDocumentOutputEvent(creditCertificatesReference),
       stubDocumentEvent({
         name: LINK,
@@ -243,6 +258,7 @@ describe('NftMetadataSelection E2E', () => {
     );
 
     expect(validationResultContent.errors).toEqual([]);
-    expect(response.resultStatus).toEqual(RuleOutputStatus.APPROVED);
+    expect(response.resultStatus).toBe(RuleOutputStatus.APPROVED);
+    expect(response.resultContent?.['image']).toBe(image);
   });
 });

--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.ts
@@ -33,6 +33,7 @@ import {
 import {
   findMassAuditId,
   findMassCertificateIdFromDocumentLinks,
+  getImageFromMetadata,
   mapMassMetadata,
   mapMethodologyMetadata,
   mapNftMetadata,
@@ -67,6 +68,7 @@ export class NftMetadataSelection extends RuleDataProcessor {
   ): Promise<Omit<MethodologyCreditNftMetadataDto, 'creditDocumentId'>> {
     const documentsLinks = new Map<string, DocumentLinks>();
     const massCertificates = new Map<string, MassCertificateMetadata>();
+    const credit = documentQuery.rootDocument;
 
     let methodologyMetadata: MethodologyMetadata = {} as MethodologyMetadata;
     let rewardsDistribution: RewardsDistributionMetadata =
@@ -111,6 +113,7 @@ export class NftMetadataSelection extends RuleDataProcessor {
     });
 
     return {
+      image: getImageFromMetadata(credit),
       massCertificates: [
         ...massCertificates.values(),
       ] as NonEmptyArray<MassCertificateMetadata>,

--- a/libs/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/methodologies/bold/getters/src/document.getters.spec.ts
@@ -10,9 +10,9 @@ import {
 } from '@carrot-fndn/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 
-import { getAuditorActorEvent } from './document.getters';
+import { getAuditorActorEvent, getOpenEvent } from './document.getters';
 
-const { ACTOR } = DocumentEventName;
+const { ACTOR, OPEN } = DocumentEventName;
 const { AUDITOR } = DocumentEventActorType;
 const { ACTOR_TYPE } = DocumentEventAttributeName;
 
@@ -46,6 +46,36 @@ describe('Document getters', () => {
       });
 
       const result = getAuditorActorEvent(document);
+
+      expect(result).toBe(undefined);
+    });
+  });
+
+  describe('getOpenEvent', () => {
+    it('should return the open event', () => {
+      const openEvent = stubDocumentEvent({ name: OPEN });
+
+      const document = stubDocument({
+        externalEvents: [...stubArray(() => stubDocumentEvent()), openEvent],
+      });
+
+      const result = getOpenEvent(document);
+
+      expect(result).toEqual(openEvent);
+    });
+
+    it('should return undefined if the open event was not found', () => {
+      const document = stubDocument({
+        externalEvents: stubArray(() => stubDocumentEvent()),
+      });
+
+      const result = getOpenEvent(document);
+
+      expect(result).toBe(undefined);
+    });
+
+    it('should return undefined if the document is undefined', () => {
+      const result = getOpenEvent(undefined);
 
       expect(result).toBe(undefined);
     });

--- a/libs/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/methodologies/bold/getters/src/document.getters.ts
@@ -21,3 +21,10 @@ export const getAuditorActorEvent = (
       event.name === ACTOR &&
       getEventAttributeValue(event, ACTOR_TYPE) === AUDITOR,
   );
+
+export const getOpenEvent = (
+  document: Document | undefined,
+): DocumentEvent | undefined =>
+  document?.externalEvents?.find(
+    (event) => event.name === DocumentEventName.OPEN.toString(),
+  );

--- a/libs/methodologies/bold/types/src/enum.types.ts
+++ b/libs/methodologies/bold/types/src/enum.types.ts
@@ -100,6 +100,7 @@ export enum DocumentEventAttributeName {
   METHODOLOGY_NAME = 'methodology-name',
   METHODOLOGY_SLUG = 'methodology-slug',
   MOVE_TYPE = 'move-type',
+  NFT_IMAGE = 'nft-image',
   REPORT_DATE_ISSUED = 'report-date-issued',
   REPORT_NUMBER = 'report-number',
   REPORT_TYPE = 'report-type',


### PR DESCRIPTION
- **chore: update test sentry dsn format**
- **feat: create getOpenEvent helper**
- **feat: get NFT image from credit metadata**

### Summary

Get the NFT image from credit metadata to allow custom images for NFTs

### Details

- Sentry DSN format changed to stop test warnings
- Added helper to get open event
- Added helper to get NFT image from credit metadata

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new optional `image` property in NFT metadata for enhanced visual identification.
  - Added a function to extract an image URL from metadata, improving NFT-related metadata processing.
  - Implemented a new document event type, "OPEN," expanding event handling capabilities.

- **Bug Fixes**
  - Updated SENTRY_DSN for improved security in the testing environment.

- **Enhancements**
  - Improved flexibility in metadata handling by allowing optional image parameters.
  - Expanded document event attributes to include `NFT_IMAGE`.

These updates enhance the overall functionality and security of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->