### PR TITLE
feat: get unit-price from RULES_METADATA event [CARROT-1393]

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.e2e.spec.ts
+++ b/apps/methodologies/bold/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.e2e.spec.ts
@@ -32,7 +32,7 @@ import {
   stubMassDocumentWithEndEventValue,
 } from './rewards-distribution.stubs';
 
-const { OPEN } = DocumentEventName;
+const { RULES_METADATA } = DocumentEventName;
 const { UNIT_PRICE } = DocumentEventAttributeName;
 
 describe('RewardsDistributionProcessor E2E', () => {
@@ -92,7 +92,7 @@ describe('RewardsDistributionProcessor E2E', () => {
 
   const credit = stubCreditDocument({
     externalEvents: [
-      stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
+      stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
         [UNIT_PRICE, unitPrice],
       ]),
       stubDocumentEvent({

--- a/apps/methodologies/bold/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.spec.ts
+++ b/apps/methodologies/bold/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.spec.ts
@@ -22,7 +22,7 @@ import {
   stubMassDocumentWithEndEventValue,
 } from './rewards-distribution.stubs';
 
-const { OPEN } = DocumentEventName;
+const { RULES_METADATA } = DocumentEventName;
 const { UNIT_PRICE } = DocumentEventAttributeName;
 
 describe('RewardsDistributionProcessor', () => {
@@ -78,7 +78,7 @@ describe('RewardsDistributionProcessor', () => {
     {
       credit: stubCreditDocument({
         externalEvents: [
-          stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
             [UNIT_PRICE, faker.string.alpha()],
           ]),
         ],

--- a/apps/methodologies/bold/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.ts
+++ b/apps/methodologies/bold/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.ts
@@ -38,7 +38,7 @@ import {
 } from './rewards-distribution.constants';
 import { calculateRewardsDistribution } from './rewards-distribution.helpers';
 
-const { END, OPEN, RULE_EXECUTION } = DocumentEventName;
+const { END, RULE_EXECUTION, RULES_METADATA } = DocumentEventName;
 const { RULE_PROCESSOR_RESULT_CONTENT, RULE_SLUG, UNIT_PRICE } =
   DocumentEventAttributeName;
 const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
@@ -173,7 +173,7 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     }
 
     const unitPrice = getEventAttributeValue(
-      credit.externalEvents?.find(eventNameIsAnyOf([OPEN])),
+      credit.externalEvents?.find(eventNameIsAnyOf([RULES_METADATA])),
       UNIT_PRICE,
     );
 

--- a/libs/methodologies/bold/types/src/enum.types.ts
+++ b/libs/methodologies/bold/types/src/enum.types.ts
@@ -74,6 +74,7 @@ export enum DocumentEventName {
   OUTPUT = 'OUTPUT',
   RELATED = 'RELATED',
   RULE_EXECUTION = 'RULE EXECUTION',
+  RULES_METADATA = 'RULES METADATA',
 }
 
 export enum DocumentEventAttributeName {


### PR DESCRIPTION
### Summary

Get the `unit-price` metadata from the `RULES_METADATA` event instead `OPEN` event.

### Related links

https://app.clickup.com/t/3005225/CARROT-1393

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event name, `RULES_METADATA`, for document processing.
- **Bug Fixes**
	- Updated event references in tests and processing logic to ensure correct handling of credit documents.
- **Documentation**
	- Enhanced clarity around event naming conventions in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->