### PR TITLE
chore: remove initialValue from MethodologyDocument

### DIFF
--- a/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
+++ b/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
@@ -551,7 +551,6 @@ export const approvedMassDocument: Document = {
   ],
   externalId: faker.string.uuid(),
   id: faker.string.uuid(),
-  initialValue: 0,
   isPublic: true,
   isPubliclySearchable: true,
   measurementUnit: 'KG',

--- a/libs/shared/methodologies/bold/testing/src/documents/rejected-mass-document.ts
+++ b/libs/shared/methodologies/bold/testing/src/documents/rejected-mass-document.ts
@@ -543,7 +543,6 @@ export const rejectedMassDocument: Document = {
   ],
   externalId: faker.string.uuid(),
   id: faker.string.uuid(),
-  initialValue: 0,
   isPublic: true,
   isPubliclySearchable: true,
   measurementUnit: 'HG',

--- a/libs/shared/types/src/methodology/methodology-document.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document.types.ts
@@ -24,7 +24,6 @@ export interface MethodologyDocument {
   externalEvents?: MethodologyDocumentEvent[] | undefined;
   externalId?: string | undefined;
   id: string;
-  initialValue: number & tags.Minimum<0> & tags.Type<'float'>;
   isPublic?: boolean | undefined;
   isPubliclySearchable: boolean;
   measurementUnit: string;


### PR DESCRIPTION
### Summary

The `initialValue` field was removed from the `MethodologyDocument` as it was not being used anywhere.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated document configurations by removing preset default values, resulting in a more streamlined structure.
  - This enhancement improves consistency and maintainability across document records, laying a cleaner foundation for future updates.
  - End-users can expect a more robust and reliable experience thanks to these internal improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->