### PR TITLE
feat(rule): crete the necessary rules to create the credit

### DIFF
--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/.eslintrc.js
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/.eslintrc.js
@@ -1,0 +1,5 @@
+const { getBaseEslintConfig } = require('../../../../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Cdf Address
+# Nft Metadata Selection
 
 Methodology: **BOLD-CARBON-ORGANIC**
 
@@ -10,13 +10,13 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📄 Description
 
-In an event, when there is a report identified as CDF, verify if the declared addresses for the participant identified in the event and the actor identified as Recycler are the same.
+Collect and aggregate information that is added to the NFT metadata.
 
-## 📂 Implementation
+### 📂 Implementation
 
-- **[Main Implementation File](./src/lib/cdf-address.processor.ts)**
+- **[Main Implementation File](./src/lib/nft-metadata-selection.processor.ts)**
 
-## 👥 Contributors
+### 👥 Contributors
 
 [![AMarcosCastelo](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/43973049?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/AMarcosCastelo)
 [![andtankian](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/12521890?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/andtankian)

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/jest.config.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/jest.config.ts
@@ -1,0 +1,3 @@
+import { getJestBaseConfig } from '../../../../../../.jest/config/jest.base.config';
+
+export default getJestBaseConfig(__dirname);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/package.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@carrot-fndn/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection",
+  "version": "0.0.0"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/project.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "methodologies-bold-carbon-organic-rule-processors-credit-nft-metadata-selection",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["type:app", "app:any", "stack:any", "methodology:bold"],
+  "sourceRoot": "apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src",
+  "projectType": "application",
+  "targets": {
+    "lint": {},
+    "ts": {},
+    "build-lambda": {},
+    "package-lambda": {},
+    "upload-lambda": {},
+    "test": {}
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lambda.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lambda.ts
@@ -1,0 +1,8 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { NftMetadataSelection } from './lib';
+
+const instance = new NftMetadataSelection();
+
+// TODO: we can try to generate this code with a ts-patch program transformer
+export const handler = wrapRuleIntoLambdaHandler(instance);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/__snapshots__/nft-metadata-selection.helpers.spec.ts.snap
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/__snapshots__/nft-metadata-selection.helpers.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Helpers findMassCertificateIdFromDocumentLinks should throw an error if the mass certificate id is not found 1`] = `"Related document Mass Certificate not found"`;

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/index.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './nft-metadata-selection.processor';

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.constants.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.constants.ts
@@ -1,0 +1,30 @@
+import type { DocumentCriteria } from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+
+import {
+  CREDIT_CERTIFICATES,
+  MASS_AUDIT,
+  MASS_CERTIFICATE_AUDIT,
+  METHODOLOGY_DEFINITION,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+
+export const NFT_METADATA_SELECTION_CRITERIA: DocumentCriteria = {
+  relatedDocuments: [
+    METHODOLOGY_DEFINITION.match,
+    {
+      ...CREDIT_CERTIFICATES,
+      relatedDocuments: [
+        {
+          ...MASS_CERTIFICATE_AUDIT.match,
+          parentDocument: {
+            relatedDocuments: [
+              {
+                ...MASS_AUDIT.match,
+                parentDocument: {},
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.dto.ts
@@ -1,0 +1,54 @@
+import type { CertificateReward } from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import type {
+  NonEmptyArray,
+  NonEmptyString,
+  Uri,
+  Url,
+} from '@carrot-fndn/shared/types';
+import type { tags } from 'typia';
+
+export interface MassMetadata {
+  documentId: NonEmptyString;
+  measurementUnit: NonEmptyString;
+  originCity: NonEmptyString;
+  originCountry: NonEmptyString;
+  originCountryState: NonEmptyString;
+  recyclerName: NonEmptyString;
+  subtype: NonEmptyString;
+  type: NonEmptyString;
+  value: number & tags.ExclusiveMinimum<0> & tags.Type<'float'>;
+}
+
+export interface MassCertificateMetadata {
+  documentId: NonEmptyString;
+  masses: NonEmptyArray<MassMetadata>;
+}
+
+export interface MethodologyMetadata {
+  description: NonEmptyString;
+  documentId: NonEmptyString;
+  name: NonEmptyString;
+}
+
+export interface RewardsDistributionParticipant {
+  id: CertificateReward['participant']['id'];
+  share: CertificateReward['percentage'];
+  type: CertificateReward['actorType'];
+}
+
+export interface RewardsDistributionMetadata {
+  externalUrl: Url;
+  participants: NonEmptyArray<RewardsDistributionParticipant>;
+  policyVersion: NonEmptyString;
+}
+
+export interface MethodologyCreditNftMetadataDto {
+  collectionName: NonEmptyString;
+  creditDocumentId: NonEmptyString;
+  image?: Uri | undefined;
+  massCertificates: NonEmptyArray<MassCertificateMetadata>;
+  methodology: MethodologyMetadata;
+  nftDescription: NonEmptyString;
+  rewardsDistribution: RewardsDistributionMetadata;
+  storeContractAddress: NonEmptyString;
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.spec.ts
@@ -1,0 +1,610 @@
+import type {
+  MethodologyDocumentEventAttributeValue,
+  NonEmptyArray,
+  UnknownObject,
+} from '@carrot-fndn/shared/types';
+import type { RequiredDeep } from 'type-fest';
+
+import {
+  stubDocument,
+  stubDocumentEvent,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type Document,
+  DocumentCategory,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventRuleSlug,
+  DocumentType,
+  type RewardDistributionResultContent,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { DocumentEventName } from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { stubArray, stubRuleInput } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import { assert, random, validate } from 'typia';
+
+import type {
+  MassCertificateMetadata,
+  MassMetadata,
+  MethodologyCreditNftMetadataDto,
+} from './nft-metadata-selection.dto';
+import type { DocumentLinks } from './nft-metadata-selection.processor';
+
+import {
+  findMassAuditId,
+  findMassCertificateIdFromDocumentLinks,
+  formatCeritificatesMassValue,
+  formatWeight,
+  getCarrotExplorePageUrl,
+  getMassCertificatesMassIdsCount,
+  getMassCertificatesMassValue,
+  getMassValue,
+  getRulesMetadataEventValues,
+  mapMassMetadata,
+  mapMethodologyMetadata,
+  mapNftMetadata,
+  mapNftMetadataDto,
+  mapRewardDistributionMetadata,
+} from './nft-metadata-selection.helpers';
+import { stubMassDocument } from './nft-metadata-selection.stubs';
+
+const {
+  ACTOR_TYPE,
+  COLLECTION_NAME,
+  METHODOLOGY_DESCRIPTION,
+  METHODOLOGY_NAME,
+  NFT_DESCRIPTION,
+  NFT_IMAGE,
+  RULE_PROCESSOR_CODE_VERSION,
+  RULE_PROCESSOR_RESULT_CONTENT,
+  RULE_PROCESSOR_SOURCE_CODE_URL,
+  RULE_SLUG,
+  STORE_CONTRACT_ADDRESS,
+} = DocumentEventAttributeName;
+const { RECYCLER } = DocumentEventActorType;
+const { ACTOR, OPEN, RULE_EXECUTION, RULES_METADATA } = DocumentEventName;
+
+describe('Helpers', () => {
+  describe('getCarrotExplorePageUrl', () => {
+    it('should return the correct url', () => {
+      const documentId = faker.string.uuid();
+      const expected = `https://explore.carrot.eco/document/${documentId}`;
+
+      expect(getCarrotExplorePageUrl(documentId)).toBe(expected);
+    });
+  });
+
+  describe('getRulesMetadataEventValues', () => {
+    it('should throw error when document is undefined', () => {
+      expect(() => getRulesMetadataEventValues(undefined)).toThrow(
+        'Rules metadata event not found',
+      );
+    });
+
+    it('should throw error when rules metadata event is not found', () => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: OPEN }, []),
+        ],
+      });
+
+      expect(() => getRulesMetadataEventValues(documentStub)).toThrow(
+        'Rules metadata event not found',
+      );
+    });
+
+    it('should throw error when required metadata collectionName attribute is missing', () => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, []),
+        ],
+      });
+
+      expect(() => getRulesMetadataEventValues(documentStub)).toThrow(
+        `Required metadata ${COLLECTION_NAME} attribute is missing`,
+      );
+    });
+
+    it.each([
+      {
+        attributes: [
+          [COLLECTION_NAME, faker.lorem.word()],
+          [NFT_DESCRIPTION, faker.lorem.sentence()],
+          [STORE_CONTRACT_ADDRESS, faker.finance.ethereumAddress()],
+        ],
+        description:
+          'should return image as undefined when NFT_IMAGE attribute is missing',
+      },
+      {
+        attributes: [
+          [NFT_IMAGE, faker.string.sample()],
+          [COLLECTION_NAME, faker.lorem.word()],
+          [NFT_DESCRIPTION, faker.lorem.sentence()],
+          [STORE_CONTRACT_ADDRESS, faker.finance.ethereumAddress()],
+        ],
+        description:
+          'should return image as undefined when NFT_IMAGE value is not a valid Uri',
+      },
+    ])('%description', ({ attributes }) => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes(
+            { name: RULES_METADATA },
+            attributes as [
+              DocumentEventAttributeName,
+              MethodologyDocumentEventAttributeValue,
+            ][],
+          ),
+        ],
+      });
+
+      const result = getRulesMetadataEventValues(documentStub);
+
+      expect(result).toEqual({
+        collectionName: expect.any(String),
+        image: undefined,
+        nftDescription: expect.any(String),
+        storeContractAddress: expect.any(String),
+      });
+    });
+
+    it('should return all metadata values when all attributes are valid', () => {
+      const image = faker.internet.url();
+      const collectionName = faker.lorem.word();
+      const nftDescription = faker.lorem.sentence();
+      const storeContractAddress = faker.finance.ethereumAddress();
+
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+            [NFT_IMAGE, image],
+            [COLLECTION_NAME, collectionName],
+            [NFT_DESCRIPTION, nftDescription],
+            [STORE_CONTRACT_ADDRESS, storeContractAddress],
+          ]),
+        ],
+      });
+
+      const result = getRulesMetadataEventValues(documentStub);
+
+      expect(result).toEqual({
+        collectionName,
+        image,
+        nftDescription,
+        storeContractAddress,
+      });
+    });
+
+    it('should throw error when collection name is missing', () => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+            [NFT_DESCRIPTION, faker.lorem.sentence()],
+            [STORE_CONTRACT_ADDRESS, faker.finance.ethereumAddress()],
+          ]),
+        ],
+      });
+
+      expect(() => getRulesMetadataEventValues(documentStub)).toThrow(
+        `Required metadata ${COLLECTION_NAME} attribute is missing`,
+      );
+    });
+
+    it('should throw error when NFT description is missing', () => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+            [COLLECTION_NAME, faker.lorem.word()],
+            [STORE_CONTRACT_ADDRESS, faker.finance.ethereumAddress()],
+          ]),
+        ],
+      });
+
+      expect(() => getRulesMetadataEventValues(documentStub)).toThrow(
+        `Required metadata ${NFT_DESCRIPTION} attribute is missing`,
+      );
+    });
+
+    it('should throw error when store smart contract address is missing', () => {
+      const documentStub = stubDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+            [COLLECTION_NAME, faker.lorem.word()],
+            [NFT_DESCRIPTION, faker.lorem.sentence()],
+          ]),
+        ],
+      });
+
+      expect(() => getRulesMetadataEventValues(documentStub)).toThrow(
+        `Required metadata ${STORE_CONTRACT_ADDRESS} attribute is missing`,
+      );
+    });
+  });
+
+  describe('mapMassMetadata', () => {
+    it('should map the mass metadata correctly', () => {
+      const documentStub = {
+        ...random<RequiredDeep<Document>>(),
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: ACTOR }, [
+            [ACTOR_TYPE, RECYCLER],
+          ]),
+        ],
+      };
+
+      const result = mapMassMetadata(documentStub);
+
+      const validation = validate<MassMetadata>(result);
+
+      expect(validation.errors).toEqual([]);
+    });
+  });
+
+  describe('getMassValue', () => {
+    it.each([...stubArray(faker.number.int), ...stubArray(faker.number.float)])(
+      'should return the correct value %p',
+      (value) => {
+        const massStub = {
+          ...random<MassMetadata>(),
+          value,
+        };
+
+        const result = getMassValue(massStub);
+
+        expect(result).toBe(value);
+      },
+    );
+  });
+
+  describe('formatWeight', () => {
+    it.each([...stubArray(faker.number.int), ...stubArray(faker.number.float)])(
+      'should return the correct formatted weight %p',
+      (weight) => {
+        const result = formatWeight(weight);
+
+        expect(result).toBe(
+          `${Intl.NumberFormat('en-US', {
+            maximumFractionDigits: 2,
+          }).format(weight)}kg`,
+        );
+      },
+    );
+  });
+
+  describe('getMassCertificatesMassValue', () => {
+    it('should return the correct total weight', () => {
+      const massCertificatesStub: NonEmptyArray<MassCertificateMetadata> = [
+        {
+          documentId: faker.string.uuid(),
+          masses: [
+            {
+              ...random<MassMetadata>(),
+              value: 1,
+            },
+            {
+              ...random<MassMetadata>(),
+              value: 2,
+            },
+          ],
+        },
+        {
+          documentId: faker.string.uuid(),
+          masses: [
+            {
+              ...random<MassMetadata>(),
+              value: 3,
+            },
+            {
+              ...random<MassMetadata>(),
+              value: 4,
+            },
+          ],
+        },
+      ];
+
+      const result = getMassCertificatesMassValue(massCertificatesStub);
+
+      expect(result).toBe(10);
+    });
+  });
+
+  describe('getMassCertificatesMassIdsCount', () => {
+    it('should return the correct total mass ids count', () => {
+      const massCertificatesStub: NonEmptyArray<MassCertificateMetadata> = [
+        {
+          documentId: faker.string.uuid(),
+          masses: random<
+            NonEmptyArray<MassMetadata>
+          >() as NonEmptyArray<MassMetadata>,
+        },
+        {
+          documentId: faker.string.uuid(),
+          masses: [random<MassMetadata>(), random<MassMetadata>()],
+        },
+      ];
+
+      const result = getMassCertificatesMassIdsCount(massCertificatesStub);
+
+      expect(result).toBe(massCertificatesStub[0].masses.length + 2);
+    });
+  });
+
+  describe('mapMethodologyMetadata', () => {
+    it('should map the methodology metadata correctly', () => {
+      const documentStub = {
+        ...random<RequiredDeep<Document>>(),
+        externalEvents: [
+          ...stubArray(stubDocumentEvent),
+          stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
+            [METHODOLOGY_DESCRIPTION, faker.lorem.sentence()],
+            [METHODOLOGY_NAME, faker.lorem.sentence()],
+          ]),
+        ],
+      };
+
+      const result = mapMethodologyMetadata(documentStub);
+
+      const validation = validate(result);
+
+      expect(validation.errors).toEqual([]);
+    });
+  });
+
+  describe('mapRewardDistributionMetadata', () => {
+    it('should map the reward distribution metadata correctly', () => {
+      const documentStub = {
+        ...random<RequiredDeep<Document>>(),
+        externalEvents: [
+          ...stubArray(stubDocumentEvent),
+          stubDocumentEventWithMetadataAttributes({ name: RULE_EXECUTION }, [
+            [RULE_SLUG, DocumentEventRuleSlug.REWARDS_DISTRIBUTION],
+            [RULE_PROCESSOR_CODE_VERSION, faker.git.commitSha()],
+            [RULE_PROCESSOR_SOURCE_CODE_URL, faker.internet.url()],
+            [
+              RULE_PROCESSOR_RESULT_CONTENT,
+              random<RewardDistributionResultContent>() as unknown as UnknownObject,
+            ],
+          ]),
+        ],
+      };
+
+      const result = mapRewardDistributionMetadata(documentStub);
+
+      const validation = validate(result);
+
+      expect(validation.errors).toEqual([]);
+    });
+  });
+
+  describe('mapNftMetadata', () => {
+    it('should map the nft metadata correctly', () => {
+      const methodologyCreditNftMetadataDtoStub =
+        random<MethodologyCreditNftMetadataDto>();
+
+      // @ts-expect-error: We are stubbing forced values
+      const result = mapNftMetadata(methodologyCreditNftMetadataDtoStub);
+
+      const validation = validate(result);
+
+      expect(validation.errors).toEqual([]);
+    });
+  });
+
+  describe('findMassCertificateIdFromDocumentLinks', () => {
+    it('should return the correct mass certificate id', () => {
+      const massAuditId = faker.string.uuid();
+      const massCertificateId = faker.string.uuid();
+      const documentsLinks = new Map([
+        ...random<Map<string, DocumentLinks>>(),
+        [
+          massAuditId,
+          {
+            parentDocumentId: faker.string.uuid(),
+            relatedDocuments: [
+              {
+                category: DocumentCategory.METHODOLOGY,
+                documentId: massCertificateId,
+                type: DocumentType.MASS_CERTIFICATE,
+              },
+            ],
+          },
+        ],
+      ]);
+
+      const result = findMassCertificateIdFromDocumentLinks(
+        massAuditId,
+        documentsLinks,
+      );
+
+      expect(result).toBe(massCertificateId);
+    });
+
+    it('should throw an error if the mass certificate id is not found', () => {
+      const massAuditId = faker.string.uuid();
+      const documentsLinks = random<Map<string, DocumentLinks>>();
+
+      expect(() =>
+        findMassCertificateIdFromDocumentLinks(massAuditId, documentsLinks),
+      ).toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('findMassAuditId', () => {
+    it('should return the correct mass audit id', () => {
+      const massAuditId = faker.string.uuid();
+      const documentStub = stubMassDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({
+            relatedDocument: {
+              category: DocumentCategory.METHODOLOGY,
+              documentId: massAuditId,
+              type: DocumentType.MASS_AUDIT,
+            },
+          }),
+        ],
+      });
+
+      const result = findMassAuditId(documentStub, new Map());
+
+      expect(result).toBe(massAuditId);
+    });
+
+    it('should throw an error if the mass audit id is not found', () => {
+      const documentStub = stubMassDocument();
+
+      expect(() => findMassAuditId(documentStub, new Map())).toThrow(
+        `Mass audit relations not found for mass document ${documentStub.id}`,
+      );
+    });
+
+    it('should throw an error if external events is undefined', () => {
+      const documentStub = stubMassDocument();
+
+      documentStub.externalEvents = undefined;
+
+      expect(() => findMassAuditId(documentStub, new Map())).toThrow(
+        `Mass audit relations not found for mass document ${documentStub.id}`,
+      );
+    });
+
+    it('should throw an error if there are multiple mass audits for the same mass without a link to the loaded documents', () => {
+      const documentStub = stubMassDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({
+            relatedDocument: {
+              category: DocumentCategory.METHODOLOGY,
+              type: DocumentType.MASS_AUDIT,
+            },
+          }),
+          stubDocumentEventWithMetadataAttributes({
+            relatedDocument: {
+              category: DocumentCategory.METHODOLOGY,
+              type: DocumentType.MASS_AUDIT,
+            },
+          }),
+        ],
+      });
+
+      expect(() => findMassAuditId(documentStub, new Map())).toThrow(
+        `Mass document ${documentStub.id} does not have an available mass audit document this credit`,
+      );
+    });
+
+    it('should throw an error if there are multiple mass audits linked to the loaded documents', () => {
+      const massAuditIds = stubArray(faker.string.uuid, 5);
+      const documentStub = stubMassDocument({
+        externalEvents: massAuditIds.map((massAuditId) =>
+          stubDocumentEventWithMetadataAttributes({
+            relatedDocument: {
+              category: DocumentCategory.METHODOLOGY,
+              documentId: massAuditId,
+              type: DocumentType.MASS_AUDIT,
+            },
+          }),
+        ),
+      });
+
+      const documentsLinks = new Map([
+        ...random<Map<string, DocumentLinks>>(),
+        ...new Map(
+          massAuditIds.map((massAuditId) => [
+            massAuditId,
+            {
+              parentDocumentId: faker.string.uuid(),
+              relatedDocuments: [],
+            },
+          ]),
+        ),
+      ]);
+
+      expect(() => findMassAuditId(documentStub, documentsLinks)).toThrow(
+        `Mass document ${documentStub.id} has more than one available mass audit document this credit`,
+      );
+    });
+
+    it('should return massAuditId if there are multiple mass audits but only one linked to the loaded documents', () => {
+      const massAuditIds = stubArray(faker.string.uuid, 5);
+      const documentStub = stubMassDocument({
+        externalEvents: massAuditIds.map((massAuditId) =>
+          stubDocumentEventWithMetadataAttributes({
+            relatedDocument: {
+              category: DocumentCategory.METHODOLOGY,
+              documentId: massAuditId,
+              type: DocumentType.MASS_AUDIT,
+            },
+          }),
+        ),
+      });
+
+      const massAuditId = assert<string>(massAuditIds[0]);
+
+      const documentsLinks = new Map([
+        ...random<Map<string, DocumentLinks>>(),
+        [
+          massAuditId,
+          {
+            parentDocumentId: faker.string.uuid(),
+            relatedDocuments: [],
+          },
+        ],
+      ]);
+
+      const result = findMassAuditId(documentStub, documentsLinks);
+
+      expect(result).toBe(massAuditId);
+    });
+  });
+
+  describe('mapNftMetadataDto', () => {
+    it('should map the nft metadata dto correctly', () => {
+      const ruleInputDto = stubRuleInput();
+      const dtoStub = random<MethodologyCreditNftMetadataDto>();
+
+      // @ts-expect-error: We are stubbing forced values
+      const result = mapNftMetadataDto(dtoStub, ruleInputDto);
+
+      const validation = validate<MethodologyCreditNftMetadataDto>(result);
+
+      expect(validation.errors).toEqual([]);
+    });
+
+    it('should throw an error if the the return value is incorrect', () => {
+      const dtoStub = random<MethodologyCreditNftMetadataDto>();
+
+      expect(() =>
+        // @ts-expect-error: force invalid return value
+        mapNftMetadataDto(dtoStub, ''),
+      ).toThrow('assert');
+    });
+  });
+
+  describe('formatCeritificatesMassValue', () => {
+    it('should return the formatted total mass value', () => {
+      const massCertificatesStub: MassCertificateMetadata[] = [
+        {
+          documentId: faker.string.uuid(),
+          masses: [
+            {
+              ...random<MassMetadata>(),
+              value: 1234.56,
+            },
+          ],
+        },
+        {
+          documentId: faker.string.uuid(),
+          masses: [
+            {
+              ...random<MassMetadata>(),
+              value: 7890.12,
+            },
+          ],
+        },
+      ];
+
+      const result = formatCeritificatesMassValue(massCertificatesStub);
+
+      expect(result).toBe('9,124.68');
+    });
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.helpers.ts
@@ -1,0 +1,404 @@
+import type { RuleInput } from '@carrot-fndn/shared/rule/types';
+import type {
+  NonEmptyArray,
+  NonEmptyString,
+  Uri,
+} from '@carrot-fndn/shared/types';
+
+import {
+  getEventAttributeValue,
+  getEventAttributeValueOrThrow,
+  getRulesMetadataEvent,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/getters';
+import {
+  MASS_AUDIT,
+  MASS_CERTIFICATE,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+import {
+  and,
+  eventHasName,
+  eventNameIsAnyOf,
+  metadataAttributeValueIsAnyOf,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/predicates';
+import {
+  type Document,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentEventRuleSlug,
+  type DocumentReference,
+  type RewardDistributionResultContent,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { validateNonEmptyString } from '@carrot-fndn/methodologies/bold/recycling/organic/utils';
+import { isNil, isNonEmptyArray } from '@carrot-fndn/shared/helpers';
+import { assert, is } from 'typia';
+
+import type {
+  MassCertificateMetadata,
+  MassMetadata,
+  MethodologyCreditNftMetadataDto,
+  MethodologyMetadata,
+  RewardsDistributionMetadata,
+  RewardsDistributionParticipant,
+} from './nft-metadata-selection.dto';
+import type { DocumentLinks } from './nft-metadata-selection.processor';
+import type {
+  NftMetadata,
+  NftMetadataMassCertificate,
+} from './nft-metadata-selection.types';
+
+const { RECYCLER } = DocumentEventActorType;
+const { ACTOR, OPEN, RULE_EXECUTION } = DocumentEventName;
+const {
+  ACTOR_TYPE,
+  COLLECTION_NAME,
+  NFT_DESCRIPTION,
+  NFT_IMAGE,
+  STORE_CONTRACT_ADDRESS,
+} = DocumentEventAttributeName;
+const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
+
+const logger = console;
+
+export const getCarrotExplorePageUrl = (documentId: string) =>
+  `https://explore.carrot.eco/document/${documentId}`;
+
+export const getRulesMetadataEventValues = (
+  document: Document | undefined,
+): {
+  collectionName: NonEmptyString;
+  image: Uri | undefined;
+  nftDescription: NonEmptyString;
+  storeContractAddress: NonEmptyString;
+} => {
+  const rulesMetadataEvent = getRulesMetadataEvent(document);
+
+  if (!rulesMetadataEvent) {
+    throw new Error('Rules metadata event not found');
+  }
+
+  const uri = getEventAttributeValue(rulesMetadataEvent, NFT_IMAGE);
+  const collectionName = getEventAttributeValueOrThrow(
+    rulesMetadataEvent,
+    COLLECTION_NAME,
+    validateNonEmptyString,
+  );
+  const nftDescription = getEventAttributeValueOrThrow(
+    rulesMetadataEvent,
+    NFT_DESCRIPTION,
+    validateNonEmptyString,
+  );
+  const storeContractAddress = getEventAttributeValueOrThrow(
+    rulesMetadataEvent,
+    STORE_CONTRACT_ADDRESS,
+    validateNonEmptyString,
+  );
+
+  return {
+    collectionName,
+    image: is<Uri>(uri) ? uri : undefined,
+    nftDescription,
+    storeContractAddress,
+  };
+};
+
+export const mapMassMetadata = (document: Document): MassMetadata => ({
+  documentId: document.id,
+  measurementUnit: document.measurementUnit,
+  originCity: document.primaryAddress.city,
+  originCountry: document.primaryAddress.countryCode,
+  originCountryState: document.primaryAddress.countryState,
+  recyclerName: document.externalEvents?.find(
+    and(
+      eventNameIsAnyOf([ACTOR]),
+      metadataAttributeValueIsAnyOf(ACTOR_TYPE, [RECYCLER]),
+    ),
+  )?.participant.name as string,
+  subtype: document.subtype as string,
+  type: document.type as string,
+  value: document.currentValue,
+});
+
+export const getMassValue = (mass: MassMetadata): number => mass.value;
+
+export const formatWeight = (weight: number, fractionDigits = 2): string =>
+  `${Intl.NumberFormat('en-US', {
+    maximumFractionDigits: fractionDigits,
+  }).format(weight)}kg`;
+
+export const findMassAuditId = (
+  massDocument: Document,
+  documentsLinks: Map<string, DocumentLinks>,
+): string => {
+  const massAuditIds = (massDocument.externalEvents ?? [])
+    .filter(
+      (event) =>
+        event.relatedDocument && MASS_AUDIT.matches(event.relatedDocument),
+    )
+    .map((event) => event.relatedDocument as DocumentReference)
+    .map((relatedDocument) => relatedDocument.documentId);
+
+  if (!isNonEmptyArray<string>(massAuditIds)) {
+    throw new Error(
+      `Mass audit relations not found for mass document ${massDocument.id}`,
+    );
+  }
+
+  if (massAuditIds.length > 1) {
+    logger.warn(
+      `Multiple mass audit documents found for mass document ${massDocument.id}`,
+    );
+    const availableMassAuditIds = massAuditIds.filter((id) =>
+      documentsLinks.has(id),
+    );
+
+    if (!isNonEmptyArray<string>(availableMassAuditIds)) {
+      throw new Error(
+        `Mass document ${massDocument.id} does not have an available mass audit document this credit`,
+      );
+    }
+
+    if (availableMassAuditIds.length > 1) {
+      throw new Error(
+        `Mass document ${massDocument.id} has more than one available mass audit document this credit: ${availableMassAuditIds.join(', ')}`,
+      );
+    }
+
+    const massAuditId = availableMassAuditIds[0];
+
+    logger.warn(
+      `Using available mass audit document ${massAuditId} for mass document ${massDocument.id}`,
+    );
+
+    return massAuditId;
+  }
+
+  return massAuditIds[0];
+};
+
+export const findMassCertificateIdFromDocumentLinks = (
+  massAuditId: string,
+  documentsLinks: Map<string, DocumentLinks>,
+): string => {
+  const massAuditLink = documentsLinks.get(massAuditId);
+
+  const documentId = massAuditLink?.relatedDocuments?.find((related) =>
+    MASS_CERTIFICATE.matches(related),
+  )?.documentId;
+
+  if (isNil(documentId)) {
+    throw new Error('Related document Mass Certificate not found');
+  }
+
+  return documentId;
+};
+
+export const getMassCertificatesMassValue = (
+  massCertificates: MassCertificateMetadata[],
+): number =>
+  massCertificates.reduce(
+    (massCertificatesAccumulator, massCertificate) =>
+      massCertificatesAccumulator +
+      massCertificate.masses.reduce(
+        (massesAccumulator, mass) => massesAccumulator + getMassValue(mass),
+        0,
+      ),
+    0,
+  );
+
+export const formatCeritificatesMassValue = (
+  massCertificates: MassCertificateMetadata[],
+): string =>
+  Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  }).format(getMassCertificatesMassValue(massCertificates));
+
+export const getMassCertificatesMassIdsCount = (
+  massCertificates: MassCertificateMetadata[],
+): number =>
+  massCertificates.reduce(
+    (accumulator, massCertificate) =>
+      accumulator + massCertificate.masses.length,
+    0,
+  );
+
+export const mapMethodologyMetadata = (
+  document: Document,
+): MethodologyMetadata => {
+  const openEvent = document.externalEvents?.find((event) =>
+    eventHasName(event, OPEN),
+  );
+
+  const { METHODOLOGY_DESCRIPTION, METHODOLOGY_NAME } =
+    DocumentEventAttributeName;
+
+  return {
+    description: getEventAttributeValue(
+      openEvent,
+      METHODOLOGY_DESCRIPTION,
+    ) as string,
+    documentId: document.id,
+    name: getEventAttributeValue(openEvent, METHODOLOGY_NAME) as string,
+  };
+};
+
+export const mapRewardDistributionMetadata = (
+  document: Document,
+): RewardsDistributionMetadata => {
+  const {
+    RULE_PROCESSOR_CODE_VERSION,
+    RULE_PROCESSOR_RESULT_CONTENT,
+    RULE_PROCESSOR_SOURCE_CODE_URL,
+    RULE_SLUG,
+  } = DocumentEventAttributeName;
+  const ruleExecutionEvent = document.externalEvents?.find(
+    and(
+      eventNameIsAnyOf([RULE_EXECUTION]),
+      metadataAttributeValueIsAnyOf(RULE_SLUG, [REWARDS_DISTRIBUTION]),
+    ),
+  );
+
+  const policyVersion = getEventAttributeValue(
+    ruleExecutionEvent,
+    RULE_PROCESSOR_CODE_VERSION,
+  ) as string;
+  const externalUrl = getEventAttributeValue(
+    ruleExecutionEvent,
+    RULE_PROCESSOR_SOURCE_CODE_URL,
+  ) as string;
+  const ruleResultContent = getEventAttributeValue(
+    ruleExecutionEvent,
+    RULE_PROCESSOR_RESULT_CONTENT,
+  ) as unknown as RewardDistributionResultContent;
+
+  return {
+    externalUrl,
+    participants: ruleResultContent.certificateRewards.map(
+      (massCertificate) => ({
+        id: massCertificate.participant.id,
+        share: massCertificate.percentage,
+        type: massCertificate.actorType,
+      }),
+    ) as NonEmptyArray<RewardsDistributionParticipant>,
+    policyVersion,
+  };
+};
+
+export const mapNftMetadataDto = (
+  ruleSubject: Omit<MethodologyCreditNftMetadataDto, 'creditDocumentId'>,
+  ruleInput: RuleInput,
+): MethodologyCreditNftMetadataDto =>
+  assert<MethodologyCreditNftMetadataDto>({
+    ...ruleSubject,
+    creditDocumentId: ruleInput.documentId,
+  });
+
+export const mapNftMetadata = ({
+  collectionName,
+  creditDocumentId,
+  image,
+  massCertificates,
+  methodology,
+  nftDescription,
+  rewardsDistribution,
+  storeContractAddress,
+}: MethodologyCreditNftMetadataDto): NftMetadata => {
+  const {
+    originCity,
+    originCountry,
+    originCountryState,
+    recyclerName,
+    subtype,
+    type,
+  } = massCertificates[0].masses[0];
+
+  return {
+    attributes: [
+      {
+        trait_type: 'Mass Type',
+        value: type,
+      },
+      {
+        trait_type: 'Mass Origin (Country)',
+        value: originCountry,
+      },
+      {
+        trait_type: 'Mass Origin (State)',
+        value: originCountryState,
+      },
+      {
+        trait_type: 'Mass Origin (City)',
+        value: originCity,
+      },
+      {
+        trait_type: 'Recycler',
+        value: recyclerName,
+      },
+      {
+        trait_type: 'Credit Type',
+        value: 'Recycling Credit',
+      },
+      {
+        trait_type: 'Collection Name',
+        value: collectionName,
+      },
+      {
+        trait_type: 'Amount in Kg',
+        value: formatCeritificatesMassValue(massCertificates),
+      },
+    ],
+    description: nftDescription,
+    details: {
+      massCertificates: {
+        count: massCertificates.length,
+        description:
+          'The BOLD mass certificate is a grouping of MassIDs audited according to the BOLD Methodology. MassIDs represent publicly verifiable ownership, and therefore responsibility, over a unit of waste mass with an immutable record of recycling operations (work orders carried out) registered on it.',
+        documents: massCertificates.map((massCertificate) => ({
+          external_id: massCertificate.documentId,
+          external_url: getCarrotExplorePageUrl(massCertificate.documentId),
+          mass_id_count: massCertificate.masses.length,
+          mass_ids: massCertificate.masses.map((mass) => ({
+            external_id: mass.documentId,
+            external_url: getCarrotExplorePageUrl(mass.documentId),
+            recycler: mass.recyclerName,
+            weight: formatWeight(getMassValue(mass)),
+          })),
+        })) as NonEmptyArray<NftMetadataMassCertificate>,
+      },
+      methodology: {
+        description: methodology.description,
+        external_url: getCarrotExplorePageUrl(methodology.documentId),
+        name: methodology.name,
+        pdf: 'ipfs://bafybeigmved7xq4loti7j6k2k63xp76aofminwdyqgpf7dkw5fqa6vi4tm',
+      },
+      rewards_distribution: {
+        description:
+          'This document identifies Carrot’s policy for distributing rewards among waste supply chain participants, determined by category, from Recycling Credits (TRC) and Carbon Credit (TCC) sales. Based on rules defined for the methodology, each participant earns a percentual share of a mass that they acted as a participant.',
+        external_url: rewardsDistribution.externalUrl,
+        participants: rewardsDistribution.participants,
+        policy_version: rewardsDistribution.policyVersion,
+      },
+      summary: {
+        mass_certificate_count: massCertificates.length,
+        mass_id_count: getMassCertificatesMassIdsCount(massCertificates),
+        mass_origin_city: originCity,
+        mass_origin_country: originCountry,
+        mass_origin_state: originCountryState,
+        mass_subtype: subtype,
+        mass_total_weight: formatWeight(
+          getMassCertificatesMassValue(massCertificates),
+        ),
+        mass_type: type,
+        recycler_name: recyclerName,
+      },
+    },
+    external_id: creditDocumentId,
+    external_url: getCarrotExplorePageUrl(creditDocumentId),
+    image:
+      image ??
+      'ipfs://bafybeiaxb5dwhmai4waltapfxrtf7rzmhulgigy4t27vynvzqtrowktyzi/image.png',
+    name: 'BOLD',
+    store_contract_address: storeContractAddress,
+  };
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.e2e.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.e2e.spec.ts
@@ -1,0 +1,295 @@
+import type { UnknownObject } from '@carrot-fndn/shared/types';
+
+import {
+  stubDocumentEvent,
+  stubDocumentEventAttribute,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type Document,
+  DocumentCategory,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentEventRuleSlug,
+  type DocumentReference,
+  DocumentSubtype,
+  DocumentType,
+  type RewardDistributionResultContent,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { toDocumentKey } from '@carrot-fndn/shared/helpers';
+import {
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubArray,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import { random, validate } from 'typia';
+
+import type { NftMetadata } from './nft-metadata-selection.types';
+
+import { handler } from '../lambda';
+import {
+  stubCreditCertificatesDocument,
+  stubCreditDocument,
+  stubDocumentOutputEvent,
+  stubDocumentRelatedEvent,
+  stubMassAuditDocument,
+  stubMassCertificateAuditDocument,
+  stubMassCertificateDocument,
+  stubMassDocument,
+  stubMethodologyDefinitionDocument,
+} from './nft-metadata-selection.stubs';
+
+const { RECYCLER } = DocumentEventActorType;
+const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
+const { ACTOR, LINK, RULE_EXECUTION, RULES_METADATA } = DocumentEventName;
+const {
+  ACTOR_TYPE,
+  COLLECTION_NAME,
+  NFT_DESCRIPTION,
+  RULE_PROCESSOR_CODE_VERSION,
+  RULE_PROCESSOR_RESULT_CONTENT,
+  RULE_PROCESSOR_SOURCE_CODE_URL,
+  RULE_SLUG,
+  STORE_CONTRACT_ADDRESS,
+} = DocumentEventAttributeName;
+const { MASS, METHODOLOGY } = DocumentCategory;
+const {
+  CREDIT_CERTIFICATES,
+  MASS_AUDIT,
+  MASS_CERTIFICATE,
+  MASS_CERTIFICATE_AUDIT,
+} = DocumentType;
+
+describe('NftMetadataSelection E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+  const creditDocumentId = faker.string.uuid();
+  const image = faker.internet.url();
+
+  // TODO: Refac this test to use a builder or a stub that prepares the documents https://app.clickup.com/t/86a36ut5a
+  const creditDocumentReference: DocumentReference = {
+    category: DocumentCategory.METHODOLOGY,
+    documentId: creditDocumentId,
+    type: DocumentType.CREDIT,
+  };
+  const massCertificateAuditsReferences: DocumentReference[] = stubArray(
+    () => ({
+      category: METHODOLOGY,
+      documentId: faker.string.uuid(),
+      subtype: DocumentSubtype.PROCESS,
+      type: MASS_CERTIFICATE_AUDIT,
+    }),
+    2,
+  );
+  const massesReferences: DocumentReference[] = stubArray(
+    () => ({
+      category: MASS,
+      documentId: faker.string.uuid(),
+    }),
+    10,
+  );
+  const massAuditsReferences: DocumentReference[] = stubArray(
+    () => ({
+      category: METHODOLOGY,
+      documentId: faker.string.uuid(),
+      type: MASS_AUDIT,
+    }),
+    massesReferences.length,
+  );
+  const massCertificatesReferences: DocumentReference[] = stubArray(
+    () => ({
+      category: METHODOLOGY,
+      documentId: faker.string.uuid(),
+      type: MASS_CERTIFICATE,
+    }),
+    2,
+  );
+  const creditCertificatesReference: DocumentReference = {
+    category: METHODOLOGY,
+    documentId: faker.string.uuid(),
+    subtype: DocumentSubtype.GROUP,
+    type: CREDIT_CERTIFICATES,
+  };
+  const methodologyDefinitionReference: DocumentReference = {
+    category: METHODOLOGY,
+    documentId: faker.string.uuid(),
+    type: DocumentType.DEFINITION,
+  };
+
+  const nftDescription = faker.lorem.sentence();
+  const collectionName = faker.lorem.word();
+  const storeContractAddress = faker.finance.ethereumAddress();
+
+  const creditDocumentStub = stubCreditDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        metadata: {
+          attributes: [
+            stubDocumentEventAttribute({
+              name: DocumentEventAttributeName.NFT_IMAGE,
+              value: image,
+            }),
+            stubDocumentEventAttribute({
+              name: COLLECTION_NAME,
+              value: collectionName,
+            }),
+            stubDocumentEventAttribute({
+              name: NFT_DESCRIPTION,
+              value: nftDescription,
+            }),
+            stubDocumentEventAttribute({
+              name: STORE_CONTRACT_ADDRESS,
+              value: storeContractAddress,
+            }),
+          ],
+        },
+        name: RULES_METADATA,
+        referencedDocument: undefined,
+        relatedDocument: undefined,
+      }),
+      stubDocumentOutputEvent(creditCertificatesReference),
+      stubDocumentEvent({
+        name: LINK,
+        relatedDocument: methodologyDefinitionReference,
+      }),
+    ],
+    id: creditDocumentReference.documentId,
+  });
+
+  const creditCertificatesDocumentStub = stubCreditCertificatesDocument({
+    externalEvents: massCertificateAuditsReferences.map(
+      (massCertificateAudit) => stubDocumentRelatedEvent(massCertificateAudit),
+    ),
+    id: creditCertificatesReference.documentId,
+    parentDocumentId: creditDocumentId,
+  });
+
+  const massCertificateAuditsDocumentsStubs = massCertificatesReferences.map(
+    (massCertificate, index) =>
+      stubMassCertificateAuditDocument({
+        externalEvents: [
+          stubDocumentRelatedEvent(creditCertificatesReference),
+          stubDocumentEventWithMetadataAttributes({ name: RULE_EXECUTION }, [
+            [RULE_SLUG, REWARDS_DISTRIBUTION],
+            [RULE_PROCESSOR_CODE_VERSION, faker.git.commitSha()],
+            [RULE_PROCESSOR_SOURCE_CODE_URL, faker.internet.url()],
+            [
+              RULE_PROCESSOR_RESULT_CONTENT,
+              random<RewardDistributionResultContent>() as unknown as UnknownObject,
+            ],
+          ]),
+        ],
+        id: massCertificateAuditsReferences[index]!.documentId,
+        parentDocumentId: massCertificate.documentId,
+      }),
+  );
+
+  const massCertificatesDocumentsStubs = massCertificatesReferences.map(
+    (massCertificateReference, index) => {
+      const firstFiveMassesValidations = massAuditsReferences.slice(0, 5);
+      const lastFiveMassesValidations = massAuditsReferences.slice(5);
+
+      return stubMassCertificateDocument({
+        externalEvents: [
+          ...(index === 0
+            ? firstFiveMassesValidations.map((massAuditReference) =>
+                stubDocumentRelatedEvent(massAuditReference),
+              )
+            : lastFiveMassesValidations.map((massAuditReference) =>
+                stubDocumentRelatedEvent(massAuditReference),
+              )),
+          stubDocumentOutputEvent(massCertificateAuditsReferences[index]!),
+        ],
+        id: massCertificateReference.documentId,
+      });
+    },
+  );
+
+  const massAuditsDocumentStubs = massesReferences.map((massReference, index) =>
+    stubMassAuditDocument({
+      externalEvents: [
+        index < 5
+          ? stubDocumentRelatedEvent(massCertificatesReferences[0]!)
+          : stubDocumentRelatedEvent(massCertificatesReferences[1]!),
+      ],
+      id: massAuditsReferences[index]!.documentId,
+      parentDocumentId: massReference.documentId,
+    }),
+  );
+
+  const massesDocumentStubs = massesReferences.map((massReference, index) =>
+    stubMassDocument({
+      externalEvents: [
+        stubDocumentOutputEvent(massAuditsReferences[index]!),
+        stubDocumentEventWithMetadataAttributes({ name: ACTOR }, [
+          [ACTOR_TYPE, RECYCLER],
+        ]),
+      ],
+      id: massReference.documentId,
+    }),
+  );
+
+  const methodologyDefinitionDocumentStub = stubMethodologyDefinitionDocument({
+    id: methodologyDefinitionReference.documentId,
+  });
+
+  const documents: Document[] = [
+    creditDocumentStub,
+    methodologyDefinitionDocumentStub,
+    creditCertificatesDocumentStub,
+    ...massCertificateAuditsDocumentsStubs,
+    ...massCertificatesDocumentsStubs,
+    ...massAuditsDocumentStubs,
+    ...massesDocumentStubs,
+  ];
+
+  beforeAll(() => {
+    prepareEnvironmentTestE2E(
+      documents.map((document) => ({
+        document,
+        documentKey: toDocumentKey({
+          documentId: document.id,
+          documentKeyPrefix,
+        }),
+      })),
+    );
+  });
+
+  it('should return the rule output APPROVED and with the extracted NFT metadata', async () => {
+    const response = (await handler(
+      stubRuleInput({
+        documentId: creditDocumentId,
+        documentKeyPrefix,
+      }),
+      stubContext(),
+      () => stubRuleResponse(),
+    )) as RuleOutput;
+
+    const validationResultContent = validate<NftMetadata>(
+      response.resultContent,
+    );
+
+    expect(validationResultContent.errors).toEqual([]);
+    expect(response.resultStatus).toBe(RuleOutputStatus.APPROVED);
+    expect(response.resultContent?.['image']).toBe(image);
+    expect(response.resultContent?.['description']).toBe(nftDescription);
+    expect(response.resultContent?.['store_contract_address']).toBe(
+      storeContractAddress,
+    );
+    expect(response.resultContent?.['attributes']).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          trait_type: 'Collection Name',
+          value: collectionName,
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.spec.ts
@@ -1,0 +1,296 @@
+import type { RuleInput } from '@carrot-fndn/shared/rule/types';
+import type { UnknownObject } from '@carrot-fndn/shared/types';
+
+import { spyOnDocumentQueryServiceLoad } from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import {
+  stubDocument,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import { DocumentEventName } from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import {
+  DocumentCategory,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventRuleSlug,
+  type DocumentReference,
+  DocumentSubtype,
+  DocumentType,
+  type RewardDistributionResultContent,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { stubArray } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import { random, validate } from 'typia';
+
+import type { NftMetadata } from './nft-metadata-selection.types';
+
+import { NftMetadataSelection } from './nft-metadata-selection.processor';
+import {
+  stubCreditCertificatesDocument,
+  stubDocumentOutputEvent,
+  stubDocumentRelatedEvent,
+  stubMassAuditDocument,
+  stubMassCertificateAuditDocument,
+  stubMassCertificateDocument,
+  stubMassDocument,
+  stubMethodologyDefinitionDocument,
+} from './nft-metadata-selection.stubs';
+
+const {
+  ACTOR_TYPE,
+  COLLECTION_NAME,
+  NFT_DESCRIPTION,
+  RULE_PROCESSOR_CODE_VERSION,
+  RULE_PROCESSOR_RESULT_CONTENT,
+  RULE_PROCESSOR_SOURCE_CODE_URL,
+  RULE_SLUG,
+  STORE_CONTRACT_ADDRESS: STORE_SMART_CONTRACT_ADDRESS,
+} = DocumentEventAttributeName;
+const { ACTOR, RULE_EXECUTION, RULES_METADATA } = DocumentEventName;
+const { RECYCLER } = DocumentEventActorType;
+const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
+
+describe('NftMetadataSelection', () => {
+  const ruleDataProcessor = new NftMetadataSelection();
+
+  const creditDocumentId = faker.string.uuid();
+
+  const creditCertificatesReference: DocumentReference = {
+    category: DocumentCategory.METHODOLOGY,
+    documentId: faker.string.uuid(),
+    subtype: DocumentSubtype.GROUP,
+    type: DocumentType.CREDIT_CERTIFICATES,
+  };
+
+  const creditDocumentStub = stubDocument({
+    externalEvents: [
+      stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+        [COLLECTION_NAME, faker.lorem.word()],
+        [NFT_DESCRIPTION, faker.lorem.sentence()],
+        [STORE_SMART_CONTRACT_ADDRESS, faker.finance.ethereumAddress()],
+      ]),
+    ],
+    id: creditDocumentId,
+  });
+
+  it('should return the rule output with the extracted NFT metadata', async () => {
+    const massCertificateAuditReference: DocumentReference = {
+      category: DocumentCategory.METHODOLOGY,
+      documentId: faker.string.uuid(),
+      subtype: DocumentSubtype.PROCESS,
+      type: DocumentType.MASS_CERTIFICATE_AUDIT,
+    };
+    const massCertificateReference: DocumentReference = {
+      category: DocumentCategory.METHODOLOGY,
+      documentId: faker.string.uuid(),
+      type: DocumentType.MASS_CERTIFICATE,
+    };
+    const massAuditReference: DocumentReference = {
+      category: DocumentCategory.METHODOLOGY,
+      documentId: faker.string.uuid(),
+      type: DocumentType.MASS_AUDIT,
+    };
+    const massReference: DocumentReference = {
+      category: DocumentCategory.MASS,
+      documentId: faker.string.uuid(),
+    };
+
+    const creditCertificatesDocumentStub = stubCreditCertificatesDocument({
+      externalEvents: [stubDocumentRelatedEvent(massCertificateAuditReference)],
+      id: creditCertificatesReference.documentId,
+      parentDocumentId: creditDocumentId,
+    });
+    const massCertificateAuditDocumentStub = stubMassCertificateAuditDocument({
+      externalEvents: [
+        stubDocumentRelatedEvent(creditCertificatesReference),
+        stubDocumentEventWithMetadataAttributes({ name: RULE_EXECUTION }, [
+          [RULE_SLUG, REWARDS_DISTRIBUTION],
+          [RULE_PROCESSOR_CODE_VERSION, faker.git.commitSha()],
+          [RULE_PROCESSOR_SOURCE_CODE_URL, faker.internet.url()],
+          [
+            RULE_PROCESSOR_RESULT_CONTENT,
+            random<RewardDistributionResultContent>() as unknown as UnknownObject,
+          ],
+        ]),
+      ],
+      id: massCertificateAuditReference.documentId,
+      parentDocumentId: massCertificateReference.documentId,
+    });
+    const massCertificateDocumentStub = stubMassCertificateDocument({
+      externalEvents: [
+        stubDocumentRelatedEvent(massAuditReference),
+        stubDocumentOutputEvent(massCertificateAuditReference),
+      ],
+      id: massCertificateReference.documentId,
+    });
+    const massAuditDocumentStub = stubMassAuditDocument({
+      externalEvents: [stubDocumentRelatedEvent(massCertificateReference)],
+      id: massAuditReference.documentId,
+      parentDocumentId: massReference.documentId,
+    });
+    const massDocumentStub = stubMassDocument({
+      externalEvents: [
+        stubDocumentOutputEvent(massAuditReference),
+        stubDocumentEventWithMetadataAttributes({ name: ACTOR }, [
+          [ACTOR_TYPE, RECYCLER],
+        ]),
+      ],
+      id: massReference.documentId,
+    });
+
+    const documents = [
+      stubMethodologyDefinitionDocument(),
+      creditCertificatesDocumentStub,
+      massCertificateAuditDocumentStub,
+      massCertificateDocumentStub,
+      massAuditDocumentStub,
+      massDocumentStub,
+    ];
+
+    spyOnDocumentQueryServiceLoad(creditDocumentStub, documents);
+
+    const result = await ruleDataProcessor.process({
+      ...random<RuleInput>(),
+      documentId: creditDocumentId,
+    });
+
+    const validation = validate<NftMetadata>(result.resultContent);
+
+    expect(validation.errors).toEqual([]);
+  });
+
+  it('should return the resultContent with a greater amount of massCertificates and masses', async () => {
+    const massCertificateAuditsReferences: DocumentReference[] = stubArray(
+      () => ({
+        category: DocumentCategory.METHODOLOGY,
+        documentId: faker.string.uuid(),
+        subtype: DocumentSubtype.PROCESS,
+        type: DocumentType.MASS_CERTIFICATE_AUDIT,
+      }),
+      2,
+    );
+    const massesReferences: DocumentReference[] = stubArray(
+      () => ({
+        category: DocumentCategory.MASS,
+        documentId: faker.string.uuid(),
+      }),
+      10,
+    );
+    const massAuditsReferences: DocumentReference[] = stubArray(
+      () => ({
+        category: DocumentCategory.METHODOLOGY,
+        documentId: faker.string.uuid(),
+        type: DocumentType.MASS_AUDIT,
+      }),
+      massesReferences.length,
+    );
+    const massCertificatesReferences: DocumentReference[] = stubArray(
+      () => ({
+        category: DocumentCategory.METHODOLOGY,
+        documentId: faker.string.uuid(),
+        type: DocumentType.MASS_CERTIFICATE,
+      }),
+      2,
+    );
+
+    const creditCertificatesDocumentsStub = stubCreditCertificatesDocument({
+      externalEvents: massCertificateAuditsReferences.map(
+        (massCertificateAudit) =>
+          stubDocumentRelatedEvent(massCertificateAudit),
+      ),
+      id: creditCertificatesReference.documentId,
+      parentDocumentId: creditDocumentId,
+    });
+
+    const massCertificateAuditsDocumentsStubs = massCertificatesReferences.map(
+      (massCertificate, index) =>
+        stubMassCertificateAuditDocument({
+          externalEvents: [
+            stubDocumentRelatedEvent(creditCertificatesReference),
+            stubDocumentEventWithMetadataAttributes({ name: RULE_EXECUTION }, [
+              [RULE_SLUG, REWARDS_DISTRIBUTION],
+              [RULE_PROCESSOR_CODE_VERSION, faker.git.commitSha()],
+              [RULE_PROCESSOR_SOURCE_CODE_URL, faker.internet.url()],
+              [
+                RULE_PROCESSOR_RESULT_CONTENT,
+                random<RewardDistributionResultContent>() as unknown as UnknownObject,
+              ],
+            ]),
+          ],
+          id: massCertificateAuditsReferences[index]!.documentId,
+          parentDocumentId: massCertificate.documentId,
+        }),
+    );
+
+    const massCertificatesDocumentsStubs = massCertificatesReferences.map(
+      (massCertificateReference, index) => {
+        const firstFiveMassesValidations = massAuditsReferences.slice(0, 5);
+        const lastFiveMassesValidations = massAuditsReferences.slice(5);
+
+        return stubMassCertificateDocument({
+          externalEvents: [
+            ...(index === 0
+              ? firstFiveMassesValidations.map((massAuditReference) =>
+                  stubDocumentRelatedEvent(massAuditReference),
+                )
+              : lastFiveMassesValidations.map((massAuditReference) =>
+                  stubDocumentRelatedEvent(massAuditReference),
+                )),
+            stubDocumentOutputEvent(massCertificateAuditsReferences[index]!),
+          ],
+          id: massCertificateReference.documentId,
+        });
+      },
+    );
+
+    const massAuditsDocumentStubs = massesReferences.map(
+      (massReference, index) =>
+        stubMassAuditDocument({
+          externalEvents: [
+            index < 5
+              ? stubDocumentRelatedEvent(massCertificatesReferences[0]!)
+              : stubDocumentRelatedEvent(massCertificatesReferences[1]!),
+          ],
+          id: massAuditsReferences[index]!.documentId,
+          parentDocumentId: massReference.documentId,
+        }),
+    );
+
+    const massesDocumentStubs = massesReferences.map((massReference, index) =>
+      stubMassDocument({
+        externalEvents: [
+          stubDocumentOutputEvent(massAuditsReferences[index]!),
+          stubDocumentEventWithMetadataAttributes({ name: ACTOR }, [
+            [ACTOR_TYPE, RECYCLER],
+          ]),
+        ],
+        id: massReference.documentId,
+      }),
+    );
+
+    spyOnDocumentQueryServiceLoad(creditDocumentStub, [
+      stubMethodologyDefinitionDocument(),
+      creditCertificatesDocumentsStub,
+      ...massCertificateAuditsDocumentsStubs,
+      ...massCertificatesDocumentsStubs,
+      ...massAuditsDocumentStubs,
+      ...massesDocumentStubs,
+    ]);
+
+    const result = await ruleDataProcessor.process({
+      ...random<RuleInput>(),
+      documentId: creditDocumentId,
+    });
+
+    const resultContent = result.resultContent as NftMetadata;
+
+    expect(resultContent.details.massCertificates.count).toBe(
+      massCertificatesReferences.length,
+    );
+    expect(resultContent.details.massCertificates.documents.length).toBe(
+      massCertificatesReferences.length,
+    );
+    expect(
+      resultContent.details.massCertificates.documents[0].mass_ids,
+    ).toHaveLength(5);
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.processor.ts
@@ -1,0 +1,136 @@
+import type { NonEmptyArray } from '@carrot-fndn/shared/types';
+
+import {
+  type DocumentQuery,
+  DocumentQueryService,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import {
+  MASS,
+  MASS_CERTIFICATE_AUDIT,
+  METHODOLOGY_DEFINITION,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+import {
+  type Document,
+  type DocumentReference,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { mapDocumentReference } from '@carrot-fndn/methodologies/bold/recycling/organic/utils';
+import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+
+import { NFT_METADATA_SELECTION_CRITERIA } from './nft-metadata-selection.constants';
+import {
+  type MassCertificateMetadata,
+  type MethodologyCreditNftMetadataDto,
+  type MethodologyMetadata,
+  type RewardsDistributionMetadata,
+} from './nft-metadata-selection.dto';
+import {
+  findMassAuditId,
+  findMassCertificateIdFromDocumentLinks,
+  getRulesMetadataEventValues,
+  mapMassMetadata,
+  mapMethodologyMetadata,
+  mapNftMetadata,
+  mapNftMetadataDto,
+  mapRewardDistributionMetadata,
+} from './nft-metadata-selection.helpers';
+
+export interface DocumentLinks {
+  parentDocumentId?: string | undefined;
+  relatedDocuments?: DocumentReference[] | undefined;
+}
+
+export class NftMetadataSelection extends RuleDataProcessor {
+  private async generateDocumentQuery(
+    ruleInput: RuleInput,
+  ): Promise<DocumentQuery<Document>> {
+    const documentQueryService = new DocumentQueryService(
+      provideDocumentLoaderService,
+    );
+
+    return documentQueryService.load({
+      context: {
+        s3KeyPrefix: ruleInput.documentKeyPrefix,
+      },
+      criteria: NFT_METADATA_SELECTION_CRITERIA,
+      documentId: ruleInput.documentId,
+    });
+  }
+
+  private async getRuleSubject(
+    documentQuery: DocumentQuery<Document>,
+  ): Promise<Omit<MethodologyCreditNftMetadataDto, 'creditDocumentId'>> {
+    const documentsLinks = new Map<string, DocumentLinks>();
+    const massCertificates = new Map<string, MassCertificateMetadata>();
+    const credit = documentQuery.rootDocument;
+
+    let methodologyMetadata: MethodologyMetadata = {} as MethodologyMetadata;
+    let rewardsDistribution: RewardsDistributionMetadata =
+      {} as RewardsDistributionMetadata;
+
+    await documentQuery.iterator().each(({ document }) => {
+      const documentReference = mapDocumentReference(document);
+
+      documentsLinks.set(document.id, {
+        parentDocumentId: document.parentDocumentId,
+        relatedDocuments: document.externalEvents
+          ?.map((event) => event.relatedDocument)
+          .filter(Boolean) as DocumentReference[],
+      });
+
+      if (MASS.matches(documentReference)) {
+        const massAuditId = findMassAuditId(document, documentsLinks);
+        const massCertificateId = findMassCertificateIdFromDocumentLinks(
+          massAuditId,
+          documentsLinks,
+        );
+        const massCertificate = massCertificates.get(massCertificateId);
+        const mass = mapMassMetadata(document);
+
+        if (massCertificate) {
+          massCertificate.masses.push(mass);
+        } else {
+          massCertificates.set(massCertificateId, {
+            documentId: massCertificateId,
+            masses: [mass],
+          });
+        }
+      }
+
+      if (METHODOLOGY_DEFINITION.matches(documentReference)) {
+        methodologyMetadata = mapMethodologyMetadata(document);
+      }
+
+      if (MASS_CERTIFICATE_AUDIT.matches(documentReference)) {
+        rewardsDistribution = mapRewardDistributionMetadata(document);
+      }
+    });
+
+    return {
+      ...getRulesMetadataEventValues(credit),
+      massCertificates: [
+        ...massCertificates.values(),
+      ] as NonEmptyArray<MassCertificateMetadata>,
+      methodology: methodologyMetadata,
+      rewardsDistribution,
+    };
+  }
+
+  async process(ruleInput: RuleInput): Promise<RuleOutput> {
+    const documentQuery = await this.generateDocumentQuery(ruleInput);
+
+    const ruleSubject = await this.getRuleSubject(documentQuery);
+
+    const dto = mapNftMetadataDto(ruleSubject, ruleInput);
+
+    return mapToRuleOutput(ruleInput, RuleOutputStatus.APPROVED, {
+      resultContent: mapNftMetadata(dto),
+    });
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.stubs.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.stubs.ts
@@ -1,0 +1,109 @@
+import type { RequiredDeep } from 'type-fest';
+
+import {
+  stubDocumentEvent,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type Document,
+  DocumentCategory,
+  type DocumentEvent,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  type DocumentReference,
+  DocumentSubtype,
+  DocumentType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { stubArray } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import { random } from 'typia';
+
+const { OPEN, OUTPUT, RELATED } = DocumentEventName;
+const { METHODOLOGY_DESCRIPTION, METHODOLOGY_NAME } =
+  DocumentEventAttributeName;
+
+export const stubDocumentOutputEvent = (
+  documentReference: DocumentReference,
+): DocumentEvent => ({
+  ...stubDocumentEvent(),
+  name: OUTPUT,
+  relatedDocument: documentReference,
+});
+
+export const stubDocumentRelatedEvent = (
+  documentReference: DocumentReference,
+): DocumentEvent => ({
+  ...stubDocumentEvent(),
+  name: RELATED,
+  relatedDocument: documentReference,
+});
+
+export const stubMethodologyDefinitionDocument = (
+  partialDocument?: Partial<Document>,
+): Document => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.METHODOLOGY,
+  externalEvents: [
+    ...stubArray(stubDocumentEvent),
+    stubDocumentEventWithMetadataAttributes({ name: OPEN }, [
+      [METHODOLOGY_DESCRIPTION, faker.lorem.sentence()],
+      [METHODOLOGY_NAME, faker.lorem.word()],
+    ]),
+    ...(partialDocument?.externalEvents ?? []),
+  ],
+  type: DocumentType.DEFINITION,
+});
+
+export const stubMassCertificateDocument = (
+  partialDocument?: Partial<Document>,
+): Document => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.METHODOLOGY,
+  type: DocumentType.MASS_CERTIFICATE,
+});
+
+export const stubMassCertificateAuditDocument = (
+  partialDocument?: Partial<Document>,
+): Document => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.METHODOLOGY,
+  subtype: DocumentSubtype.PROCESS,
+  type: DocumentType.MASS_CERTIFICATE_AUDIT,
+});
+
+export const stubCreditDocument = (partialDocument?: Partial<Document>) => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.METHODOLOGY,
+  type: DocumentType.CREDIT,
+});
+
+export const stubMassAuditDocument = (
+  partialDocument?: Partial<Document>,
+): Document => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.METHODOLOGY,
+  type: DocumentType.MASS_AUDIT,
+});
+
+export const stubMassDocument = (
+  partialDocument?: Partial<Document>,
+): Document => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.MASS,
+});
+
+export const stubCreditCertificatesDocument = (
+  partialDocument?: Partial<Document>,
+): Document => ({
+  ...random<RequiredDeep<Document>>(),
+  ...partialDocument,
+  category: DocumentCategory.METHODOLOGY,
+  subtype: DocumentSubtype.GROUP,
+  type: DocumentType.CREDIT_CERTIFICATES,
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
@@ -1,0 +1,78 @@
+import type {
+  NonEmptyArray,
+  NonEmptyString,
+  NonZeroPositive,
+  Uri,
+  Url,
+} from '@carrot-fndn/shared/types';
+
+import type { RewardsDistributionParticipant } from './nft-metadata-selection.dto';
+
+interface NftMetadataAttributes {
+  trait_type: NonEmptyString;
+  value: NonEmptyString;
+}
+
+interface NftMetadataMassId {
+  external_id: NonEmptyString;
+  external_url: Url;
+  recycler: NonEmptyString;
+  weight: NonEmptyString;
+}
+
+export interface NftMetadataMassCertificate {
+  external_id: NonEmptyString;
+  external_url: Url;
+  mass_id_count: NonZeroPositive;
+  mass_ids: NonEmptyArray<NftMetadataMassId>;
+}
+
+export interface NftMetadataMassCertificates {
+  count: NonZeroPositive;
+  description: NonEmptyString;
+  documents: NonEmptyArray<NftMetadataMassCertificate>;
+}
+
+export interface NftMetadataMethodology {
+  description: NonEmptyString;
+  external_url: Url;
+  name: NonEmptyString;
+  pdf: Uri;
+}
+
+interface NftMetadataSummary {
+  mass_certificate_count: NonZeroPositive;
+  mass_id_count: NonZeroPositive;
+  mass_origin_city: NonEmptyString;
+  mass_origin_country: NonEmptyString;
+  mass_origin_state: NonEmptyString;
+  mass_subtype: NonEmptyString;
+  mass_total_weight: NonEmptyString;
+  mass_type: NonEmptyString;
+  recycler_name: NonEmptyString;
+}
+
+export interface NftMetadataRewardsDistribution {
+  description: NonEmptyString;
+  external_url: Url;
+  participants: NonEmptyArray<RewardsDistributionParticipant>;
+  policy_version: NonEmptyString;
+}
+
+interface NftMetadataDetails {
+  massCertificates: NftMetadataMassCertificates;
+  methodology: NftMetadataMethodology;
+  rewards_distribution: NftMetadataRewardsDistribution;
+  summary: NftMetadataSummary;
+}
+
+export interface NftMetadata {
+  attributes: NonEmptyArray<NftMetadataAttributes>;
+  description: NonEmptyString;
+  details: NftMetadataDetails;
+  external_id: NonEmptyString;
+  external_url: Url;
+  image: Uri;
+  name: NonEmptyString;
+  store_contract_address: NonEmptyString;
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.build.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../../../../../.tsconfig/tsconfig.build.json"
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.eslint.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.spec.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/nft-metadata-selection/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../../../.tsconfig/tsconfig.spec.json"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/.eslintrc.js
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/.eslintrc.js
@@ -1,0 +1,5 @@
+const { getBaseEslintConfig } = require('../../../../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Cdf Address
+# Rewards Distribution
 
 Methodology: **BOLD-CARBON-ORGANIC**
 
@@ -10,13 +10,13 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📄 Description
 
-In an event, when there is a report identified as CDF, verify if the declared addresses for the participant identified in the event and the actor identified as Recycler are the same.
+Calculate rewards rights, in USDC, for the participants that contributed to the Circular Economy cycle in this document.
 
-## 📂 Implementation
+### 📂 Implementation
 
-- **[Main Implementation File](./src/lib/cdf-address.processor.ts)**
+- **[Main Implementation File](./src/lib/rewards-distribution.processor.ts)**
 
-## 👥 Contributors
+### 👥 Contributors
 
 [![AMarcosCastelo](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/43973049?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/AMarcosCastelo)
 [![andtankian](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/12521890?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/andtankian)

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/jest.config.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/jest.config.ts
@@ -1,0 +1,3 @@
+import { getJestBaseConfig } from '../../../../../../.jest/config/jest.base.config';
+
+export default getJestBaseConfig(__dirname);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/package.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@carrot-fndn/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution",
+  "version": "0.0.0"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/project.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "methodologies-bold-carbon-organic-rule-processors-credit-rewards-distribution",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["type:app", "app:any", "stack:any", "methodology:bold"],
+  "sourceRoot": "apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src",
+  "projectType": "application",
+  "targets": {
+    "build-lambda": {},
+    "lint": {},
+    "package-lambda": {},
+    "upload-lambda": {},
+    "test": {},
+    "ts": {}
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lambda.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lambda.ts
@@ -1,0 +1,8 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { RewardsDistributionProcessor } from './lib/rewards-distribution.processor';
+
+const instance = new RewardsDistributionProcessor();
+
+// TODO: we can try to generate this code with a ts-patch program transformer
+export const handler = wrapRuleIntoLambdaHandler(instance);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/__snapshots__/rewards-distribution.helpers.spec.ts.snap
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/__snapshots__/rewards-distribution.helpers.spec.ts.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rewards Distribution Helpers calculateRewardsDistribution should match the snapshot 1`] = `
+{
+  "actors": [
+    {
+      "actorType": "HAULER",
+      "amount": "0.00004",
+      "participant": {
+        "id": "h1",
+        "name": "h1",
+      },
+      "percentage": "0.0000003999",
+    },
+    {
+      "actorType": "INTEGRATOR",
+      "amount": "0.000045",
+      "participant": {
+        "id": "i1",
+        "name": "i1",
+      },
+      "percentage": "0.0000004499",
+    },
+    {
+      "actorType": "RECYCLER",
+      "amount": "0.000004",
+      "participant": {
+        "id": "r1",
+        "name": "r1",
+      },
+      "percentage": "0.0000000399",
+    },
+    {
+      "actorType": "NETWORK",
+      "amount": "0.000029",
+      "participant": {
+        "id": "n1",
+        "name": "n1",
+      },
+      "percentage": "0.0000002899",
+    },
+    {
+      "actorType": "HAULER",
+      "amount": "0.000033",
+      "participant": {
+        "id": "e1",
+        "name": "e1",
+      },
+      "percentage": "0.0000003299",
+    },
+    {
+      "actorType": "INTEGRATOR",
+      "amount": "0.000033",
+      "participant": {
+        "id": "e2",
+        "name": "e2",
+      },
+      "percentage": "0.0000003299",
+    },
+    {
+      "actorType": "RECYCLER",
+      "amount": "0.000033",
+      "participant": {
+        "id": "e3",
+        "name": "e3",
+      },
+      "percentage": "0.0000003299",
+    },
+    {
+      "actorType": "HAULER",
+      "amount": "0.00025",
+      "participant": {
+        "id": "s1",
+        "name": "s1",
+      },
+      "percentage": "0.0000024999",
+    },
+    {
+      "actorType": "RECYCLER",
+      "amount": "0.00025",
+      "participant": {
+        "id": "s2",
+        "name": "s2",
+      },
+      "percentage": "0.0000024999",
+    },
+    {
+      "actorType": "INTEGRATOR",
+      "amount": "0",
+      "participant": {
+        "id": "b1",
+        "name": "b1",
+      },
+      "percentage": "0",
+    },
+    {
+      "actorType": "HAULER",
+      "amount": "0",
+      "participant": {
+        "id": "b2",
+        "name": "b2",
+      },
+      "percentage": "0",
+    },
+    {
+      "actorType": "PROCESSOR",
+      "amount": "9999.999999",
+      "participant": {
+        "id": "b3",
+        "name": "b3",
+      },
+      "percentage": "99.99999283",
+    },
+  ],
+  "massTotalValue": "10000000716.076499",
+  "remainder": {
+    "amount": "0.000007",
+    "percentage": "0.0000000699",
+  },
+  "unitPrice": 0.000001,
+}
+`;

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.constants.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.constants.ts
@@ -1,0 +1,33 @@
+import type { DocumentCriteria } from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+
+import {
+  CREDIT_CERTIFICATES,
+  MASS,
+  MASS_AUDIT,
+  MASS_CERTIFICATE,
+  MASS_CERTIFICATE_AUDIT,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+
+export const MASS_CERTIFICATE_AUDIT_CRITERIA: DocumentCriteria = {
+  relatedDocuments: [
+    {
+      ...CREDIT_CERTIFICATES.match,
+      omit: true,
+      relatedDocuments: [MASS_CERTIFICATE_AUDIT.match],
+    },
+  ],
+};
+
+export const MASS_CRITERIA: DocumentCriteria = {
+  parentDocument: {
+    ...MASS_CERTIFICATE.match,
+    omit: true,
+    relatedDocuments: [
+      {
+        ...MASS_AUDIT.match,
+        omit: true,
+        parentDocument: MASS.match,
+      },
+    ],
+  },
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.helpers.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.helpers.spec.ts
@@ -1,0 +1,185 @@
+import type { NonEmptyArray } from '@carrot-fndn/shared/types';
+
+import {
+  type CertificateReward,
+  DocumentEventActorType,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { splitBigNumberIntoParts } from '@carrot-fndn/shared/helpers';
+import { stubBigNumber } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import BigNumber from 'bignumber.js';
+import { random, validate } from 'typia';
+
+import type {
+  Participant,
+  ResultContentWithMassValue,
+  RewardsDistribution,
+} from './rewards-distribution.types';
+
+import {
+  AMOUNT_DECIMALS,
+  PERCENTAGE_DECIMALS,
+  calculateRewardsDistribution,
+  formatPercentage,
+  roundAmount,
+} from './rewards-distribution.helpers';
+import { stubUnitPrice } from './rewards-distribution.stubs';
+import { RESULT_CONTENT_WITH_MASS_VALUE_STUB } from './rewards-distribution.test.data';
+import { assertExpectedRewardsDistribution } from './rewards-distribution.test.helpers';
+
+describe('Rewards Distribution Helpers', () => {
+  describe('formatPercentage', () => {
+    it(`should return correct percentage divided by 100 and rounded to ${PERCENTAGE_DECIMALS} decimals`, () => {
+      const value = stubBigNumber();
+      const totalValue = value.plus(stubBigNumber());
+
+      const percentage = formatPercentage(value, totalValue);
+
+      expect(Number(percentage)).toBeLessThan(100);
+      expect(BigNumber(percentage).decimalPlaces()).toBeLessThanOrEqual(
+        PERCENTAGE_DECIMALS,
+      );
+    });
+
+    it('should return 0 if the total value is 0', () => {
+      const value = stubBigNumber();
+      const totalValue = new BigNumber(0);
+
+      const percentage = formatPercentage(value, totalValue);
+
+      expect(percentage).toBe('0');
+    });
+  });
+
+  describe('roundAmount', () => {
+    it.each([
+      ['13.6898828123', '13.689882', 'should round down normally'],
+      ['13.6898885999', '13.689888', 'should round down at boundary'],
+      ['0.00000123', '0.000001', 'should handle very small amounts'],
+      ['999999.9999999', '999999.999999', 'should handle large amounts'],
+    ])('case: %s -> %s (%s)', (input, expected) => {
+      expect(roundAmount(new BigNumber(input)).toString()).toBe(expected);
+      expect(roundAmount(new BigNumber(input)).decimalPlaces()).toBe(
+        AMOUNT_DECIMALS,
+      );
+    });
+  });
+
+  describe('calculateRewardsDistribution', () => {
+    it('should throw error if two different NETWORK actors are present', () => {
+      expect(() =>
+        calculateRewardsDistribution(faker.number.float(), [
+          {
+            massValue: stubBigNumber(),
+            resultContent: {
+              certificateRewards: [
+                random<Participant>(),
+                random<Participant>(),
+              ].map((participant) => ({
+                actorType: DocumentEventActorType.NETWORK,
+                participant,
+                percentage: '50',
+              })) as never,
+              massRewards: [] as never,
+            },
+          },
+        ]),
+      ).toThrow('Can only have one network actor');
+    });
+
+    it('should not throw error if two same NETWORK actors are present', () => {
+      const actor = {
+        actorType: DocumentEventActorType.NETWORK,
+        participant: random<Participant>(),
+        percentage: '50',
+      };
+      const result = calculateRewardsDistribution(faker.number.float(), [
+        {
+          massValue: stubBigNumber(),
+          resultContent: {
+            certificateRewards: [actor, actor] as never,
+            massRewards: [] as never,
+          },
+        },
+      ]);
+
+      expect(validate<RewardsDistribution>(result).errors).toEqual([]);
+    });
+
+    it('should match the snapshot', () => {
+      const unitPrice = 0.000_001;
+      const result = calculateRewardsDistribution(
+        unitPrice,
+        RESULT_CONTENT_WITH_MASS_VALUE_STUB,
+      );
+
+      assertExpectedRewardsDistribution(unitPrice, result);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('should throw error if NETWORK actors are not present', () => {
+      expect(() =>
+        calculateRewardsDistribution(faker.number.float(), []),
+      ).toThrow('Network actor not found');
+    });
+
+    it('should correctly calculate the rewards distribution', () => {
+      const unitPrice = stubUnitPrice();
+      const actorTypes: NonEmptyArray<RewardsDistributionActorType> = [
+        DocumentEventActorType.APPOINTED_NGO,
+        DocumentEventActorType.HAULER,
+        DocumentEventActorType.INTEGRATOR,
+        DocumentEventActorType.METHODOLOGY_AUTHOR,
+        DocumentEventActorType.METHODOLOGY_DEVELOPER,
+        DocumentEventActorType.NETWORK,
+        DocumentEventActorType.PROCESSOR,
+        DocumentEventActorType.RECYCLER,
+        DocumentEventActorType.SOURCE,
+      ];
+
+      const participants: Record<RewardsDistributionActorType, Participant> =
+        Object.fromEntries(
+          actorTypes.map((actorType) => [actorType, random<Participant>()]),
+        ) as never;
+
+      const resultContentsWithMassValue: ResultContentWithMassValue[] = [];
+      const certificatesMassValue = [stubBigNumber(), stubBigNumber()];
+
+      for (const massValue of certificatesMassValue) {
+        const percentages = splitBigNumberIntoParts(
+          new BigNumber(100),
+          actorTypes.length,
+        );
+
+        const certificateRewards: CertificateReward[] = actorTypes.map(
+          (actorType, index) => {
+            const percentage = percentages[index]!;
+
+            return {
+              actorType,
+              participant: participants[actorType],
+              percentage: percentage.toString(),
+            };
+          },
+        );
+
+        resultContentsWithMassValue.push({
+          massValue,
+          resultContent: {
+            certificateRewards: certificateRewards as never,
+            massRewards: [] as never,
+          },
+        });
+      }
+
+      const result = calculateRewardsDistribution(
+        unitPrice,
+        resultContentsWithMassValue,
+      );
+
+      expect(result.actors.length).toBe(actorTypes.length);
+      assertExpectedRewardsDistribution(unitPrice, result);
+    });
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.helpers.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.helpers.ts
@@ -1,0 +1,115 @@
+import type { NonZeroPositive } from '@carrot-fndn/shared/types';
+
+import { DocumentEventActorType } from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { sumBigNumbers } from '@carrot-fndn/shared/helpers';
+import BigNumber from 'bignumber.js';
+
+import type {
+  Actor,
+  ActorsByActorType,
+  ResultContentWithMassValue,
+  RewardsDistribution,
+} from './rewards-distribution.types';
+
+export const AMOUNT_DECIMALS = 6;
+export const PERCENTAGE_DECIMALS = 10;
+
+export const roundAmount = (value: BigNumber): BigNumber =>
+  value.decimalPlaces(AMOUNT_DECIMALS, BigNumber.ROUND_DOWN);
+
+export const formatPercentage = (
+  value: BigNumber,
+  totalValue: BigNumber,
+): string =>
+  totalValue.isZero()
+    ? new BigNumber(0).toString()
+    : value
+        .dividedBy(totalValue)
+        .multipliedBy(100)
+        .decimalPlaces(PERCENTAGE_DECIMALS, BigNumber.ROUND_DOWN)
+        .toString(PERCENTAGE_DECIMALS);
+
+export const calculateRewardsDistribution = (
+  unitPrice: NonZeroPositive,
+  resultContentsWithMassValue: ResultContentWithMassValue[],
+): RewardsDistribution => {
+  const actors: ActorsByActorType = new Map();
+  let networkActorKey = '';
+
+  const massTotalValue = sumBigNumbers(
+    resultContentsWithMassValue.map(({ massValue }) => massValue),
+  );
+  const totalAmount = roundAmount(massTotalValue.multipliedBy(unitPrice));
+
+  for (const {
+    massValue,
+    resultContent: { certificateRewards },
+  } of resultContentsWithMassValue) {
+    for (const { actorType, participant, percentage } of certificateRewards) {
+      const actorKey = `${actorType}-${participant.id}`;
+      const aggregatedActor = actors.get(actorKey);
+      const actorCurrentAmount = aggregatedActor?.amount ?? 0;
+      const actorCertificateAmount = roundAmount(
+        new BigNumber(percentage)
+          .dividedBy(100)
+          .multipliedBy(massValue)
+          .multipliedBy(unitPrice),
+      );
+
+      const actorAmount = roundAmount(
+        actorCertificateAmount.plus(actorCurrentAmount),
+      );
+
+      const actor: Actor = {
+        actorType,
+        amount: actorAmount.toString(),
+        participant,
+        percentage: formatPercentage(actorAmount, totalAmount),
+      };
+
+      if (actorType === DocumentEventActorType.NETWORK) {
+        networkActorKey = actorKey;
+      }
+
+      actors.set(actorKey, actor);
+    }
+  }
+
+  const networkActorsKeys = [...actors.keys()].filter((actorKey) =>
+    actorKey.startsWith(DocumentEventActorType.NETWORK),
+  );
+
+  if (networkActorsKeys.length > 1) {
+    throw new Error(
+      `Can only have one network actor. Received ${JSON.stringify(networkActorsKeys)}`,
+    );
+  }
+
+  const networkActor = actors.get(networkActorKey);
+
+  if (!networkActor) {
+    throw new Error('Network actor not found when calculating rewards');
+  }
+
+  const actorsAmount = sumBigNumbers(
+    [...actors.values()].map(({ amount }) => new BigNumber(amount)),
+  );
+  const remainderAmount = totalAmount.minus(actorsAmount);
+  const networkActorAmount = remainderAmount.plus(networkActor.amount);
+
+  actors.set(networkActorKey, {
+    ...networkActor,
+    amount: networkActorAmount.toString(),
+    percentage: formatPercentage(networkActorAmount, totalAmount),
+  });
+
+  return {
+    actors: [...actors.values()],
+    massTotalValue: massTotalValue.toString(),
+    remainder: {
+      amount: remainderAmount.toString(),
+      percentage: formatPercentage(remainderAmount, totalAmount),
+    },
+    unitPrice,
+  };
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.e2e.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.e2e.spec.ts
@@ -1,0 +1,155 @@
+import {
+  stubCreditCertificatesDocument,
+  stubCreditDocument,
+  stubDocumentEvent,
+  stubDocumentEventWithMetadataAttributes,
+  stubMassAuditDocument,
+  stubMassCertificateDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  DocumentEventAttributeName,
+  DocumentEventName,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { pick, toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubBigNumber,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+
+import { handler } from '../lambda';
+import {
+  stubCertificateRewardsDistributionResultContent,
+  stubMassCertificateAuditDocumentWithResultContent,
+  stubMassDocumentWithEndEventValue,
+  stubUnitPrice,
+} from './rewards-distribution.stubs';
+import { assertExpectedRewardsDistribution } from './rewards-distribution.test.helpers';
+
+const { RULES_METADATA } = DocumentEventName;
+const { UNIT_PRICE } = DocumentEventAttributeName;
+
+describe('RewardsDistributionProcessor E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+  const creditId = faker.string.uuid();
+  const unitPrice = stubUnitPrice();
+  const massValues = [stubBigNumber(), stubBigNumber()];
+
+  const masses = massValues.map((value) =>
+    stubMassDocumentWithEndEventValue(value.toNumber()),
+  );
+
+  const massAudits = masses.map(({ id: parentDocumentId }) =>
+    stubMassAuditDocument({ parentDocumentId }),
+  );
+
+  const massCertificate = stubMassCertificateDocument({
+    externalEvents: massAudits.map((value) =>
+      stubDocumentEvent({
+        relatedDocument: {
+          ...pick(value, 'category', 'type', 'subtype'),
+          documentId: value.id,
+        },
+      }),
+    ),
+  });
+
+  const rewards = stubCertificateRewardsDistributionResultContent();
+
+  const massCertificateAudit =
+    stubMassCertificateAuditDocumentWithResultContent(
+      { parentDocumentId: massCertificate.id },
+      rewards,
+    );
+  const creditCertificate = stubCreditCertificatesDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        relatedDocument: {
+          ...pick(massCertificateAudit, 'category', 'type', 'subtype'),
+          documentId: massCertificateAudit.id,
+        },
+      }),
+    ],
+    parentDocumentId: creditId,
+  });
+
+  const credit = stubCreditDocument({
+    externalEvents: [
+      stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+        [UNIT_PRICE, unitPrice],
+      ]),
+      stubDocumentEvent({
+        relatedDocument: {
+          ...pick(creditCertificate, 'category', 'type', 'subtype'),
+          documentId: creditCertificate.id,
+        },
+      }),
+    ],
+    id: creditId,
+  });
+
+  beforeAll(() => {
+    prepareEnvironmentTestE2E([
+      {
+        document: credit,
+        documentKey: toDocumentKey({
+          documentId: credit.id,
+          documentKeyPrefix,
+        }),
+      },
+      {
+        document: massCertificate,
+        documentKey: toDocumentKey({
+          documentId: massCertificate.id,
+          documentKeyPrefix,
+        }),
+      },
+      {
+        document: creditCertificate,
+        documentKey: toDocumentKey({
+          documentId: creditCertificate.id,
+          documentKeyPrefix,
+        }),
+      },
+      {
+        document: massCertificateAudit,
+        documentKey: toDocumentKey({
+          documentId: massCertificateAudit.id,
+          documentKeyPrefix,
+        }),
+      },
+      ...masses.map((document) => ({
+        document,
+        documentKey: toDocumentKey({
+          documentId: document.id,
+          documentKeyPrefix,
+        }),
+      })),
+      ...massAudits.map((document) => ({
+        document,
+        documentKey: toDocumentKey({
+          documentId: document.id,
+          documentKeyPrefix,
+        }),
+      })),
+    ]);
+  });
+
+  it('should return APPROVED and correct rewards distribution', async () => {
+    const { resultContent, resultStatus } = (await handler(
+      stubRuleInput({
+        documentId: credit.id,
+        documentKeyPrefix,
+      }),
+      stubContext(),
+      () => stubRuleResponse(),
+    )) as never;
+
+    expect(resultStatus).toBe(RuleOutputStatus.APPROVED);
+    assertExpectedRewardsDistribution(unitPrice, resultContent);
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.spec.ts
@@ -1,0 +1,160 @@
+import {
+  spyOnDocumentQueryServiceLoad,
+  spyOnLoadParentDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import {
+  stubCreditDocument,
+  stubDocument,
+  stubDocumentEventWithMetadataAttributes,
+  stubMassCertificateAuditDocument,
+  stubMassDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type CertificateRewardDistributionOutput,
+  DocumentEventAttributeName,
+  DocumentEventName,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { type RuleInput } from '@carrot-fndn/shared/rule/types';
+import { random } from 'typia';
+
+import { RewardsDistributionProcessor } from './rewards-distribution.processor';
+import {
+  stubMassCertificateAuditDocumentWithResultContent,
+  stubMassDocumentWithEndEventValue,
+} from './rewards-distribution.stubs';
+
+const { END, RULES_METADATA } = DocumentEventName;
+const { UNIT_PRICE } = DocumentEventAttributeName;
+
+describe('RewardsDistributionProcessor', () => {
+  const ruleDataProcessor = new RewardsDistributionProcessor();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it.each([
+    {
+      credit: stubCreditDocument(),
+      errorMessage:
+        ruleDataProcessor[
+          'ErrorMessage'
+        ].UNEXPECTED_RULE_PROCESSOR_RESULT_CONTENT('123'),
+      massCertificateAudits: [
+        stubMassCertificateAuditDocumentWithResultContent(
+          { id: '123' },
+          {} as CertificateRewardDistributionOutput,
+        ),
+      ],
+      scenario: 'the rule result content is an unexpected value',
+    },
+    {
+      credit: stubCreditDocument(),
+      errorMessage:
+        ruleDataProcessor['ErrorMessage'].REWARDS_DISTRIBUTION_NOT_FOUND(
+          'documentId',
+        ),
+      massCertificateAudits: [
+        stubMassCertificateAuditDocument({ id: 'documentId' }),
+      ],
+      scenario: 'the rewards distribution was not found',
+    },
+    {
+      credit: stubCreditDocument(),
+      errorMessage:
+        ruleDataProcessor['ErrorMessage'].MASS_CERTIFICATE_AUDITS_NOT_FOUND,
+      scenario: 'mass certificate audits are not found',
+    },
+    {
+      credit: stubCreditDocument(),
+      errorMessage: ruleDataProcessor['ErrorMessage'].INVALID_END_EVENT_VALUE(
+        'documentId',
+        'invalid',
+      ),
+      massCertificateAudits: [
+        stubMassCertificateAuditDocumentWithResultContent(),
+      ],
+      masses: [
+        stubMassDocument({
+          externalEvents: [
+            stubDocumentEventWithMetadataAttributes({
+              name: END,
+              value: 'invalid' as never,
+            }),
+          ],
+          id: 'documentId',
+        }),
+      ],
+      scenario: 'the mass END event value is not a number',
+    },
+    {
+      credit: stubCreditDocument(),
+      errorMessage:
+        ruleDataProcessor['ErrorMessage'].END_EVENT_NOT_FOUND('documentId'),
+      massCertificateAudits: [
+        stubMassCertificateAuditDocumentWithResultContent(),
+      ],
+      masses: [stubMassDocument({ id: 'documentId' })],
+      scenario: 'the mass END event was not found',
+    },
+    {
+      credit: undefined,
+      errorMessage: ruleDataProcessor['ErrorMessage'].CREDIT_NOT_FOUND,
+      massCertificateAudits: [
+        stubMassCertificateAuditDocumentWithResultContent(),
+      ],
+      masses: [stubMassDocumentWithEndEventValue()],
+      scenario: 'the credit document was not found',
+    },
+    {
+      credit: stubCreditDocument({ id: 'documentId' }),
+      errorMessage:
+        ruleDataProcessor['ErrorMessage'].RULES_METADATA_NOT_FOUND(
+          'documentId',
+        ),
+      massCertificateAudits: [
+        stubMassCertificateAuditDocumentWithResultContent(),
+      ],
+      masses: [stubMassDocumentWithEndEventValue()],
+      scenario: 'the rules metadata event was not found',
+    },
+    {
+      credit: stubCreditDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes({ name: RULES_METADATA }, [
+            [UNIT_PRICE, 'invalid'],
+          ]),
+        ],
+        id: 'documentId',
+      }),
+      errorMessage: ruleDataProcessor['ErrorMessage'].INVALID_UNIT_PRICE(
+        'documentId',
+        'invalid',
+      ),
+      massCertificateAudits: [
+        stubMassCertificateAuditDocumentWithResultContent(),
+      ],
+      masses: [stubMassDocumentWithEndEventValue()],
+      scenario: 'the credit OPEN event has an invalid unit price',
+    },
+  ])(
+    `should throw error when $scenario`,
+    async ({ credit, errorMessage, massCertificateAudits, masses }) => {
+      const ruleInput = random<Required<RuleInput>>();
+
+      spyOnLoadParentDocument(credit);
+
+      if (massCertificateAudits) {
+        spyOnDocumentQueryServiceLoad(stubDocument(), massCertificateAudits);
+      }
+
+      if (masses) {
+        spyOnDocumentQueryServiceLoad(stubDocument(), masses);
+      }
+
+      await expect(ruleDataProcessor.process(ruleInput)).rejects.toThrow(
+        errorMessage,
+      );
+    },
+  );
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.processor.ts
@@ -1,0 +1,251 @@
+import { getEventAttributeValue } from '@carrot-fndn/methodologies/bold/recycling/organic/getters';
+import {
+  type DocumentQuery,
+  DocumentQueryService,
+  loadParentDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import {
+  and,
+  eventNameIsAnyOf,
+  metadataAttributeValueIsAnyOf,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/predicates';
+import {
+  type CertificateRewardDistributionOutput,
+  type Document,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentEventRuleSlug,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import { isNil, toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import {
+  type MethodologyDocumentEventAttributeValue,
+  type NonZeroPositive,
+} from '@carrot-fndn/shared/types';
+import BigNumber from 'bignumber.js';
+import { is } from 'typia';
+
+import type { ResultContentWithMassValue } from './rewards-distribution.types';
+
+import {
+  MASS_CERTIFICATE_AUDIT_CRITERIA,
+  MASS_CRITERIA,
+} from './rewards-distribution.constants';
+import { calculateRewardsDistribution } from './rewards-distribution.helpers';
+
+const { END, RULE_EXECUTION, RULES_METADATA } = DocumentEventName;
+const { RULE_PROCESSOR_RESULT_CONTENT, RULE_SLUG, UNIT_PRICE } =
+  DocumentEventAttributeName;
+const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
+
+export class RewardsDistributionProcessor extends RuleDataProcessor {
+  private ErrorMessage = {
+    CREDIT_NOT_FOUND: 'The Credit was not found',
+    END_EVENT_NOT_FOUND: (documentId: string) =>
+      `${END} event not found in the document ${documentId}`,
+    INVALID_END_EVENT_VALUE: (documentId: string, value: unknown) =>
+      `Invalid ${END} event value ${String(value)} in the document ${documentId}`,
+    INVALID_UNIT_PRICE: (
+      documentId: string,
+      untiPrice: MethodologyDocumentEventAttributeValue | undefined,
+    ) => `Invalid ${String(untiPrice)} in the document ${documentId}`,
+    MASS_CERTIFICATE_AUDITS_NOT_FOUND:
+      'The Mass Certificate Audits was not found',
+    REWARDS_DISTRIBUTION_NOT_FOUND: (documentId: string) =>
+      `${REWARDS_DISTRIBUTION} ${RULE_EXECUTION} not found in the document ${documentId}`,
+    RULES_METADATA_NOT_FOUND: (documentId: string) =>
+      `${RULES_METADATA} event not found in the document ${documentId}`,
+    UNEXPECTED_RULE_PROCESSOR_RESULT_CONTENT: (documentId: string) =>
+      `Unexpected ${RULE_PROCESSOR_RESULT_CONTENT} on the ${REWARDS_DISTRIBUTION} ${RULE_EXECUTION} event in the document ${documentId}`,
+  };
+
+  private async generateDocumentQuery(ruleInput: RuleInput) {
+    const documentQueryService = new DocumentQueryService(
+      provideDocumentLoaderService,
+    );
+
+    const massCertificateAuditsQuery = await documentQueryService.load({
+      context: {
+        s3KeyPrefix: ruleInput.documentKeyPrefix,
+      },
+      criteria: MASS_CERTIFICATE_AUDIT_CRITERIA,
+      documentId: ruleInput.documentId,
+    });
+
+    return {
+      documentQueryService,
+      massCertificateAuditsQuery,
+    };
+  }
+
+  private async getRuleSubject(
+    ruleInput: RuleInput,
+    documentQueries: {
+      documentQueryService: DocumentQueryService;
+      massCertificateAuditsQuery: DocumentQuery<Document> | undefined;
+    },
+  ) {
+    const { documentQueryService, massCertificateAuditsQuery } =
+      documentQueries;
+
+    const credit = await loadParentDocument(
+      this.context.documentLoaderService,
+      toDocumentKey({
+        documentId: ruleInput.documentId,
+        documentKeyPrefix: ruleInput.documentKeyPrefix,
+      }),
+    );
+
+    const massCertificateAuditsRuleResultContent =
+      await massCertificateAuditsQuery
+        ?.iterator()
+        .map(
+          ({
+            document: { externalEvents, id: massCertificateAuditDocumentId },
+          }) => {
+            const rewardsDistributionEvent = externalEvents?.find(
+              and(
+                eventNameIsAnyOf([RULE_EXECUTION]),
+                metadataAttributeValueIsAnyOf(RULE_SLUG, [
+                  REWARDS_DISTRIBUTION,
+                ]),
+              ),
+            );
+
+            if (!rewardsDistributionEvent) {
+              throw new Error(
+                this.ErrorMessage.REWARDS_DISTRIBUTION_NOT_FOUND(
+                  massCertificateAuditDocumentId,
+                ),
+              );
+            }
+
+            const resultContent = getEventAttributeValue(
+              rewardsDistributionEvent,
+              RULE_PROCESSOR_RESULT_CONTENT,
+            );
+
+            if (!is<CertificateRewardDistributionOutput>(resultContent)) {
+              throw new Error(
+                this.ErrorMessage.UNEXPECTED_RULE_PROCESSOR_RESULT_CONTENT(
+                  massCertificateAuditDocumentId,
+                ),
+              );
+            }
+
+            return {
+              massCertificateAuditDocumentId,
+              resultContent,
+            };
+          },
+        );
+
+    if (isNil(massCertificateAuditsRuleResultContent)) {
+      throw new Error(this.ErrorMessage.MASS_CERTIFICATE_AUDITS_NOT_FOUND);
+    }
+
+    const resultContentsWithMassValue = await Promise.all(
+      massCertificateAuditsRuleResultContent.map(
+        async ({ massCertificateAuditDocumentId, resultContent }) => {
+          let massValue = new BigNumber(0);
+
+          const massesQuery = await documentQueryService.load({
+            context: {
+              s3KeyPrefix: ruleInput.documentKeyPrefix,
+            },
+            criteria: MASS_CRITERIA,
+            documentId: massCertificateAuditDocumentId,
+          });
+
+          await massesQuery.iterator().each(({ document }) => {
+            const massDocumentId = document.id;
+            const endEvent = document.externalEvents?.find(
+              eventNameIsAnyOf([END]),
+            );
+
+            if (!endEvent) {
+              throw new Error(
+                this.ErrorMessage.END_EVENT_NOT_FOUND(massDocumentId),
+              );
+            }
+
+            const { value } = endEvent;
+
+            if (!is<number>(value)) {
+              throw new Error(
+                this.ErrorMessage.INVALID_END_EVENT_VALUE(
+                  massDocumentId,
+                  value,
+                ),
+              );
+            }
+
+            massValue = massValue.plus(new BigNumber(value));
+          });
+
+          return {
+            massValue,
+            resultContent,
+          };
+        },
+      ),
+    );
+
+    return {
+      credit,
+      resultContentsWithMassValue,
+    };
+  }
+
+  private result(
+    ruleInput: RuleInput,
+    ruleSubject: {
+      credit: Document | undefined;
+      resultContentsWithMassValue: ResultContentWithMassValue[];
+    },
+  ) {
+    const { credit, resultContentsWithMassValue } = ruleSubject;
+
+    if (isNil(credit)) {
+      throw new Error(this.ErrorMessage.CREDIT_NOT_FOUND);
+    }
+
+    const rulesMetadataEvent = credit.externalEvents?.find(
+      eventNameIsAnyOf([RULES_METADATA]),
+    );
+
+    if (!rulesMetadataEvent) {
+      throw new Error(this.ErrorMessage.RULES_METADATA_NOT_FOUND(credit.id));
+    }
+
+    const unitPrice = getEventAttributeValue(rulesMetadataEvent, UNIT_PRICE);
+
+    if (!is<NonZeroPositive>(unitPrice) || new BigNumber(unitPrice).isNaN()) {
+      throw new Error(
+        this.ErrorMessage.INVALID_UNIT_PRICE(credit.id, unitPrice),
+      );
+    }
+
+    return mapToRuleOutput(ruleInput, RuleOutputStatus.APPROVED, {
+      resultContent: calculateRewardsDistribution(
+        unitPrice,
+        resultContentsWithMassValue,
+      ),
+    });
+  }
+
+  async process(ruleInput: RuleInput): Promise<RuleOutput> {
+    const documentQueries = await this.generateDocumentQuery(ruleInput);
+
+    const ruleSubject = await this.getRuleSubject(ruleInput, documentQueries);
+
+    return this.result(ruleInput, ruleSubject);
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.stubs.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.stubs.ts
@@ -1,0 +1,104 @@
+import type { NonEmptyArray } from '@carrot-fndn/shared/types';
+import type { PartialDeep } from 'type-fest';
+
+import {
+  stubDocumentEventWithMetadataAttributes,
+  stubMassCertificateAuditDocument,
+  stubMassDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type CertificateReward,
+  type CertificateRewardDistributionOutput,
+  type Document,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentEventRuleSlug,
+  type MassReward,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { stubArray } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import BigNumber from 'bignumber.js';
+import { random } from 'typia';
+
+const { END, RULE_EXECUTION } = DocumentEventName;
+const { RULE_PROCESSOR_RESULT_CONTENT, RULE_SLUG } = DocumentEventAttributeName;
+const { REWARDS_DISTRIBUTION } = DocumentEventRuleSlug;
+const { NETWORK } = DocumentEventActorType;
+
+export const stubUnitPrice = () =>
+  faker.number.float({ max: 10, min: 0.000_001 });
+
+export const stubMassCertificateAuditDocumentWithResultContent = (
+  partialDocument?: PartialDeep<Document>,
+  resultContent?: CertificateRewardDistributionOutput,
+) =>
+  stubMassCertificateAuditDocument({
+    ...partialDocument,
+    externalEvents: [
+      stubDocumentEventWithMetadataAttributes({ name: RULE_EXECUTION }, [
+        [RULE_SLUG, REWARDS_DISTRIBUTION],
+        [
+          RULE_PROCESSOR_RESULT_CONTENT,
+          resultContent ?? random<CertificateRewardDistributionOutput>(),
+        ],
+      ]),
+    ],
+  });
+
+export const stubMassDocumentWithEndEventValue = (endEventValue?: number) =>
+  stubMassDocument({
+    externalEvents: [
+      stubDocumentEventWithMetadataAttributes({
+        name: END,
+        value: endEventValue ?? faker.number.float(),
+      }),
+    ],
+  });
+
+export const stubCertificateRewardsDistributionResultContent =
+  (): CertificateRewardDistributionOutput => {
+    const certificateRewards: NonEmptyArray<CertificateReward> = [
+      {
+        ...random<CertificateReward>(),
+        actorType: NETWORK,
+      },
+      ...stubArray(() => ({
+        ...random<CertificateReward>(),
+        actorType: random<Exclude<RewardsDistributionActorType, 'NETWORK'>>(),
+      })),
+    ];
+
+    let remainderPercentage = new BigNumber(100);
+
+    const calculatePercentage = () => {
+      const percentage = faker.number.float({
+        fractionDigits: 10,
+        max: remainderPercentage.toNumber(),
+        min: 0,
+      });
+
+      remainderPercentage = remainderPercentage.minus(percentage);
+
+      return percentage.toString();
+    };
+
+    for (const [index] of certificateRewards.entries()) {
+      // eslint-disable-next-line security/detect-object-injection
+      const certificateReward = certificateRewards[index] as CertificateReward;
+
+      certificateReward.percentage =
+        certificateRewards.length === index + 1
+          ? remainderPercentage.toString()
+          : calculatePercentage();
+    }
+
+    return {
+      certificateRewards,
+      massRewards: [
+        random<MassReward>(),
+        ...stubArray(() => random<MassReward>()),
+      ],
+    };
+  };

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.test.data.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.test.data.ts
@@ -1,0 +1,93 @@
+import {
+  type CertificateReward,
+  DocumentEventActorType,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import BigNumber from 'bignumber.js';
+
+import type { ResultContentWithMassValue } from './rewards-distribution.types';
+
+const { HAULER, INTEGRATOR, NETWORK, PROCESSOR, RECYCLER } =
+  DocumentEventActorType;
+
+const createCertificateReward = (
+  actorType: RewardsDistributionActorType,
+  participantId: string,
+  participantName: string,
+  percentage: string,
+): CertificateReward => ({
+  actorType,
+  participant: {
+    id: participantId,
+    name: participantName,
+  },
+  percentage,
+});
+
+export const RESULT_CONTENT_WITH_MASS_VALUE_STUB: ResultContentWithMassValue[] =
+  [
+    {
+      massValue: new BigNumber('24.419'),
+      resultContent: {
+        certificateRewards: [
+          createCertificateReward(HAULER, 'h1', 'h1', '12'),
+          createCertificateReward(HAULER, 'h1', 'h1', '7.711408'),
+          createCertificateReward(INTEGRATOR, 'i1', 'i1', '17.986262'),
+          createCertificateReward(RECYCLER, 'r1', 'r1', '17.95633'),
+          createCertificateReward(NETWORK, 'n1', 'n1', '44.346'),
+        ],
+        massRewards: [] as never,
+      },
+    },
+    {
+      massValue: new BigNumber('91.6575'),
+      resultContent: {
+        certificateRewards: [
+          createCertificateReward(HAULER, 'h1', 'h1', '41'),
+          createCertificateReward(INTEGRATOR, 'i1', 'i1', '45'),
+          createCertificateReward(NETWORK, 'n1', 'n1', '14'),
+        ],
+        massRewards: [] as never,
+      },
+    },
+    {
+      massValue: new BigNumber('100'),
+      resultContent: {
+        certificateRewards: [
+          createCertificateReward(HAULER, 'e1', 'e1', '33.3333333333'),
+          createCertificateReward(INTEGRATOR, 'e2', 'e2', '33.3333333333'),
+          createCertificateReward(RECYCLER, 'e3', 'e3', '33.3333333334'),
+        ],
+        massRewards: [] as never,
+      },
+    },
+    {
+      massValue: new BigNumber('500'),
+      resultContent: {
+        certificateRewards: [
+          createCertificateReward(HAULER, 's1', 's1', '50'),
+          createCertificateReward(RECYCLER, 's2', 's2', '50'),
+        ],
+        massRewards: [] as never,
+      },
+    },
+    {
+      massValue: new BigNumber('0'),
+      resultContent: {
+        certificateRewards: [
+          createCertificateReward(INTEGRATOR, 'b1', 'b1', '100'),
+        ],
+        massRewards: [] as never,
+      },
+    },
+    {
+      massValue: new BigNumber('9999999999.999999'),
+      resultContent: {
+        certificateRewards: [
+          createCertificateReward(HAULER, 'b2', 'b2', '0.0000000001'),
+          createCertificateReward(PROCESSOR, 'b3', 'b3', '99.9999999999'),
+        ],
+        massRewards: [] as never,
+      },
+    },
+  ];

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.test.helpers.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.test.helpers.ts
@@ -1,0 +1,57 @@
+import BigNumber from 'bignumber.js';
+import { validate } from 'typia';
+
+import type { RewardsDistribution } from './rewards-distribution.types';
+
+import {
+  AMOUNT_DECIMALS,
+  PERCENTAGE_DECIMALS,
+  roundAmount,
+} from './rewards-distribution.helpers';
+
+const PERCENTAGE_TOLERANCE = 0.000_001;
+
+/* istanbul ignore next */
+export const assertExpectedRewardsDistribution = (
+  unitPrice: number,
+  rewardsDistribution: RewardsDistribution,
+) => {
+  const { actors, massTotalValue, remainder } = rewardsDistribution;
+
+  expect(validate<RewardsDistribution>(rewardsDistribution).errors).toEqual([]);
+
+  const remainderPercentage = new BigNumber(remainder.percentage);
+  const totalAmount = roundAmount(
+    new BigNumber(massTotalValue).times(unitPrice),
+  ).toString();
+
+  let resultTotalAmount = new BigNumber(0);
+  let resultTotalPercentage = new BigNumber(0);
+
+  for (const actor of actors) {
+    const amount = new BigNumber(actor.amount);
+    const percentage = new BigNumber(actor.percentage);
+
+    expect(amount.toNumber()).toBeGreaterThanOrEqual(0);
+    expect(amount.decimalPlaces()).toBeLessThanOrEqual(AMOUNT_DECIMALS);
+
+    expect(percentage.toNumber()).toBeGreaterThanOrEqual(0);
+    expect(percentage.decimalPlaces()).toBeLessThanOrEqual(PERCENTAGE_DECIMALS);
+
+    resultTotalAmount = resultTotalAmount.plus(amount);
+    resultTotalPercentage = resultTotalPercentage.plus(percentage);
+  }
+
+  expect(resultTotalAmount.decimalPlaces()).toBeLessThanOrEqual(
+    AMOUNT_DECIMALS,
+  );
+  expect(resultTotalAmount.toString()).toBe(totalAmount);
+
+  expect(
+    new BigNumber(100).minus(resultTotalPercentage).toNumber(),
+  ).toBeLessThan(PERCENTAGE_TOLERANCE);
+  expect(remainderPercentage.decimalPlaces()).toBeLessThanOrEqual(
+    PERCENTAGE_DECIMALS,
+  );
+  expect(remainderPercentage.toNumber()).toBeGreaterThanOrEqual(0);
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.types.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/src/lib/rewards-distribution.types.ts
@@ -1,0 +1,41 @@
+import type {
+  CertificateRewardDistributionOutput,
+  DocumentEventActorType,
+  RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import type {
+  NonEmptyString,
+  NonZeroPositive,
+} from '@carrot-fndn/shared/types';
+import type BigNumber from 'bignumber.js';
+
+export interface ResultContentWithMassValue {
+  massValue: BigNumber;
+  resultContent: CertificateRewardDistributionOutput;
+}
+
+export interface Participant {
+  id: NonEmptyString;
+  name: NonEmptyString;
+}
+
+export interface Actor {
+  actorType: DocumentEventActorType.REMAINDER | RewardsDistributionActorType;
+  amount: NonEmptyString;
+  participant: Participant;
+  percentage: NonEmptyString;
+}
+
+export type ActorsByActorType = Map<string, Actor>;
+
+export interface RewardsDistribution {
+  actors: Actor[];
+  massTotalValue: NonEmptyString;
+  remainder: Remainder<string>;
+  unitPrice: NonZeroPositive;
+}
+
+export interface Remainder<T = BigNumber> {
+  amount: T;
+  percentage: T;
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.build.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../../../../../.tsconfig/tsconfig.build.json"
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.eslint.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.spec.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/credit/rewards-distribution/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../../../.tsconfig/tsconfig.spec.json"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/.eslintrc.js
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/.eslintrc.js
@@ -1,0 +1,7 @@
+const {
+  getBaseEslintConfig,
+} = require('../../../../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Cdf Address
+# Mass Audit Document Status
 
 Methodology: **BOLD-CARBON-ORGANIC**
 
@@ -10,13 +10,13 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📄 Description
 
-In an event, when there is a report identified as CDF, verify if the declared addresses for the participant identified in the event and the actor identified as Recycler are the same.
+Verify if all mass audit documents that make up the mass certificate have an approved status.
 
-## 📂 Implementation
+### 📂 Implementation
 
-- **[Main Implementation File](./src/lib/cdf-address.processor.ts)**
+- **[Main Implementation File](./src/lib/mass-audit-document-status.processor.ts)**
 
-## 👥 Contributors
+### 👥 Contributors
 
 [![AMarcosCastelo](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/43973049?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/AMarcosCastelo)
 [![andtankian](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/12521890?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/andtankian)

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/jest.config.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/jest.config.ts
@@ -1,0 +1,3 @@
+import { getJestBaseConfig } from '../../../../../../.jest/config/jest.base.config';
+
+export default getJestBaseConfig(__dirname);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/package.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@carrot-fndn/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status",
+  "version": "0.0.0"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/project.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "methodologies-bold-carbon-organic-rule-processors-mass-certificate-mass-audit-document-status",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["type:app", "methodology:bold"],
+  "sourceRoot": "apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src",
+  "projectType": "application",
+  "targets": {
+    "build-lambda": {},
+    "lint": {},
+    "package-lambda": {},
+    "upload-lambda": {},
+    "test": {},
+    "ts": {}
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lambda.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lambda.ts
@@ -1,0 +1,8 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { MassAuditDocumentStatusProcessor } from './lib/mass-audit-document-status.processor';
+
+const instance = new MassAuditDocumentStatusProcessor();
+
+// TODO: we can try to generate this code with a ts-patch program transformer
+export const handler = wrapRuleIntoLambdaHandler(instance);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lib/mass-audit-document-status.processor.e2e.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lib/mass-audit-document-status.processor.e2e.spec.ts
@@ -1,0 +1,115 @@
+import {
+  stubDocument,
+  stubDocumentEvent,
+  stubDocumentEventWithMetadataAttributes,
+  stubMassAuditDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  DocumentEventAttributeName,
+  DocumentEventName,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { CARROT_PARTICIPANT_BY_ENVIRONMENT } from '@carrot-fndn/methodologies/bold/recycling/organic/utils';
+import { pick, toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubArray,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import {
+  DataSetName,
+  MethodologyEvaluationResult,
+} from '@carrot-fndn/shared/types';
+import { faker } from '@faker-js/faker';
+import { random } from 'typia';
+
+import { handler } from '../lambda';
+
+describe('MassAuditDocumentStatusProcessor E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+  const parentDocumentId = faker.string.uuid();
+
+  const { CLOSE } = DocumentEventName;
+  const { METHODOLOGY_EVALUATION_RESULT } = DocumentEventAttributeName;
+  const { APPROVED } = MethodologyEvaluationResult;
+  const dataSetName = random<DataSetName>();
+
+  const document = stubDocument({
+    dataSetName,
+    parentDocumentId,
+  });
+
+  const relatedDocumentsOfParentDocument = stubArray(() =>
+    stubMassAuditDocument({
+      dataSetName,
+      externalEvents: [
+        stubDocumentEventWithMetadataAttributes(
+          {
+            name: CLOSE,
+            participant: {
+              id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development[
+                document.dataSetName
+              ].id,
+            },
+          },
+          [[METHODOLOGY_EVALUATION_RESULT, APPROVED]],
+        ),
+      ],
+    }),
+  );
+
+  const parentDocument = stubDocument({
+    dataSetName,
+    externalEvents: relatedDocumentsOfParentDocument.map((value) =>
+      stubDocumentEvent({
+        relatedDocument: {
+          ...pick(value, 'category', 'type', 'subtype'),
+          documentId: value.id,
+        },
+      }),
+    ),
+    id: parentDocumentId,
+    type: faker.string.sample(),
+  });
+
+  beforeAll(() => {
+    prepareEnvironmentTestE2E([
+      {
+        document,
+        documentKey: toDocumentKey({
+          documentId: document.id,
+          documentKeyPrefix,
+        }),
+      },
+      {
+        document: parentDocument,
+        documentKey: toDocumentKey({
+          documentId: parentDocumentId,
+          documentKeyPrefix,
+        }),
+      },
+      ...relatedDocumentsOfParentDocument.map((value) => ({
+        document: value,
+        documentKey: toDocumentKey({
+          documentId: value.id,
+          documentKeyPrefix,
+        }),
+      })),
+    ]);
+  });
+
+  it('should return APPROVED when documents matches mass audit and have approved close event', async () => {
+    const response = await handler(
+      stubRuleInput({
+        documentId: document.id,
+        documentKeyPrefix,
+      }),
+      stubContext(),
+      () => stubRuleResponse(),
+    );
+
+    expect(response).toMatchObject({ resultStatus: RuleOutputStatus.APPROVED });
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lib/mass-audit-document-status.processor.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lib/mass-audit-document-status.processor.spec.ts
@@ -1,0 +1,153 @@
+import { spyOnDocumentQueryServiceLoad } from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import {
+  stubDocument,
+  stubDocumentEvent,
+  stubDocumentEventWithMetadataAttributes,
+  stubMassAuditDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  DocumentEventAttributeName,
+  DocumentEventName,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { CARROT_PARTICIPANT_BY_ENVIRONMENT } from '@carrot-fndn/methodologies/bold/recycling/organic/utils';
+import { pick } from '@carrot-fndn/shared/helpers';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import { stubArray } from '@carrot-fndn/shared/testing';
+import {
+  DataSetName,
+  MethodologyEvaluationResult,
+} from '@carrot-fndn/shared/types';
+import { random } from 'typia';
+
+import { MassAuditDocumentStatusProcessor } from './mass-audit-document-status.processor';
+
+const { CLOSE } = DocumentEventName;
+const { METHODOLOGY_EVALUATION_RESULT } = DocumentEventAttributeName;
+const { APPROVED } = MethodologyEvaluationResult;
+
+describe('MassAuditDocumentStatusProcessor', () => {
+  const ruleDataProcessor = new MassAuditDocumentStatusProcessor();
+
+  it('should return APPROVED when related documents matches mass audit and have approved close event', async () => {
+    const ruleInput = random<Required<RuleInput>>();
+
+    const relatedDocumentsOfParentDocument = stubArray(() =>
+      stubMassAuditDocument({
+        dataSetName: DataSetName.TEST,
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes(
+            {
+              name: CLOSE,
+              participant: {
+                id: CARROT_PARTICIPANT_BY_ENVIRONMENT.development.TEST.id,
+              },
+            },
+            [[METHODOLOGY_EVALUATION_RESULT, APPROVED]],
+          ),
+        ],
+      }),
+    );
+
+    spyOnDocumentQueryServiceLoad(
+      stubDocument(),
+      relatedDocumentsOfParentDocument,
+    );
+
+    const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+    const expectedRuleOutput: RuleOutput = {
+      requestId: ruleInput.requestId,
+      responseToken: ruleInput.responseToken,
+      responseUrl: ruleInput.responseUrl,
+      resultComment: ruleDataProcessor['ResultComment'].APPROVED,
+      resultStatus: RuleOutputStatus.APPROVED,
+    };
+
+    expect(ruleOutput).toEqual(expectedRuleOutput);
+  });
+
+  it('should return REJECTED when the related documents do not match the mass audit criteria', async () => {
+    const ruleInput = random<Required<RuleInput>>();
+
+    const relatedDocumentsOfParentDocument = stubArray(() => stubDocument(), {
+      max: 10,
+      min: 2,
+    });
+
+    spyOnDocumentQueryServiceLoad(
+      stubDocument(),
+      stubArray(() => {
+        const document = stubMassAuditDocument();
+
+        document.externalEvents = relatedDocumentsOfParentDocument.map(
+          (value) =>
+            stubDocumentEvent({
+              relatedDocument: pick(value, 'id', 'category', 'type', 'subtype'),
+            }),
+        );
+
+        return document;
+      }),
+    );
+
+    const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+    const expectedRuleOutput: RuleOutput = {
+      requestId: ruleInput.requestId,
+      responseToken: ruleInput.responseToken,
+      responseUrl: ruleInput.responseUrl,
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
+      resultStatus: RuleOutputStatus.REJECTED,
+    };
+
+    expect(ruleOutput).toEqual(expectedRuleOutput);
+  });
+
+  it('should return REJECTED when the related documents matches mass audit but does not have a CLOSE event', async () => {
+    const ruleInput = random<Required<RuleInput>>();
+
+    const relatedDocumentsOfParentDocument = stubArray(() => {
+      const document = stubMassAuditDocument();
+
+      document.externalEvents = [
+        stubDocumentEvent({
+          name: DocumentEventName.MOVE,
+        }),
+      ];
+
+      return document;
+    });
+
+    spyOnDocumentQueryServiceLoad(
+      stubDocument(),
+      stubArray(() => {
+        const document = stubMassAuditDocument();
+
+        document.externalEvents = relatedDocumentsOfParentDocument.map(
+          (value) =>
+            stubDocumentEvent({
+              relatedDocument: pick(value, 'id', 'category', 'type', 'subtype'),
+            }),
+        );
+
+        return document;
+      }),
+    );
+
+    const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+    const expectedRuleOutput: RuleOutput = {
+      requestId: ruleInput.requestId,
+      responseToken: ruleInput.responseToken,
+      responseUrl: ruleInput.responseUrl,
+      resultComment: ruleDataProcessor['ResultComment'].REJECTED,
+      resultStatus: RuleOutputStatus.REJECTED,
+    };
+
+    expect(ruleOutput).toEqual(expectedRuleOutput);
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lib/mass-audit-document-status.processor.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/src/lib/mass-audit-document-status.processor.ts
@@ -1,0 +1,104 @@
+import {
+  type DocumentQuery,
+  DocumentQueryService,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import { MASS_AUDIT } from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+import {
+  and,
+  eventHasCarrotParticipant,
+  eventNameIsAnyOf,
+  metadataAttributeValueIsAnyOf,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/predicates';
+import {
+  type Document,
+  DocumentEventAttributeName,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { DocumentEventName } from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { mapDocumentReference } from '@carrot-fndn/methodologies/bold/recycling/organic/utils';
+import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import { MethodologyEvaluationResult } from '@carrot-fndn/shared/types';
+
+const { CLOSE } = DocumentEventName;
+const { METHODOLOGY_EVALUATION_RESULT } = DocumentEventAttributeName;
+const { APPROVED } = MethodologyEvaluationResult;
+
+export class MassAuditDocumentStatusProcessor extends RuleDataProcessor {
+  private readonly ResultComment = {
+    APPROVED:
+      'All related documents have a CLOSE event with methodology-evaluation-result = APPROVED',
+    REJECTED: 'Some related documents do not meet the criteria',
+  };
+
+  private evaluateResult(ruleInput: RuleInput, documents: Array<Document>) {
+    const hasCloseEventWithNetworkActor = documents.every((document) =>
+      document.externalEvents?.some(
+        and(
+          eventNameIsAnyOf([CLOSE]),
+          metadataAttributeValueIsAnyOf(METHODOLOGY_EVALUATION_RESULT, [
+            APPROVED,
+          ]),
+          (event) => eventHasCarrotParticipant(event, document.dataSetName),
+        ),
+      ),
+    );
+
+    if (!hasCloseEventWithNetworkActor) {
+      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
+        resultComment: this.ResultComment.REJECTED,
+      });
+    }
+
+    return mapToRuleOutput(ruleInput, RuleOutputStatus.APPROVED, {
+      resultComment: this.ResultComment.APPROVED,
+    });
+  }
+
+  private async generateDocumentQuery(
+    documentKeyPrefix: string,
+    documentId: string,
+  ) {
+    const documentQueryService = new DocumentQueryService(
+      provideDocumentLoaderService,
+    );
+
+    return documentQueryService.load({
+      context: {
+        s3KeyPrefix: documentKeyPrefix,
+      },
+      criteria: {
+        parentDocument: {
+          relatedDocuments: [MASS_AUDIT.match],
+        },
+      },
+      documentId,
+    });
+  }
+
+  private async getRuleSubject(documentQuery: DocumentQuery<Document>) {
+    const documents = await documentQuery.iterator().map(({ document }) => ({
+      ...document,
+    }));
+
+    return documents.filter((document) =>
+      MASS_AUDIT.matches(mapDocumentReference(document)),
+    );
+  }
+
+  async process(ruleInput: RuleInput): Promise<RuleOutput> {
+    const documentQuery = await this.generateDocumentQuery(
+      ruleInput.documentKeyPrefix,
+      ruleInput.documentId,
+    );
+
+    const documents = await this.getRuleSubject(documentQuery);
+
+    return this.evaluateResult(ruleInput, documents);
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.build.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../../../../../.tsconfig/tsconfig.build.json"
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.eslint.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.spec.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/mass-audit-document-status/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../../../.tsconfig/tsconfig.spec.json"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/.eslintrc.js
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/.eslintrc.js
@@ -1,0 +1,5 @@
+const { getBaseEslintConfig } = require('../../../../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Cdf Address
+# Rewards Distribution
 
 Methodology: **BOLD-CARBON-ORGANIC**
 
@@ -10,13 +10,13 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📄 Description
 
-In an event, when there is a report identified as CDF, verify if the declared addresses for the participant identified in the event and the actor identified as Recycler are the same.
+Calculate rewards percentage rights for the participants that contributed to the Circular Economy cycle in this document.
 
-## 📂 Implementation
+### 📂 Implementation
 
-- **[Main Implementation File](./src/lib/cdf-address.processor.ts)**
+- **[Main Implementation File](./src/lib/rewards-distribution.processor.ts)**
 
-## 👥 Contributors
+### 👥 Contributors
 
 [![AMarcosCastelo](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/43973049?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/AMarcosCastelo)
 [![andtankian](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/12521890?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/andtankian)

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/jest.config.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/jest.config.ts
@@ -1,0 +1,3 @@
+import { getJestBaseConfig } from '../../../../../../.jest/config/jest.base.config';
+
+export default getJestBaseConfig(__dirname);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/package.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@carrot-fndn/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution",
+  "version": "0.0.0"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/project.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "methodologies-bold-carbon-organic-rule-processors-mass-certificate-rewards-distribution",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["type:app", "app:any", "stack:any", "methodology:bold"],
+  "sourceRoot": "apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src",
+  "projectType": "application",
+  "targets": {
+    "build-lambda": {},
+    "lint": {},
+    "package-lambda": {},
+    "upload-lambda": {},
+    "test": {},
+    "ts": {}
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lambda.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lambda.ts
@@ -1,0 +1,8 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { RewardsDistributionProcessor } from './lib';
+
+const instance = new RewardsDistributionProcessor();
+
+// TODO: we can try to generate this code with a ts-patch program transformer
+export const handler = wrapRuleIntoLambdaHandler(instance);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/index.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './rewards-distribution.processor';

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.constants.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.constants.ts
@@ -1,0 +1,112 @@
+import type { DocumentCriteria } from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+
+import {
+  MASS_AUDIT,
+  METHODOLOGY_DEFINITION,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+import {
+  DocumentEventActorType,
+  MassSubtype,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import BigNumber from 'bignumber.js';
+
+import type { RewardsDistribution } from './rewards-distribution.types';
+
+const {
+  APPOINTED_NGO,
+  HAULER,
+  INTEGRATOR,
+  METHODOLOGY_AUTHOR,
+  METHODOLOGY_DEVELOPER,
+  NETWORK,
+  PROCESSOR,
+  RECYCLER,
+  SOURCE,
+} = DocumentEventActorType;
+
+export const REQUIRED_ACTOR_TYPES = {
+  MASS: [SOURCE, RECYCLER, PROCESSOR, INTEGRATOR],
+  METHODOLOGY: [
+    APPOINTED_NGO,
+    METHODOLOGY_AUTHOR,
+    METHODOLOGY_DEVELOPER,
+    NETWORK,
+  ],
+};
+
+export const REWARDS_DISTRIBUTION: RewardsDistribution = {
+  FOOD_WASTE: {
+    [APPOINTED_NGO]: BigNumber(0),
+    [HAULER]: BigNumber(0.1),
+    [INTEGRATOR]: BigNumber(0.08),
+    [METHODOLOGY_AUTHOR]: BigNumber(0.01),
+    [METHODOLOGY_DEVELOPER]: BigNumber(0.01),
+    [NETWORK]: BigNumber(0.2),
+    [PROCESSOR]: BigNumber(0.1),
+    [RECYCLER]: BigNumber(0.2),
+    [SOURCE]: BigNumber(0.3),
+  },
+  OTHER_ORGANIC_WASTE: {
+    [APPOINTED_NGO]: BigNumber(0),
+    [HAULER]: BigNumber(0.1),
+    [INTEGRATOR]: BigNumber(0.08),
+    [METHODOLOGY_AUTHOR]: BigNumber(0.01),
+    [METHODOLOGY_DEVELOPER]: BigNumber(0.01),
+    [NETWORK]: BigNumber(0.2),
+    [PROCESSOR]: BigNumber(0.1),
+    [RECYCLER]: BigNumber(0.2),
+    [SOURCE]: BigNumber(0.3),
+  },
+  SLUDGE: {
+    [APPOINTED_NGO]: BigNumber(0),
+    [HAULER]: BigNumber(0.05),
+    [INTEGRATOR]: BigNumber(0.08),
+    [METHODOLOGY_AUTHOR]: BigNumber(0.01),
+    [METHODOLOGY_DEVELOPER]: BigNumber(0.01),
+    [NETWORK]: BigNumber(0.2),
+    [PROCESSOR]: BigNumber(0.1),
+    [RECYCLER]: BigNumber(0.3),
+    [SOURCE]: BigNumber(0.25),
+  },
+};
+
+export enum RewardsDistributionWasteType {
+  FOOD_WASTE = 'FOOD_WASTE',
+  OTHER_ORGANIC_WASTE = 'OTHER_ORGANIC_WASTE',
+  SLUDGE = 'SLUDGE',
+}
+
+export const REWARDS_DISTRIBUTION_BY_WASTE_TYPE: Record<
+  MassSubtype,
+  RewardsDistributionWasteType
+> = {
+  [MassSubtype.AGRO_INDUSTRIAL]:
+    RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+  [MassSubtype.ANIMAL_MANURE]: RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+  [MassSubtype.ANIMAL_WASTE_MANAGEMENT]:
+    RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+  [MassSubtype.DOMESTIC_SLUDGE]: RewardsDistributionWasteType.SLUDGE,
+  [MassSubtype.FOOD_WASTE]: RewardsDistributionWasteType.FOOD_WASTE,
+  [MassSubtype.GARDEN_AND_PARK_WASTE]:
+    RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+  [MassSubtype.INDUSTRIAL_FOOD_WASTE]: RewardsDistributionWasteType.FOOD_WASTE,
+  [MassSubtype.INDUSTRIAL_SLUDGE]: RewardsDistributionWasteType.SLUDGE,
+  [MassSubtype.OTHER_NON_DANGEROUS_ORGANICS]:
+    RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+  [MassSubtype.WOOD]: RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+  [MassSubtype.WOOD_AND_WOOD_PRODUCTS]:
+    RewardsDistributionWasteType.OTHER_ORGANIC_WASTE,
+};
+
+export const REWARDS_DISTRIBUTION_CRITERIA: DocumentCriteria = {
+  parentDocument: {
+    relatedDocuments: [
+      {
+        omit: true,
+        parentDocument: {},
+        ...MASS_AUDIT.match,
+      },
+    ],
+  },
+  relatedDocuments: [METHODOLOGY_DEFINITION.match],
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.helpers.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.helpers.ts
@@ -1,0 +1,135 @@
+import {
+  and,
+  eventNameIsAnyOf,
+  metadataAttributeValueIsAnyOf,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/predicates';
+import {
+  type Document,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  type MassReward,
+  type RewardActorParticipant,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { DocumentEventName } from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { isNil } from '@carrot-fndn/shared/helpers';
+import BigNumber from 'bignumber.js';
+
+import type {
+  ActorReward,
+  RewardsDistributionActor,
+} from './rewards-distribution.types';
+
+import { REQUIRED_ACTOR_TYPES } from './rewards-distribution.constants';
+
+export const checkIfHaulerActorExists = (
+  participants: RewardsDistributionActor[],
+) => participants.some(({ type }) => type === DocumentEventActorType.HAULER);
+
+export const sumBigNumbers = (values: BigNumber[]): BigNumber => {
+  let result = new BigNumber(0);
+
+  for (const value of values) {
+    result = result.plus(value);
+  }
+
+  return result;
+};
+
+export const getDocumentsTotalMassWeight = (documents: Document[]): BigNumber =>
+  sumBigNumbers(
+    documents.map(({ currentValue }) => new BigNumber(currentValue)),
+  );
+
+export const formatPercentage = (percentage: BigNumber): string =>
+  percentage.multipliedBy(100).toString();
+
+export const mapMassRewards = (participants: ActorReward[]): MassReward[] =>
+  participants.map(
+    ({
+      actorType,
+      document,
+      massCertificatePercentage,
+      massPercentage,
+      participant,
+    }) => ({
+      actorType,
+      documentId: document.id,
+      massCertificatePercentage: formatPercentage(massCertificatePercentage),
+      massPercentage: formatPercentage(massPercentage),
+      participant,
+    }),
+  );
+
+export const getActorPercentageOfMassCertificate = (
+  document: Document,
+  participantPercentage: BigNumber,
+  documentsTotalMassWeight: BigNumber,
+): BigNumber => {
+  const participantMassWeight = new BigNumber(
+    participantPercentage,
+  ).multipliedBy(document.currentValue);
+
+  return participantMassWeight.div(documentsTotalMassWeight);
+};
+
+export const mapActorReward = ({
+  actorType,
+  document,
+  massPercentage,
+  participant,
+  totalMassOfDocuments,
+}: {
+  actorType: RewardsDistributionActorType;
+  document: Document;
+  massPercentage: BigNumber;
+  participant: RewardActorParticipant;
+  totalMassOfDocuments: BigNumber;
+}): ActorReward => ({
+  actorType,
+  document,
+  massCertificatePercentage: getActorPercentageOfMassCertificate(
+    document,
+    massPercentage,
+    totalMassOfDocuments,
+  ),
+  massPercentage,
+  participant,
+});
+
+export const getActorsByType = ({
+  actorType,
+  actors,
+  methodologyDocument,
+}: {
+  actorType: RewardsDistributionActorType;
+  actors: RewardsDistributionActor[];
+  methodologyDocument: Document;
+}): RewardsDistributionActor[] => {
+  if (REQUIRED_ACTOR_TYPES.METHODOLOGY.includes(actorType)) {
+    const methodologyParticipant = methodologyDocument.externalEvents?.find(
+      and(
+        eventNameIsAnyOf([DocumentEventName.ACTOR]),
+        metadataAttributeValueIsAnyOf(DocumentEventAttributeName.ACTOR_TYPE, [
+          actorType,
+        ]),
+      ),
+    )?.participant;
+
+    if (isNil(methodologyParticipant)) {
+      throw new Error(`${actorType} not found in the methodology document`);
+    }
+
+    return [
+      {
+        participant: {
+          id: methodologyParticipant.id,
+          name: methodologyParticipant.name,
+        },
+        type: actorType,
+      },
+    ];
+  }
+
+  return actors.filter(({ type }) => type === actorType);
+};

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.e2e.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.e2e.spec.ts
@@ -1,0 +1,113 @@
+// No changes needed - imports are already correctly structured with:
+// - DocumentEventName from '@carrot-fndn/methodologies/bold/recycling/organic/types'
+// - Other imports remain unchanged
+
+import {
+  stubDocumentEvent,
+  stubMassAuditDocument,
+  stubMassCertificateAuditDocument,
+  stubMassCertificateDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  DocumentCategory,
+  DocumentEventName,
+  type DocumentReference,
+  DocumentSubtype,
+  DocumentType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubArray,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+
+import { handler } from '../lambda';
+import {
+  stubMassDocumentWithRequiredActors,
+  stubMethodologyWithRequiredActors,
+} from './rewards-distribution.stubs';
+
+describe('RewardsDistributionProcessor E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+
+  const methodologyReference: DocumentReference = {
+    category: DocumentCategory.METHODOLOGY,
+    documentId: faker.string.uuid(),
+    type: DocumentType.DEFINITION,
+  };
+
+  const organicMasses = stubArray(() =>
+    stubMassDocumentWithRequiredActors({
+      subtype: DocumentSubtype.FOOD_WASTE,
+    }),
+  );
+  const massAudits = organicMasses.map(({ id }) =>
+    stubMassAuditDocument({
+      parentDocumentId: id,
+    }),
+  );
+  const methodologyDocument = stubMethodologyWithRequiredActors({
+    id: methodologyReference.documentId,
+  });
+  const externalEvents = massAudits.map(({ category, id, subtype, type }) =>
+    stubDocumentEvent({
+      relatedDocument: {
+        category,
+        documentId: id,
+        subtype,
+        type,
+      },
+    }),
+  );
+  const massCertificate = stubMassCertificateDocument({
+    externalEvents,
+  });
+  const massCertificateAudit = stubMassCertificateAuditDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        name: DocumentEventName.ACTOR,
+        referencedDocument: methodologyReference,
+        relatedDocument: undefined,
+      }),
+    ],
+    parentDocumentId: massCertificate.id,
+  });
+
+  const documents = [
+    massCertificate,
+    massCertificateAudit,
+    methodologyDocument,
+    ...organicMasses,
+    ...massAudits,
+  ];
+
+  beforeAll(() => {
+    prepareEnvironmentTestE2E(
+      documents.map((document) => ({
+        document,
+        documentKey: toDocumentKey({
+          documentId: document.id,
+          documentKeyPrefix,
+        }),
+      })),
+    );
+  });
+
+  it('should return resultStatus approved when all massCertificates containing mass documents are correct', async () => {
+    const response = await handler(
+      stubRuleInput({
+        documentId: massCertificateAudit.id,
+        documentKeyPrefix,
+      }),
+      stubContext(),
+      () => stubRuleResponse(),
+    );
+
+    expect(response).toMatchObject({ resultStatus: RuleOutputStatus.APPROVED });
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.errors.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.errors.ts
@@ -1,0 +1,49 @@
+import { logger } from '@carrot-fndn/shared/helpers';
+import { AWSLambda } from '@sentry/serverless';
+
+export class RewardsDistributionProcessorErrors {
+  private readonly KNOWN_ERROR_PREFIX = String(Symbol('[KNOWN ERROR]: '));
+
+  readonly ERROR_MESSAGE = {
+    DOCUMENT_DOES_NOT_CONTAIN_EVENTS: (documentId: string) =>
+      `Document ${documentId} does not contain events`,
+    MASS_DOCUMENTS_NOT_FOUND: 'Mass documents not found',
+    METHODOLOGY_DOCUMENT_NOT_FOUND: 'Methodology document not found',
+    MISSING_REQUIRED_ACTORS: (documentId: string, actorTypes: string[]) =>
+      `Missing required actor types "${actorTypes.join(', ')}" in the document ${documentId}`,
+    REJECTED_BY_ERROR: 'Unable to calculate rewards distribution',
+    UNEXPECTED_DOCUMENT_SUBTYPE: 'Unexpected document subtype',
+  } as const;
+
+  private getKnownErrorMessage(error: Error): string {
+    return error.message.replace(this.KNOWN_ERROR_PREFIX, '');
+  }
+
+  private isKnownError(error: unknown): error is Error {
+    return (
+      error instanceof Error &&
+      error.message.startsWith(this.KNOWN_ERROR_PREFIX)
+    );
+  }
+
+  private processKnownError(error: unknown): string | undefined {
+    if (this.isKnownError(error)) {
+      return this.getKnownErrorMessage(error);
+    }
+
+    logger.error(error, 'Unexpected error on "processKnownError" method');
+    AWSLambda.captureException(error);
+
+    return undefined;
+  }
+
+  getKnownError(message: string): Error {
+    return new Error(this.KNOWN_ERROR_PREFIX + message);
+  }
+
+  getResultCommentFromError(error: unknown): string {
+    return (
+      this.processKnownError(error) || this.ERROR_MESSAGE.REJECTED_BY_ERROR
+    );
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.spec.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.spec.ts
@@ -1,0 +1,776 @@
+import { getEventAttributeValue } from '@carrot-fndn/methodologies/bold/recycling/organic/getters';
+import {
+  DocumentQueryService,
+  spyOnDocumentQueryServiceLoad,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import { isActorEventWithSourceActorType } from '@carrot-fndn/methodologies/bold/recycling/organic/predicates';
+import {
+  stubAddress,
+  stubDocument,
+  stubDocumentEvent,
+  stubMassDocument,
+  stubMethodologyDefinitionDocument,
+  stubParticipant,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type CertificateReward,
+  type CertificateRewardDistributionOutput,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentSubtype,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { sumBigNumbers } from '@carrot-fndn/shared/helpers';
+import {
+  type RuleInput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import { stubArray } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+import BigNumber from 'bignumber.js';
+import { random, validate } from 'typia';
+
+import {
+  REQUIRED_ACTOR_TYPES,
+  REWARDS_DISTRIBUTION,
+} from './rewards-distribution.constants';
+import { formatPercentage } from './rewards-distribution.helpers';
+import { RewardsDistributionProcessor } from './rewards-distribution.processor';
+import { RewardsDistributionProcessorErrors } from './rewards-distribution.processor.errors';
+import {
+  requiredMassActorEvents,
+  requiredMethodologyActorsEvents,
+  stubMassDocumentWithRequiredActors,
+  stubMethodologyWithRequiredActors,
+} from './rewards-distribution.stubs';
+
+const requiredActorEvents = [
+  ...requiredMethodologyActorsEvents,
+  ...requiredMassActorEvents,
+].sort((a, b) =>
+  a.metadata!.attributes![0]!.value! > b.metadata!.attributes![0]!.value!
+    ? 1
+    : -1,
+);
+
+const {
+  APPOINTED_NGO,
+  METHODOLOGY_AUTHOR,
+  METHODOLOGY_DEVELOPER,
+  NETWORK,
+  SOURCE,
+} = DocumentEventActorType;
+
+const ALL_ACTOR_TYPES = [
+  ...REQUIRED_ACTOR_TYPES.MASS,
+  APPOINTED_NGO,
+  METHODOLOGY_DEVELOPER,
+  METHODOLOGY_AUTHOR,
+  NETWORK,
+];
+
+const NETWORK_REWARD_DISTRIBUTION_WASTE_NOT_IDENTIFIED = {
+  WITH_HAULER: BigNumber(60),
+  WITHOUT_HAULER: BigNumber(67.5),
+};
+
+const requiredActorEventsWithNoWasteOriginIdentified =
+  requiredMassActorEvents.map((actorEvent) => {
+    if (isActorEventWithSourceActorType(actorEvent)) {
+      return {
+        ...actorEvent,
+        metadata: {
+          attributes: [
+            ...(actorEvent.metadata?.attributes ?? []),
+            {
+              isPublic: faker.datatype.boolean(),
+              name: DocumentEventAttributeName.WASTE_ORIGIN_IDENTIFIED,
+              value: false,
+            },
+          ],
+        },
+      };
+    }
+
+    return actorEvent;
+  });
+
+const fiftyPercentageDiscount = (value: BigNumber): BigNumber =>
+  value.multipliedBy('0.5');
+
+describe('RewardsDistributionProcessor', () => {
+  const service = new RewardsDistributionProcessor();
+  const errorProcessor = new RewardsDistributionProcessorErrors();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return "REJECTED" when Mass documents is not found', async () => {
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), []);
+
+    const result = await service.process(data);
+
+    expect(result).toMatchObject({
+      resultComment: errorProcessor.ERROR_MESSAGE.MASS_DOCUMENTS_NOT_FOUND,
+      resultStatus: RuleOutputStatus.REJECTED,
+    });
+  });
+
+  it('should return "REJECTED" when the methodology document does not extist', async () => {
+    const documents = [stubMassDocument()];
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), documents);
+
+    const result = await service.process(data);
+
+    expect(result).toMatchObject({
+      resultComment:
+        errorProcessor.ERROR_MESSAGE.METHODOLOGY_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.REJECTED,
+    });
+  });
+
+  it('should return "REJECTED" when the methodology document does not have the required actors', async () => {
+    const documents = [
+      stubMassDocumentWithRequiredActors({
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+      stubMethodologyDefinitionDocument({
+        externalEvents: [],
+      }),
+    ];
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), documents);
+
+    const result = await service.process(data);
+
+    expect(result).toMatchObject({
+      resultComment: errorProcessor.ERROR_MESSAGE.REJECTED_BY_ERROR,
+      resultStatus: RuleOutputStatus.REJECTED,
+    });
+  });
+
+  it('should return "REJECTED" when mass document does not contain the required actors', async () => {
+    const documents = [
+      stubMassDocumentWithRequiredActors({
+        subtype: DocumentSubtype.INDUSTRIAL_FOOD_WASTE,
+      }),
+      stubMassDocument({
+        externalEvents: [
+          stubDocumentEvent({
+            metadata: {
+              attributes: [
+                {
+                  isPublic: faker.datatype.boolean(),
+                  name: DocumentEventAttributeName.ACTOR_TYPE,
+                  value: DocumentEventActorType.SOURCE,
+                },
+              ],
+            },
+            name: DocumentEventName.ACTOR,
+          }),
+        ],
+      }),
+      stubMethodologyWithRequiredActors(),
+    ];
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), documents);
+
+    const result = await service.process(data);
+
+    expect(result).toMatchObject({
+      resultComment: errorProcessor.ERROR_MESSAGE.MISSING_REQUIRED_ACTORS(
+        documents[1]?.id as string,
+        REQUIRED_ACTOR_TYPES.MASS.filter((actorType) => actorType !== SOURCE),
+      ),
+      resultStatus: RuleOutputStatus.REJECTED,
+    });
+  });
+
+  it('should return "REJECTED" when a unknown error is throwed', async () => {
+    const data = random<RuleInput>();
+
+    jest
+      .spyOn(DocumentQueryService.prototype, 'load')
+      .mockRejectedValueOnce(new Error(faker.string.uuid()));
+
+    const result = await service.process(data);
+
+    expect(result).toMatchObject({
+      resultComment: errorProcessor.ERROR_MESSAGE.REJECTED_BY_ERROR,
+      resultStatus: RuleOutputStatus.REJECTED,
+    });
+  });
+
+  it.each([
+    {
+      document: { ...stubMassDocument(), externalEvents: undefined },
+      resultComment: (documentId?: string) =>
+        errorProcessor.ERROR_MESSAGE.DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
+          documentId as string,
+        ),
+      scenario: 'the document does not contain events',
+    },
+    {
+      document: stubMassDocumentWithRequiredActors({
+        subtype: faker.string.uuid(),
+      }),
+      resultComment: () =>
+        errorProcessor.ERROR_MESSAGE.UNEXPECTED_DOCUMENT_SUBTYPE,
+      scenario: 'document subtype is unknown',
+    },
+  ])(
+    'should return "REJECTED" when $scenario',
+    async ({ document, resultComment }) => {
+      const data = random<RuleInput>();
+
+      spyOnDocumentQueryServiceLoad(stubDocument(), [
+        document,
+        stubMethodologyWithRequiredActors(),
+      ]);
+
+      const result = await service.process(data);
+
+      expect(result).toMatchObject({
+        resultComment: resultComment(document.id),
+        resultStatus: RuleOutputStatus.REJECTED,
+      });
+    },
+  );
+
+  it('should return "APPROVED" with certificateRewards and massRewards', async () => {
+    const massDocuments = stubArray(() =>
+      stubMassDocumentWithRequiredActors({
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+    );
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), [
+      ...massDocuments,
+      stubMethodologyWithRequiredActors(),
+    ]);
+
+    const result = await service.process(data);
+
+    const totalPercentageOfCertificateOfMassRewards = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).massRewards.map(
+        ({ massCertificatePercentage }) =>
+          new BigNumber(massCertificatePercentage),
+      ),
+    );
+
+    const totalPercentageOfCertificateOfCertificateReward = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).certificateRewards.map(({ percentage }) => new BigNumber(percentage)),
+    );
+
+    expect(result.resultStatus).toBe(RuleOutputStatus.APPROVED);
+
+    expect(result.resultContent).toMatchObject({
+      certificateRewards: expect.arrayContaining(
+        requiredActorEvents.map((actorEvent) => {
+          const actorType = getEventAttributeValue(
+            actorEvent,
+            DocumentEventAttributeName.ACTOR_TYPE,
+          );
+
+          return {
+            actorType,
+            participant: {
+              id: actorEvent.participant.id,
+              name: actorEvent.participant.name,
+            },
+            percentage: expect.stringMatching(/^\d+(\.\d{8}$)?/),
+          };
+        }),
+      ),
+      massRewards: massDocuments.flatMap((document) =>
+        requiredActorEvents.flatMap((actorEvent) => {
+          const type = getEventAttributeValue(
+            actorEvent,
+            DocumentEventAttributeName.ACTOR_TYPE,
+          );
+
+          return {
+            actorType: type,
+            documentId: document.id,
+            massCertificatePercentage: expect.any(String),
+            massPercentage: expect.any(String),
+            participant: {
+              id: actorEvent.participant.id,
+              name: actorEvent.participant.name,
+            },
+          };
+        }),
+      ),
+    });
+    expect(totalPercentageOfCertificateOfCertificateReward.toString()).toBe(
+      totalPercentageOfCertificateOfMassRewards.toString(),
+    );
+    expect(
+      Math.round(totalPercentageOfCertificateOfCertificateReward.toNumber()),
+    ).toBe(100);
+  });
+
+  it('should apply mass origin identification rule and return correct rewards', async () => {
+    const documents = [
+      stubMassDocument({
+        externalEvents: requiredActorEventsWithNoWasteOriginIdentified,
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+      stubMethodologyWithRequiredActors(),
+    ];
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), documents);
+
+    const result = await service.process(data);
+
+    expect(result.resultStatus).toBe(RuleOutputStatus.APPROVED);
+
+    const totalPercentageOfCertificateMassRewards = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).massRewards.map(
+        ({ massCertificatePercentage }) =>
+          new BigNumber(massCertificatePercentage),
+      ),
+    );
+
+    const totalPercentageOfCertificateRewards = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).certificateRewards.map(({ percentage }) => new BigNumber(percentage)),
+    );
+
+    expect(totalPercentageOfCertificateMassRewards.toString()).toBe(
+      totalPercentageOfCertificateRewards.toString(),
+    );
+    expect(Math.round(totalPercentageOfCertificateRewards.toNumber())).toBe(
+      100,
+    );
+
+    const networkReward = (
+      result.resultContent as CertificateRewardDistributionOutput
+    ).massRewards.find(
+      ({ actorType }) => actorType === DocumentEventActorType.NETWORK,
+    );
+
+    expect(networkReward?.massPercentage).toBe('67.5'); // NETWORK + SOURCE (100%) + HAULER (100%) + RECYCLER (25%) + PROCESSOR (25%)
+  });
+
+  it('should apply mass origin identification rule and return correct rewards when there is HAULER actor', async () => {
+    const actorEvents = [
+      ...requiredActorEventsWithNoWasteOriginIdentified,
+      stubDocumentEvent({
+        metadata: {
+          attributes: [
+            {
+              isPublic: faker.datatype.boolean(),
+              name: DocumentEventAttributeName.ACTOR_TYPE,
+              value: DocumentEventActorType.HAULER,
+            },
+          ],
+        },
+        name: DocumentEventName.ACTOR,
+      }),
+    ];
+
+    const documents = [
+      stubMassDocument({
+        externalEvents: actorEvents,
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+      stubMethodologyWithRequiredActors(),
+    ];
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), documents);
+
+    const result = await service.process(data);
+
+    expect(result.resultStatus).toBe(RuleOutputStatus.APPROVED);
+
+    const totalPercentageOfMassRewards = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).massRewards.map(({ massPercentage }) => new BigNumber(massPercentage)),
+    );
+
+    const totalPercentageCertificateRewards = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).certificateRewards.map(({ percentage }) => new BigNumber(percentage)),
+    );
+
+    expect(totalPercentageOfMassRewards.toString()).toBe(
+      totalPercentageCertificateRewards.toString(),
+    );
+    expect(Math.round(totalPercentageCertificateRewards.toNumber())).toBe(100);
+
+    const networkReward = (
+      result.resultContent as CertificateRewardDistributionOutput
+    ).massRewards.find(
+      ({ actorType }) => actorType === DocumentEventActorType.NETWORK,
+    );
+
+    expect(networkReward?.massPercentage).toBe(
+      NETWORK_REWARD_DISTRIBUTION_WASTE_NOT_IDENTIFIED.WITH_HAULER.toString(),
+    ); // NETWORK + SOURCE (100%) + HAULER (25%) + RECYCLER (25%) + PROCESSOR (25%)
+  });
+
+  it('should apply mass origin identification rule and return correct rewards for multiple documents', async () => {
+    const withNoWasteOriginIdentified = faker.string.uuid();
+    const withWasteOriginIdentified = faker.string.uuid();
+
+    const documents = [
+      stubMassDocument({
+        externalEvents: requiredActorEventsWithNoWasteOriginIdentified,
+        id: withNoWasteOriginIdentified,
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+      stubMassDocument({
+        externalEvents: requiredActorEvents,
+        id: withWasteOriginIdentified,
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+      stubMethodologyWithRequiredActors(),
+    ];
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), documents);
+
+    const result = await service.process(data);
+
+    expect(result.resultStatus).toBe(RuleOutputStatus.APPROVED);
+
+    const totalPercentOfCertificateMassReward = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).massRewards.map(
+        ({ massCertificatePercentage }) =>
+          new BigNumber(massCertificatePercentage),
+      ),
+    );
+
+    const totalPercentageOfCertificateRewards = sumBigNumbers(
+      (
+        result.resultContent as CertificateRewardDistributionOutput
+      ).certificateRewards.map(({ percentage }) => new BigNumber(percentage)),
+    );
+
+    expect(totalPercentOfCertificateMassReward.toString()).toBe(
+      totalPercentageOfCertificateRewards.toString(),
+    );
+
+    expect(Math.round(totalPercentageOfCertificateRewards.toNumber())).toBe(
+      100,
+    );
+
+    const networkParticipantOfWasteNotIdentified = (
+      result.resultContent as CertificateRewardDistributionOutput
+    ).massRewards.find(
+      ({ actorType, documentId }) =>
+        actorType === DocumentEventActorType.NETWORK &&
+        documentId === withNoWasteOriginIdentified,
+    );
+
+    const networkParticipantOfWasteIdentified = (
+      result.resultContent as CertificateRewardDistributionOutput
+    ).massRewards.find(
+      ({ actorType, documentId }) =>
+        actorType === DocumentEventActorType.NETWORK &&
+        documentId === withWasteOriginIdentified,
+    );
+
+    expect(networkParticipantOfWasteNotIdentified?.massPercentage).toBe(
+      NETWORK_REWARD_DISTRIBUTION_WASTE_NOT_IDENTIFIED.WITHOUT_HAULER.toString(),
+    ); // NETWORK + SOURCE (100%) + HAULER (100%) + RECYCLER (25%) + PROCESSOR (25%)
+
+    expect(networkParticipantOfWasteIdentified?.massPercentage).toBe(
+      REWARDS_DISTRIBUTION.SLUDGE.NETWORK.multipliedBy(100).toString(),
+    ); // ONLY NETWORK
+  });
+
+  it.each([
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.OTHER_ORGANIC_WASTE,
+      subtype: DocumentSubtype.AGRO_INDUSTRIAL,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.OTHER_ORGANIC_WASTE,
+      subtype: DocumentSubtype.ANIMAL_MANURE,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.OTHER_ORGANIC_WASTE,
+      subtype: DocumentSubtype.ANIMAL_WASTE_MANAGEMENT,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.SLUDGE,
+      subtype: DocumentSubtype.DOMESTIC_SLUDGE,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.FOOD_WASTE,
+      subtype: DocumentSubtype.FOOD_WASTE,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.OTHER_ORGANIC_WASTE,
+      subtype: DocumentSubtype.GARDEN_AND_PARK_WASTE,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.FOOD_WASTE,
+      subtype: DocumentSubtype.INDUSTRIAL_FOOD_WASTE,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.SLUDGE,
+      subtype: DocumentSubtype.INDUSTRIAL_SLUDGE,
+    },
+    {
+      rewardDistribution: REWARDS_DISTRIBUTION.OTHER_ORGANIC_WASTE,
+      subtype: DocumentSubtype.OTHER_NON_DANGEROUS_ORGANICS,
+    },
+  ])(
+    'should return "APPROVED" with certificateRewards and massRewards for $subtype',
+    async ({ rewardDistribution, subtype }) => {
+      const actorEvents = [
+        ...requiredMassActorEvents,
+        stubDocumentEvent({
+          metadata: {
+            attributes: [
+              {
+                isPublic: faker.datatype.boolean(),
+                name: DocumentEventAttributeName.ACTOR_TYPE,
+                value: DocumentEventActorType.HAULER,
+              },
+            ],
+          },
+          name: DocumentEventName.ACTOR,
+        }),
+      ];
+
+      const massDocument = stubMassDocument({
+        externalEvents: actorEvents,
+        subtype: String(subtype),
+      });
+
+      const data = random<RuleInput>();
+
+      spyOnDocumentQueryServiceLoad(stubDocument(), [
+        massDocument,
+        stubMethodologyWithRequiredActors(),
+      ]);
+
+      const result = await service.process(data);
+
+      expect(result.resultContent).toMatchObject({
+        certificateRewards: expect.arrayContaining(
+          actorEvents.map((actorEvent) => {
+            const actorType = getEventAttributeValue(
+              actorEvent,
+              DocumentEventAttributeName.ACTOR_TYPE,
+            );
+
+            return {
+              actorType,
+              participant: {
+                id: actorEvent.participant.id,
+                name: actorEvent.participant.name,
+              },
+              percentage: expect.any(String),
+            };
+          }),
+        ),
+        massRewards: expect.arrayContaining(
+          actorEvents.map((actorEvent) => {
+            const actorType = getEventAttributeValue(
+              actorEvent,
+              DocumentEventAttributeName.ACTOR_TYPE,
+            ) as RewardsDistributionActorType;
+
+            return {
+              actorType,
+              documentId: massDocument.id,
+              massCertificatePercentage: expect.any(String),
+              massPercentage:
+                actorType === SOURCE
+                  ? formatPercentage(
+                      fiftyPercentageDiscount(rewardDistribution[actorType]),
+                    ) // SOURCE (50% of SOURCE percentage) -> APPOINTED_NGO
+                  : formatPercentage(rewardDistribution[actorType]),
+              participant: {
+                id: actorEvent.participant.id,
+                name: actorEvent.participant.name,
+              },
+            };
+          }),
+        ),
+      });
+    },
+  );
+
+  it('should direct the "HAULER" mass percentage to the "SOURCE" when it is not present', async () => {
+    const massDocument = stubMassDocumentWithRequiredActors({
+      subtype: DocumentSubtype.FOOD_WASTE,
+    });
+    const sourceActorEvent = massDocument.externalEvents!.find(
+      (event) =>
+        getEventAttributeValue(event, DocumentEventAttributeName.ACTOR_TYPE) ===
+        SOURCE,
+    );
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), [
+      massDocument,
+      stubMethodologyWithRequiredActors({
+        externalEvents: requiredMethodologyActorsEvents,
+      }),
+    ]);
+
+    const result = await service.process(data);
+
+    expect(result.resultContent).toMatchObject({
+      massRewards: expect.arrayContaining([
+        {
+          actorType: SOURCE,
+          documentId: massDocument.id,
+          massCertificatePercentage: expect.any(String),
+          massPercentage: formatPercentage(
+            fiftyPercentageDiscount(
+              REWARDS_DISTRIBUTION.FOOD_WASTE.SOURCE.plus(
+                REWARDS_DISTRIBUTION.FOOD_WASTE.HAULER,
+              ), // SOURCE (50% of SOURCE percentage) -> APPOINTED_NGO
+            ),
+          ),
+          participant: {
+            id: sourceActorEvent?.participant.id,
+            name: sourceActorEvent?.participant.name,
+          },
+        },
+      ]),
+    });
+  });
+
+  it('should divide the percentage when there is more than one participant of the same type', async () => {
+    const processorActorEvent = stubDocumentEvent({
+      metadata: {
+        attributes: [
+          {
+            isPublic: faker.datatype.boolean(),
+            name: DocumentEventAttributeName.ACTOR_TYPE,
+            value: DocumentEventActorType.PROCESSOR,
+          },
+        ],
+      },
+      name: DocumentEventName.ACTOR,
+    });
+    const massDocument = stubMassDocument({
+      externalEvents: [...requiredActorEvents, processorActorEvent],
+      subtype: DocumentSubtype.FOOD_WASTE,
+    });
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), [
+      massDocument,
+      stubMethodologyWithRequiredActors(),
+    ]);
+
+    const result = await service.process(data);
+
+    const expectedProcessorMassRewards = (
+      result.resultContent as CertificateRewardDistributionOutput
+    ).massRewards.filter(
+      ({ actorType }) => actorType === DocumentEventActorType.PROCESSOR,
+    );
+
+    expect(expectedProcessorMassRewards).toHaveLength(2);
+    expect(result.resultContent).toMatchObject({
+      massRewards: expect.arrayContaining([
+        {
+          actorType: DocumentEventActorType.PROCESSOR,
+          documentId: massDocument.id,
+          massCertificatePercentage: expect.any(String),
+          massPercentage: formatPercentage(
+            REWARDS_DISTRIBUTION.FOOD_WASTE.PROCESSOR.dividedBy(2),
+          ),
+          participant: {
+            id: processorActorEvent.participant.id,
+            name: processorActorEvent.participant.name,
+          },
+        },
+      ]),
+    });
+  });
+
+  it('should return rule processor resultContent certificate reward grouped by actor type', async () => {
+    const participant = stubParticipant();
+    const address = stubAddress();
+
+    const externalEvents = REQUIRED_ACTOR_TYPES.MASS.map((actorType) =>
+      stubDocumentEvent({
+        address,
+        metadata: {
+          attributes: [
+            {
+              isPublic: faker.datatype.boolean(),
+              name: DocumentEventAttributeName.ACTOR_TYPE,
+              value: String(actorType),
+            },
+          ],
+        },
+        name: DocumentEventName.ACTOR,
+        participant,
+      }),
+    );
+    const massDocuments = stubArray(() =>
+      stubMassDocument({
+        externalEvents,
+        subtype: DocumentSubtype.FOOD_WASTE,
+      }),
+    );
+
+    const data = random<RuleInput>();
+
+    spyOnDocumentQueryServiceLoad(stubDocument(), [
+      ...massDocuments,
+      stubMethodologyWithRequiredActors(),
+    ]);
+
+    const result = await service.process(data);
+
+    const certificateRewards = result.resultContent?.['certificateRewards'];
+
+    const validationResult = validate<CertificateReward[]>(certificateRewards);
+
+    expect(validationResult.errors).toEqual([]);
+
+    expect(certificateRewards).toEqual(
+      expect.arrayContaining(
+        ALL_ACTOR_TYPES.map((actorType) => ({
+          actorType,
+          participant: expect.any(Object),
+          percentage: expect.stringMatching(/^\d+(\.\d{8}$)?/),
+        })),
+      ),
+    );
+  });
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.processor.ts
@@ -1,0 +1,419 @@
+import { getEventAttributeValue } from '@carrot-fndn/methodologies/bold/recycling/organic/getters';
+import {
+  type DocumentQuery,
+  DocumentQueryService,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/io-helpers';
+import {
+  MASS,
+  METHODOLOGY_DEFINITION,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/matchers';
+import {
+  and,
+  isActorEvent,
+  isActorEventWithSourceActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/predicates';
+import {
+  type CertificateReward,
+  type Document,
+  DocumentEventActorType,
+  DocumentEventAttributeName,
+  MassSubtype,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { mapDocumentReference } from '@carrot-fndn/methodologies/bold/recycling/organic/utils';
+import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import { isNil, isNonEmptyArray } from '@carrot-fndn/shared/helpers';
+import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import { BigNumber } from 'bignumber.js';
+import { is } from 'typia';
+
+import type {
+  ActorMassPercentageInputDto,
+  ActorReward,
+  RewardsDistributionActor,
+  RewardsDistributionActorTypePercentage,
+} from './rewards-distribution.types';
+
+import {
+  REQUIRED_ACTOR_TYPES,
+  REWARDS_DISTRIBUTION,
+  REWARDS_DISTRIBUTION_BY_WASTE_TYPE,
+  REWARDS_DISTRIBUTION_CRITERIA,
+} from './rewards-distribution.constants';
+import {
+  checkIfHaulerActorExists,
+  formatPercentage,
+  getActorsByType,
+  getDocumentsTotalMassWeight,
+  mapActorReward,
+  mapMassRewards,
+} from './rewards-distribution.helpers';
+import { RewardsDistributionProcessorErrors } from './rewards-distribution.processor.errors';
+
+BigNumber.config({ DECIMAL_PLACES: 10, ROUNDING_MODE: BigNumber.ROUND_DOWN });
+
+const LARGE_SOURCE_COMPANY_DISCOUNT = 0.5;
+
+export class RewardsDistributionProcessor extends RuleDataProcessor {
+  private checkIfHasRequiredActorTypes = ({
+    actors,
+    documentId,
+    requiredActorTypes,
+  }: {
+    actors: RewardsDistributionActor[];
+    documentId: string;
+    requiredActorTypes: DocumentEventActorType[];
+  }) => {
+    const missingRequiredActors = requiredActorTypes.filter(
+      (requiredActorType) =>
+        !actors.some((actor) => actor.type === requiredActorType),
+    );
+
+    if (isNonEmptyArray(missingRequiredActors)) {
+      throw this.errorProcessor.getKnownError(
+        this.errorProcessor.ERROR_MESSAGE.MISSING_REQUIRED_ACTORS(
+          documentId,
+          missingRequiredActors,
+        ),
+      );
+    }
+  };
+
+  readonly errorProcessor = new RewardsDistributionProcessorErrors();
+
+  private checkIfWasteOriginIsNotIdentified(document: Document): boolean {
+    return Boolean(
+      document.externalEvents?.some(
+        and(
+          isActorEventWithSourceActorType,
+          (event) =>
+            getEventAttributeValue(
+              event,
+              DocumentEventAttributeName.WASTE_ORIGIN_IDENTIFIED,
+            ) === false,
+        ),
+      ),
+    );
+  }
+
+  private extractMassSubtype(document: Document): MassSubtype {
+    if (!is<MassSubtype>(document.subtype)) {
+      throw this.errorProcessor.getKnownError(
+        this.errorProcessor.ERROR_MESSAGE.UNEXPECTED_DOCUMENT_SUBTYPE,
+      );
+    }
+
+    return document.subtype;
+  }
+
+  private getActorMassPercentage(dto: ActorMassPercentageInputDto): BigNumber {
+    const { actorType, actors, document, rewardDistribution } = dto;
+
+    let actorMassPercentage = rewardDistribution;
+    const rewardDistributions =
+      this.getRewardsDistributionActorTypePercentages(document);
+
+    if (actorType === DocumentEventActorType.SOURCE) {
+      actorMassPercentage = this.getSourceActorMassPercentage(
+        document,
+        rewardDistributions.SOURCE,
+        actors,
+        rewardDistributions,
+      );
+    }
+
+    if (actorType === DocumentEventActorType.APPOINTED_NGO) {
+      const sourcePercentage = this.getNgoActorMassPercentage(
+        document,
+        rewardDistributions.SOURCE,
+        actors,
+        rewardDistributions,
+      );
+
+      actorMassPercentage = actorMassPercentage.plus(sourcePercentage);
+    }
+
+    if (this.checkIfWasteOriginIsNotIdentified(document)) {
+      if (actorType === DocumentEventActorType.NETWORK) {
+        actorMassPercentage = actorMassPercentage
+          .plus(rewardDistributions.SOURCE)
+          .plus(this.getSourceAdditionalPercentage(actors, rewardDistributions))
+          .plus(new BigNumber(rewardDistributions.PROCESSOR).multipliedBy(0.25))
+          .plus(new BigNumber(rewardDistributions.RECYCLER).multipliedBy(0.25));
+
+        if (checkIfHaulerActorExists(actors)) {
+          actorMassPercentage = actorMassPercentage.plus(
+            new BigNumber(rewardDistributions.HAULER).multipliedBy(0.25),
+          );
+        }
+      } else if (
+        [
+          DocumentEventActorType.HAULER,
+          DocumentEventActorType.PROCESSOR,
+          DocumentEventActorType.RECYCLER,
+        ].includes(actorType)
+      ) {
+        actorMassPercentage = actorMassPercentage.multipliedBy(0.75);
+      }
+    }
+
+    return actorMassPercentage;
+  }
+
+  private getActorRewards({
+    massDocuments,
+    methodologyDocument,
+  }: {
+    massDocuments: Document[];
+    methodologyDocument: Document;
+  }): ActorReward[] {
+    const result: ActorReward[] = [];
+    const totalMassOfDocuments = getDocumentsTotalMassWeight(massDocuments);
+
+    for (const document of massDocuments) {
+      const actors = this.getRewardsDistributionActors(document);
+
+      for (const [actorType, rewardDistribution] of Object.entries(
+        this.getRewardsDistributionActorTypePercentages(document),
+      )) {
+        if (
+          is<RewardsDistributionActorType>(actorType) &&
+          is<BigNumber>(rewardDistribution)
+        ) {
+          const actorsByType = getActorsByType({
+            actorType,
+            actors,
+            methodologyDocument,
+          });
+
+          const massPercentage = this.getActorMassPercentage({
+            actorType,
+            actors,
+            document,
+            rewardDistribution,
+          }).div(actorsByType.length);
+
+          result.push(
+            ...actorsByType.map(({ participant, type }) =>
+              mapActorReward({
+                actorType: type,
+                document,
+                massPercentage,
+                participant,
+                totalMassOfDocuments,
+              }),
+            ),
+          );
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private getCertificateRewards(actors: ActorReward[]): CertificateReward[] {
+    const certificateRewardGroup = new Map<string, CertificateReward>();
+
+    for (const actor of actors) {
+      const certificateReward = certificateRewardGroup.get(
+        `${actor.actorType}-${actor.participant.id}`,
+      );
+
+      certificateRewardGroup.set(`${actor.actorType}-${actor.participant.id}`, {
+        actorType: actor.actorType,
+        participant: actor.participant,
+        percentage: new BigNumber(actor.massCertificatePercentage)
+          .plus(certificateReward?.percentage ?? 0)
+          .toString(),
+      });
+    }
+
+    return [...certificateRewardGroup.values()].map((certificateReward) => ({
+      ...certificateReward,
+      percentage: formatPercentage(new BigNumber(certificateReward.percentage)),
+    }));
+  }
+
+  private getNgoActorMassPercentage(
+    document: Document,
+    actorMassPercentage: BigNumber,
+    actors: RewardsDistributionActor[],
+    rewardDistributions: RewardsDistributionActorTypePercentage,
+  ): BigNumber {
+    return this.getSourceActorMassFullPercentage(
+      document,
+      actorMassPercentage,
+      actors,
+      rewardDistributions,
+    ).multipliedBy(LARGE_SOURCE_COMPANY_DISCOUNT);
+  }
+
+  private getRewardsDistributionActorTypePercentages(
+    document: Document,
+  ): RewardsDistributionActorTypePercentage {
+    const documentSubtype = this.extractMassSubtype(document);
+
+    return REWARDS_DISTRIBUTION[
+      // eslint-disable-next-line security/detect-object-injection
+      REWARDS_DISTRIBUTION_BY_WASTE_TYPE[documentSubtype]
+    ];
+  }
+
+  private getRewardsDistributionActors(
+    document: Document,
+  ): RewardsDistributionActor[] {
+    const actors: RewardsDistributionActor[] = [];
+
+    if (!isNonEmptyArray(document.externalEvents)) {
+      throw this.errorProcessor.getKnownError(
+        this.errorProcessor.ERROR_MESSAGE.DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
+          document.id,
+        ),
+      );
+    }
+
+    const actorEvents = document.externalEvents.filter((event) =>
+      isActorEvent(event),
+    );
+
+    for (const event of actorEvents) {
+      const actorType = getEventAttributeValue(
+        event,
+        DocumentEventAttributeName.ACTOR_TYPE,
+      );
+
+      if (is<RewardsDistributionActorType>(actorType)) {
+        actors.push({
+          participant: {
+            id: event.participant.id,
+            name: event.participant.name,
+          },
+          type: actorType,
+        });
+      }
+    }
+
+    this.checkIfHasRequiredActorTypes({
+      actors,
+      documentId: document.id,
+      requiredActorTypes: REQUIRED_ACTOR_TYPES.MASS,
+    });
+
+    return actors;
+  }
+
+  private getSourceActorMassFullPercentage(
+    document: Document,
+    actorMassPercentage: BigNumber,
+    actors: RewardsDistributionActor[],
+    rewardDistributions: RewardsDistributionActorTypePercentage,
+  ): BigNumber {
+    return this.checkIfWasteOriginIsNotIdentified(document)
+      ? new BigNumber(0)
+      : actorMassPercentage.plus(
+          this.getSourceAdditionalPercentage(actors, rewardDistributions),
+        );
+  }
+
+  private getSourceActorMassPercentage(
+    document: Document,
+    actorMassPercentage: BigNumber,
+    actors: RewardsDistributionActor[],
+    rewardDistributions: RewardsDistributionActorTypePercentage,
+  ): BigNumber {
+    return this.getSourceActorMassFullPercentage(
+      document,
+      actorMassPercentage,
+      actors,
+      rewardDistributions,
+    ).multipliedBy(1 - LARGE_SOURCE_COMPANY_DISCOUNT);
+  }
+
+  private getSourceAdditionalPercentage(
+    actors: RewardsDistributionActor[],
+    rewardDistributions: RewardsDistributionActorTypePercentage,
+  ): BigNumber {
+    if (!checkIfHaulerActorExists(actors)) {
+      return rewardDistributions.HAULER;
+    }
+
+    return BigNumber(0);
+  }
+
+  async getRuleDocuments(documentQuery: DocumentQuery<Document>): Promise<{
+    massDocuments: Document[];
+    methodologyDocument: Document | undefined;
+  }> {
+    const massDocuments: Document[] = [];
+    let methodologyDocument: Document | undefined;
+
+    await documentQuery.iterator().each(({ document }) => {
+      const documentReference = mapDocumentReference(document);
+
+      if (MASS.matches(documentReference)) {
+        massDocuments.push(document);
+      }
+
+      if (METHODOLOGY_DEFINITION.matches(documentReference)) {
+        methodologyDocument = document;
+      }
+    });
+
+    return {
+      massDocuments,
+      methodologyDocument,
+    };
+  }
+
+  async process(ruleInput: RuleInput): Promise<RuleOutput> {
+    try {
+      const documentLoader = await new DocumentQueryService(
+        provideDocumentLoaderService,
+      ).load({
+        context: {
+          s3KeyPrefix: ruleInput.documentKeyPrefix,
+        },
+        criteria: REWARDS_DISTRIBUTION_CRITERIA,
+        documentId: String(ruleInput.documentId),
+      });
+
+      // TODO: refactor to return actorRewards here [https://app.clickup.com/t/3005225/CARROT-734]
+      const { massDocuments, methodologyDocument } =
+        await this.getRuleDocuments(documentLoader);
+
+      if (massDocuments.length === 0) {
+        throw this.errorProcessor.getKnownError(
+          this.errorProcessor.ERROR_MESSAGE.MASS_DOCUMENTS_NOT_FOUND,
+        );
+      }
+
+      if (isNil(methodologyDocument)) {
+        throw this.errorProcessor.getKnownError(
+          this.errorProcessor.ERROR_MESSAGE.METHODOLOGY_DOCUMENT_NOT_FOUND,
+        );
+      }
+
+      const actorRewards = this.getActorRewards({
+        massDocuments,
+        methodologyDocument,
+      });
+
+      return mapToRuleOutput(ruleInput, RuleOutputStatus.APPROVED, {
+        resultContent: {
+          certificateRewards: this.getCertificateRewards(actorRewards),
+          massRewards: mapMassRewards(actorRewards),
+        },
+      });
+    } catch (error: unknown) {
+      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
+        resultComment: this.errorProcessor.getResultCommentFromError(error),
+      });
+    }
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.stubs.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.stubs.ts
@@ -1,0 +1,58 @@
+import {
+  stubDocumentEventWithMetadata,
+  stubMassDocument,
+  stubMethodologyDefinitionDocument,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/testing';
+import {
+  type Document,
+  type DocumentEvent,
+  type DocumentEventActorType,
+  DocumentEventAttributeName,
+  DocumentEventName,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+import { faker } from '@faker-js/faker';
+
+import { REQUIRED_ACTOR_TYPES } from './rewards-distribution.constants';
+
+const getActorTypeMetadata = (
+  actorType: DocumentEventActorType,
+): DocumentEvent => ({
+  ...stubDocumentEventWithMetadata([
+    {
+      isPublic: faker.datatype.boolean(),
+      name: DocumentEventAttributeName.ACTOR_TYPE,
+      value: String(actorType),
+    },
+  ]),
+  name: DocumentEventName.ACTOR,
+});
+
+export const requiredMassActorEvents = REQUIRED_ACTOR_TYPES.MASS.map(
+  (actorType) => getActorTypeMetadata(actorType),
+);
+export const requiredMethodologyActorsEvents =
+  REQUIRED_ACTOR_TYPES.METHODOLOGY.map((actorType) =>
+    getActorTypeMetadata(actorType),
+  );
+
+export const stubMassDocumentWithRequiredActors = (
+  partialDocument?: Partial<Document>,
+) =>
+  stubMassDocument({
+    ...partialDocument,
+    externalEvents: [
+      ...(partialDocument?.externalEvents ?? []),
+      ...requiredMassActorEvents,
+    ],
+  });
+
+export const stubMethodologyWithRequiredActors = (
+  partialDocument?: Partial<Document>,
+) =>
+  stubMethodologyDefinitionDocument({
+    ...partialDocument,
+    externalEvents: [
+      ...(partialDocument?.externalEvents ?? []),
+      ...requiredMethodologyActorsEvents,
+    ],
+  });

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.types.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/src/lib/rewards-distribution.types.ts
@@ -1,0 +1,48 @@
+import type BigNumber from 'bignumber.js';
+
+import {
+  type Document,
+  type DocumentSubtype,
+  type RewardActorParticipant,
+  type RewardsDistributionActorType,
+} from '@carrot-fndn/methodologies/bold/recycling/organic/types';
+
+export interface RewardsDistributionActor {
+  participant: RewardActorParticipant;
+  type: RewardsDistributionActorType;
+}
+
+export interface ActorReward {
+  actorType: RewardsDistributionActorType;
+  document: Document;
+  massCertificatePercentage: BigNumber;
+  massPercentage: BigNumber;
+  participant: RewardActorParticipant;
+}
+
+export type RewardsDistributionType =
+  | 'FOOD_WASTE'
+  | 'OTHER_ORGANIC_WASTE'
+  | 'SLUDGE';
+
+export type RewardsDistributionTypeByDocumentSubtype = Record<
+  keyof DocumentSubtype,
+  RewardsDistributionType | undefined
+>;
+
+export type RewardsDistributionActorTypePercentage = Record<
+  RewardsDistributionActorType,
+  BigNumber
+>;
+
+export type RewardsDistribution = Record<
+  RewardsDistributionType,
+  RewardsDistributionActorTypePercentage
+>;
+
+export interface ActorMassPercentageInputDto {
+  actorType: RewardsDistributionActorType;
+  actors: RewardsDistributionActor[];
+  document: Document;
+  rewardDistribution: BigNumber;
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.build.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../../../../../.tsconfig/tsconfig.build.json"
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.eslint.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.spec.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-certificate/rewards-distribution/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../../../.tsconfig/tsconfig.spec.json"
+}


### PR DESCRIPTION
### Summary

Create the rules for bold carbon. Only rules that are necessary to generate the credit.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Based on the comprehensive summary of changes, here are the release notes:

- **New Features**
	- Added multiple rule processors for carbon credit methodologies
	- Introduced NFT metadata selection functionality
	- Implemented rewards distribution calculations for mass certificates
	- Created mass audit document status verification

- **Improvements**
	- Enhanced document processing and validation logic
	- Added comprehensive test coverage for new methodologies
	- Implemented robust error handling mechanisms

- **Configuration**
	- Added TypeScript, ESLint, and Jest configuration files
	- Set up project and package configurations for new modules

- **Documentation**
	- Created README files for new methodologies
	- Added contributor information and licensing details

The changes primarily focus on expanding the carbon credit ecosystem with new rule processors and supporting infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->