### PR TITLE
Remove european format from extractNumberFromString

### DIFF
--- a/libs/shared/helpers/src/string.helpers.spec.ts
+++ b/libs/shared/helpers/src/string.helpers.spec.ts
@@ -41,17 +41,10 @@ describe('string helpers', () => {
       expect(extractNumberFromString('123,456,678.0')).toBe(123_456_678);
     });
 
-    it('should return the number from the string as European format', () => {
-      expect(extractNumberFromString('123,456')).toBe(123.456);
-      expect(extractNumberFromString('123.456,00')).toBe(123_456);
-      expect(extractNumberFromString('123.456.678,0')).toBe(123_456_678);
-    });
-
     it('should correctly remove unrelated characters', () => {
       expect(extractNumberFromString('123kg')).toBe(123);
       expect(extractNumberFromString('123.456 kg-1')).toBe(123.456);
       expect(extractNumberFromString('123,456,789.12 kg')).toBe(123_456_789.12);
-      expect(extractNumberFromString('123.456.789,12 kg')).toBe(123_456_789.12);
     });
 
     it('should throw an error if the string is not a number', () => {

--- a/libs/shared/helpers/src/string.helpers.ts
+++ b/libs/shared/helpers/src/string.helpers.ts
@@ -5,14 +5,7 @@ export const getNonEmptyString = (value: unknown): string | undefined =>
   isNonEmptyString(value) ? value : undefined;
 
 export const extractNumberFromString = (value: string): number => {
-  let sanitized = value.replaceAll(' ', '');
-
-  const isEuropeanFormat =
-    sanitized.includes(',') && sanitized.indexOf(',') > sanitized.indexOf('.');
-
-  sanitized = isEuropeanFormat
-    ? sanitized.replaceAll('.', '').replace(',', '.')
-    : sanitized.replaceAll(',', '');
+  const sanitized = value.replaceAll(' ', '').replaceAll(',', '');
 
   // eslint-disable-next-line security/detect-unsafe-regex
   const match = sanitized.match(/-?\d+(?:\.\d+)?(?:e[+-]?\d+)?/i);


### PR DESCRIPTION
### Summary

Do not handle European format on `extractNumberFromString` helper.

### Details

Makes it simpler and avoid unhandled edge cases.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed tests for European number formats in the string extraction functionality to streamline testing.
  
- **Refactor**
	- Simplified the `extractNumberFromString` function by removing European number format handling, enhancing performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->