### PR TITLE
feat: allow approximation of 1 kg in net-weight-verification [CARROT-1593]

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.stubs.ts
+++ b/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.stubs.ts
@@ -20,41 +20,46 @@ const VEHICLE_WEIGHT = faker.number.float({
   max: VEHICLE_GROSS_WEIGHT,
   min: 300,
 });
-const LOAD_NET_WEIGHT = new BigNumber(VEHICLE_GROSS_WEIGHT).minus(
-  VEHICLE_WEIGHT,
-);
 
-export const APPROVED_WEIGHING_MOVE_EVENT_ATTRIBUTES = [
-  {
-    isPublic: true,
-    name: DocumentEventAttributeName.MOVE_TYPE,
-    value: DocumentEventMoveType.WEIGHING,
-  },
-  {
-    isPublic: true,
-    name: DocumentEventAttributeName.VEHICLE_GROSS_WEIGHT,
-    value: `${VEHICLE_GROSS_WEIGHT} KG`,
-  },
-  {
-    isPublic: true,
-    name: DocumentEventAttributeName.VEHICLE_WEIGHT,
-    value: `${VEHICLE_WEIGHT} KG`,
-  },
+export const stubApprovedWeighingMoveEventAttributes = (
+  weightDifference = 0,
+) => {
+  const loadNetWeight = new BigNumber(VEHICLE_GROSS_WEIGHT)
+    .minus(VEHICLE_WEIGHT)
+    .minus(weightDifference);
 
-  {
-    isPublic: true,
-    name: DocumentEventAttributeName.LOAD_NET_WEIGHT,
-    value: `${LOAD_NET_WEIGHT.toString()} KG`,
-  },
-];
+  return [
+    {
+      isPublic: true,
+      name: DocumentEventAttributeName.MOVE_TYPE,
+      value: DocumentEventMoveType.WEIGHING,
+    },
+    {
+      isPublic: true,
+      name: DocumentEventAttributeName.VEHICLE_GROSS_WEIGHT,
+      value: `${VEHICLE_GROSS_WEIGHT} KG`,
+    },
+    {
+      isPublic: true,
+      name: DocumentEventAttributeName.VEHICLE_WEIGHT,
+      value: `${VEHICLE_WEIGHT} KG`,
+    },
+    {
+      isPublic: true,
+      name: DocumentEventAttributeName.LOAD_NET_WEIGHT,
+      value: `${loadNetWeight.toString()} KG`,
+    },
+  ];
+};
 
 export const stubApprovedWeighingMoveEvent = (
   partialEvent?: PartialDeep<DocumentEvent>,
+  weightDifference?: number,
 ): DocumentEvent =>
   stubDocumentEvent({
     ...partialEvent,
     metadata: {
-      attributes: APPROVED_WEIGHING_MOVE_EVENT_ATTRIBUTES,
+      attributes: stubApprovedWeighingMoveEventAttributes(weightDifference),
     },
     name: DocumentEventName.MOVE,
   });

--- a/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.utils.ts
+++ b/apps/methodologies/bold/rule-processors/mass/net-weight-verification/src/lib/net-weight-verification.utils.ts
@@ -30,6 +30,8 @@ interface WeighingAttributesOutput {
 
 type ExtracteAttributes = Array<[WeighingAttributes, WeighingAttributesOutput]>;
 
+export const ALLOWABLE_WEIGHT_DIFFERENCE = 1;
+
 export const isValidWeighingAttributes =
   createIs<Record<WeighingAttributes, number>>();
 


### PR DESCRIPTION
### Summary

_Allow approximation of 1 kg in net-weight-verification._

### Related links

_https://app.clickup.com/t/3005225/CARROT-1593_

---

- [X] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a tolerance for net weight validation, allowing for approximate weight comparisons.
	- Added new test cases to enhance coverage for edge cases related to weight approximations.

- **Bug Fixes**
	- Updated output messages to clarify the new tolerance in weight validation.

- **Refactor**
	- Replaced static constants with dynamic functions for generating event attributes, improving adaptability to varying weight conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->