### PR TITLE
Fix extractNumberFromString

### DIFF
--- a/libs/shared/helpers/src/string.helpers.spec.ts
+++ b/libs/shared/helpers/src/string.helpers.spec.ts
@@ -34,22 +34,24 @@ describe('string helpers', () => {
   });
 
   describe('extractNumberFromString', () => {
-    it('should return the number from the string without measurement unit', () => {
+    it('should return the number from the string as US format', () => {
       expect(extractNumberFromString('123')).toBe(123);
       expect(extractNumberFromString('123.456')).toBe(123.456);
-      expect(extractNumberFromString('123,456')).toBe(123_456);
+      expect(extractNumberFromString('123,456.00')).toBe(123_456);
+      expect(extractNumberFromString('123,456,678.0')).toBe(123_456_678);
     });
 
-    it('should return the number from the string with spaced measurement unit', () => {
-      expect(extractNumberFromString('123 kg')).toBe(123);
-      expect(extractNumberFromString('123.456 kg')).toBe(123.456);
-      expect(extractNumberFromString('123,456 kg')).toBe(123_456);
+    it('should return the number from the string as European format', () => {
+      expect(extractNumberFromString('123,456')).toBe(123.456);
+      expect(extractNumberFromString('123.456,00')).toBe(123_456);
+      expect(extractNumberFromString('123.456.678,0')).toBe(123_456_678);
     });
 
-    it('should return the number from the string with measurement unit without space', () => {
+    it('should correctly remove unrelated characters', () => {
       expect(extractNumberFromString('123kg')).toBe(123);
-      expect(extractNumberFromString('123.456kg')).toBe(123.456);
-      expect(extractNumberFromString('123,456kg')).toBe(123_456);
+      expect(extractNumberFromString('123.456 kg-1')).toBe(123.456);
+      expect(extractNumberFromString('123,456,789.12 kg')).toBe(123_456_789.12);
+      expect(extractNumberFromString('123.456.789,12 kg')).toBe(123_456_789.12);
     });
 
     it('should throw an error if the string is not a number', () => {

--- a/libs/shared/helpers/src/string.helpers.spec.ts
+++ b/libs/shared/helpers/src/string.helpers.spec.ts
@@ -40,10 +40,16 @@ describe('string helpers', () => {
       expect(extractNumberFromString('123,456')).toBe(123_456);
     });
 
-    it('should return the number from the string with measurement unit', () => {
+    it('should return the number from the string with spaced measurement unit', () => {
       expect(extractNumberFromString('123 kg')).toBe(123);
       expect(extractNumberFromString('123.456 kg')).toBe(123.456);
       expect(extractNumberFromString('123,456 kg')).toBe(123_456);
+    });
+
+    it('should return the number from the string with measurement unit without space', () => {
+      expect(extractNumberFromString('123kg')).toBe(123);
+      expect(extractNumberFromString('123.456kg')).toBe(123.456);
+      expect(extractNumberFromString('123,456kg')).toBe(123_456);
     });
 
     it('should throw an error if the string is not a number', () => {

--- a/libs/shared/helpers/src/string.helpers.ts
+++ b/libs/shared/helpers/src/string.helpers.ts
@@ -5,8 +5,17 @@ export const getNonEmptyString = (value: unknown): string | undefined =>
   isNonEmptyString(value) ? value : undefined;
 
 export const extractNumberFromString = (value: string): number => {
+  let sanitized = value.replaceAll(' ', '');
+
+  const isEuropeanFormat =
+    sanitized.includes(',') && sanitized.indexOf(',') > sanitized.indexOf('.');
+
+  sanitized = isEuropeanFormat
+    ? sanitized.replaceAll('.', '').replace(',', '.')
+    : sanitized.replaceAll(',', '');
+
   // eslint-disable-next-line security/detect-unsafe-regex
-  const match = value.replace(',', '').match(/-?\d+(?:\.\d+)?/);
+  const match = sanitized.match(/-?\d+(?:\.\d+)?(?:e[+-]?\d+)?/i);
   const number = match ? Number(match[0]) : Number.NaN;
 
   if (Number.isNaN(number)) {

--- a/libs/shared/helpers/src/string.helpers.ts
+++ b/libs/shared/helpers/src/string.helpers.ts
@@ -5,7 +5,9 @@ export const getNonEmptyString = (value: unknown): string | undefined =>
   isNonEmptyString(value) ? value : undefined;
 
 export const extractNumberFromString = (value: string): number => {
-  const number = Number(value.replace(',', '').split(' ')[0]);
+  // eslint-disable-next-line security/detect-unsafe-regex
+  const match = value.replace(',', '').match(/-?\d+(?:\.\d+)?/);
+  const number = match ? Number(match[0]) : Number.NaN;
 
   if (Number.isNaN(number)) {
     throw new TypeError(`Could not extract number from ${value}`);


### PR DESCRIPTION
### Summary

Fix `extractNumberFromString` implementation

### Details

Also handle when there aren't spaces in the string

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced number extraction functionality from strings, now supporting US and European formats, including cases like '123,456.00' and '123.456,00'.
- **Bug Fixes**
	- Improved test cases to verify correct behavior of the number extraction function with various string formats, including unrelated characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->