### PR TITLE
feat(script): add methodology-slug in lambda metadata

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": "always"
   },
-  "conventionalCommits.scopes": ["nx", "rule", "shared"],
+  "conventionalCommits.scopes": ["nx", "rule", "shared", "script"],
   "cSpell.words": [
     "airbnb",
     "commitlint",

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -41,6 +41,10 @@ export const wrapRuleIntoLambdaHandler = (
     environment: String(process.env['ENVIRONMENT']),
   });
 
+  // TODO: remove this log when the metadata is tested
+  // eslint-disable-next-line no-console
+  console.log('Temporary log');
+
   const handler = async (
     event: MethodologyRuleEvent,
   ): Promise<MethodologyRuleResponse> => {

--- a/scripts/upload-lambda.sh
+++ b/scripts/upload-lambda.sh
@@ -19,6 +19,8 @@ S3_FOLDER=$(echo "$PROJECT_FOLDER" | sed 's/^apps\/methodologies\///' | sed 's/r
 S3_KEY=$S3_FOLDER/$FILE_NAME-$FILE_CHECKSUM.zip
 S3_URL=s3://$S3_BUCKET/$S3_KEY
 
+METHODOLOGY_SLUG=$(echo "$PROJECT_FOLDER" | sed -n 's/^apps\/methodologies\/\([^/]*\)\/rule-processors\/.*/\1/p')
+
 RULE_NAME=$(echo "$S3_FOLDER" | sed 's/\//-/g')
 
 GIT_REPO_URL=$(git config --get remote.origin.url | sed 's/\.git//g')
@@ -37,7 +39,7 @@ then
   METADATA_TEMP_FILE="temp-rules-metadata.json"
 
   if [ -s "$METADATA_FILE" ]; then
-    jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"
+    jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"methodology-slug\": \"$METHODOLOGY_SLUG\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"
   fi
 else
   echo "Error: Failed to upload file $ZIP_PATH"


### PR DESCRIPTION
### Summary

- Add the `methodology-slug` in rules metadata;
- Add a new commit conventional scope called `script`;
- Add a console log to force the rules deploy;

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated VS Code settings to include a new "script" scope for conventional commits
- **Development**
	- Added temporary logging in lambda wrapper for debugging
	- Enhanced upload lambda script to include methodology slug in metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->