### PR TITLE
fix: fix checksum in upload metadata script [CARROT-1394]

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,21 +6,10 @@ on:
   workflow_call:
 
 jobs:
-  package-lambda:
-    name: Package Lambda
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0 # required for Nx affected
-      - uses: ./.github/actions/prepare-to-run-nx
-      - run: pnpm nx affected --target=package-lambda --configuration=production
-
   upload-lambda:
     name: Upload Lambda to S3
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: [package-lambda]
 
     env:
       AWS_REGION: us-east-1
@@ -29,10 +18,10 @@ jobs:
       matrix:
         include:
           - environment: production
-            AWS_ACCOUNT_ID: "629216831935"
+            AWS_ACCOUNT_ID: '629216831935'
 
           - environment: development
-            AWS_ACCOUNT_ID: "954701063678"
+            AWS_ACCOUNT_ID: '954701063678'
 
     steps:
       - uses: actions/checkout@v4.1.1

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -48,8 +48,6 @@ export const wrapRuleIntoLambdaHandler = (
 
     logger.info({ ruleInput }, 'Rule invoked');
 
-    logger.info('Force upload all rules');
-
     try {
       const ruleOutput = await rule.process(ruleInput);
 

--- a/scripts/upload-lambdas-and-metadata.sh
+++ b/scripts/upload-lambdas-and-metadata.sh
@@ -10,12 +10,6 @@ fi
 ENVIRONMENT=$1
 FILE_PATH="rules-metadata.json"
 
-FILE_CHECKSUM=$(md5sum "$FILE_PATH" | cut -f1 -d" ")
-FILE_NAME=$(basename "$FILE_PATH" .json)
-
-S3_BUCKET=elrond-$ENVIRONMENT-methodology-rules-metadata-lambda-artifacts
-S3_KEY=$FILE_NAME-$FILE_CHECKSUM.json
-
 if [ -f "$FILE_PATH" ]; then
   rm -f "$FILE_PATH"
 fi
@@ -23,6 +17,12 @@ fi
 echo '{"rulesMetadata":[]}' > "$FILE_PATH"
 
 pnpm nx affected --target=upload-lambda --configuration=production --environment=$ENVIRONMENT --parallel=10
+
+FILE_CHECKSUM=$(md5sum "$FILE_PATH" | cut -f1 -d" ")
+FILE_NAME=$(basename "$FILE_PATH" .json)
+
+S3_BUCKET=elrond-$ENVIRONMENT-methodology-rules-metadata-lambda-artifacts
+S3_KEY=$FILE_NAME-$FILE_CHECKSUM.json
 
 if aws s3 cp "$FILE_PATH" "s3://$S3_BUCKET/$S3_KEY"
 then


### PR DESCRIPTION
### Summary

_Fix checksum in upload metadata script._

### Related links

_https://app.clickup.com/t/3005225/CARROT-1567_

---

- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the deployment workflow by removing the `package-lambda` job and updating the `upload-lambda` job for independent execution.
	- Adjusted AWS account ID syntax for consistency.
	- Modified the upload script to ensure accurate checksum and file name calculations after file creation, enhancing reliability during S3 uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->