### PR TITLE
fix: rename metadata path for checksum [CARROT-1394]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Thumbs.db
 
 # Custom
 local/
+rules-metadata.json
+temp-rules-metadata.json

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -48,6 +48,8 @@ export const wrapRuleIntoLambdaHandler = (
 
     logger.info({ ruleInput }, 'Rule invoked');
 
+    logger.info('Force upload all rules');
+
     try {
       const ruleOutput = await rule.process(ruleInput);
 

--- a/nx.json
+++ b/nx.json
@@ -88,6 +88,7 @@
         "{workspaceRoot}/scripts/package-lambda.sh",
         "{workspaceRoot}/scripts/upload-lambda.sh"
       ],
+      "parallelism": false,
       "dependsOn": ["package-lambda"],
       "options": {
         "commands": [

--- a/scripts/upload-lambda.sh
+++ b/scripts/upload-lambda.sh
@@ -33,8 +33,8 @@ then
   echo "Uploaded $ZIP_PATH to $S3_URL"
 
   # concatenates metadata rules in rules metadata file
-  METADATA_FILE="tmp/rules-metadata.json"
-  METADATA_TEMP_FILE="tmp/temp-rules-metadata.json"
+  METADATA_FILE="rules-metadata.json"
+  METADATA_TEMP_FILE="temp-rules-metadata.json"
 
   if [ -s "$METADATA_FILE" ]; then
     jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"

--- a/scripts/upload-lambdas-and-metadata.sh
+++ b/scripts/upload-lambdas-and-metadata.sh
@@ -8,7 +8,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 ENVIRONMENT=$1
-FILE_PATH="tmp/rules-metadata.json"
+FILE_PATH="rules-metadata.json"
 
 FILE_CHECKSUM=$(md5sum "$FILE_PATH" | cut -f1 -d" ")
 FILE_NAME=$(basename "$FILE_PATH" .json)

--- a/scripts/upload-lambdas-and-metadata.sh
+++ b/scripts/upload-lambdas-and-metadata.sh
@@ -20,10 +20,9 @@ if [ -f "$FILE_PATH" ]; then
   rm -f "$FILE_PATH"
 fi
 
-mkdir -p "$(dirname "$FILE_PATH")"
 echo '{"rulesMetadata":[]}' > "$FILE_PATH"
 
-pnpm nx affected --target=upload-lambda --configuration=production --environment=$ENVIRONMENT
+pnpm nx affected --target=upload-lambda --configuration=production --environment=$ENVIRONMENT --parallel=10
 
 if aws s3 cp "$FILE_PATH" "s3://$S3_BUCKET/$S3_KEY"
 then


### PR DESCRIPTION
- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude `rules-metadata.json` and `temp-rules-metadata.json` from version control.
	- Adjusted file paths in scripts to directly reference metadata files instead of using a `tmp/` prefix, improving file accessibility during operations.
	- Modified the `upload-lambda` target in `nx.json` to disable parallel processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->