### PR TITLE
refactor: change nonEmptyString assert

### DIFF
--- a/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
+++ b/apps/methodologies/bold/rule-processors/credit/nft-metadata-selection/src/lib/nft-metadata-selection.types.ts
@@ -1,6 +1,5 @@
 import type {
   NonEmptyArray,
-  NonEmptyString,
   NonZeroPositive,
   Uri,
   Url,
@@ -8,20 +7,22 @@ import type {
 
 import type { RewardsDistributionParticipant } from './nft-metadata-selection.dto';
 
+// TODO: Refactor to use NonEmptyString type [on-call] - https://app.clickup.com/t/3005225/CARROT-1947
+
 interface NftMetadataAttributes {
-  trait_type: NonEmptyString;
-  value: NonEmptyString;
+  trait_type: string;
+  value: string;
 }
 
 interface NftMetadataMassId {
-  external_id: NonEmptyString;
+  external_id: string;
   external_url: Url;
-  recycler: NonEmptyString;
-  weight: NonEmptyString;
+  recycler: string;
+  weight: string;
 }
 
 export interface NftMetadataMassCertificate {
-  external_id: NonEmptyString;
+  external_id: string;
   external_url: Url;
   mass_id_count: NonZeroPositive;
   mass_ids: NonEmptyArray<NftMetadataMassId>;
@@ -29,34 +30,34 @@ export interface NftMetadataMassCertificate {
 
 export interface NftMetadataMassCertificates {
   count: NonZeroPositive;
-  description: NonEmptyString;
+  description: string;
   documents: NonEmptyArray<NftMetadataMassCertificate>;
 }
 
 export interface NftMetadataMethodology {
-  description: NonEmptyString;
+  description: string;
   external_url: Url;
-  name: NonEmptyString;
+  name: string;
   pdf: Uri;
 }
 
 interface NftMetadataSummary {
   mass_certificate_count: NonZeroPositive;
   mass_id_count: NonZeroPositive;
-  mass_origin_city: NonEmptyString;
-  mass_origin_country: NonEmptyString;
-  mass_origin_state: NonEmptyString;
-  mass_subtype: NonEmptyString;
-  mass_total_weight: NonEmptyString;
-  mass_type: NonEmptyString;
-  recycler_name: NonEmptyString;
+  mass_origin_city: string;
+  mass_origin_country: string;
+  mass_origin_state: string;
+  mass_subtype: string;
+  mass_total_weight: string;
+  mass_type: string;
+  recycler_name: string;
 }
 
 export interface NftMetadataRewardsDistribution {
-  description: NonEmptyString;
+  description: string;
   external_url: Url;
   participants: NonEmptyArray<RewardsDistributionParticipant>;
-  policy_version: NonEmptyString;
+  policy_version: string;
 }
 
 interface NftMetadataDetails {
@@ -68,11 +69,11 @@ interface NftMetadataDetails {
 
 export interface NftMetadata {
   attributes: NonEmptyArray<NftMetadataAttributes>;
-  description: NonEmptyString;
+  description: string;
   details: NftMetadataDetails;
-  external_id: NonEmptyString;
+  external_id: string;
   external_url: Url;
   image: Uri;
-  name: NonEmptyString;
-  store_contract_address: NonEmptyString;
+  name: string;
+  store_contract_address: string;
 }

--- a/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
+++ b/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
@@ -77,7 +77,7 @@ const weightScale = {
 export const approvedMassDocument: Document = {
   attachments: [attachment],
   category: DocumentCategory.MASS,
-  createdAt: '2023-12-19T13:34:35.785Z',
+  createdAt: `${lastYear}-12-19T13:34:35.785Z`,
   currentValue: 109_200,
   dataSetName: DataSetName.PROD,
   externalCreatedAt,
@@ -259,7 +259,7 @@ export const approvedMassDocument: Document = {
     {
       address: recyclerAddress,
       author,
-      externalCreatedAt: '2023-04-10T23:18:00.000Z',
+      externalCreatedAt: `${lastYear}-04-10T23:18:00.000Z`,
       externalId,
       id: faker.string.uuid(),
       isPublic: true,
@@ -299,7 +299,7 @@ export const approvedMassDocument: Document = {
     {
       address: recyclerAddress,
       author,
-      externalCreatedAt: '2023-04-10T23:23:00.000Z',
+      externalCreatedAt: `${lastYear}-04-10T23:23:00.000Z`,
       externalId,
       id: faker.string.uuid(),
       isPublic: true,
@@ -364,7 +364,7 @@ export const approvedMassDocument: Document = {
     {
       address: recyclerAddress,
       author,
-      externalCreatedAt: '2023-04-10T23:29:00.000Z',
+      externalCreatedAt: `${lastYear}-04-10T23:29:00.000Z`,
       externalId,
       id: faker.string.uuid(),
       isPublic: true,
@@ -389,7 +389,7 @@ export const approvedMassDocument: Document = {
     {
       address: recyclerAddress,
       author,
-      externalCreatedAt: '2023-04-10T23:59:00.000Z',
+      externalCreatedAt: `${lastYear}-04-10T23:59:00.000Z`,
       externalId,
       id: faker.string.uuid(),
       isPublic: true,
@@ -455,7 +455,7 @@ export const approvedMassDocument: Document = {
     {
       address: recyclerAddress,
       author,
-      externalCreatedAt: '2023-10-02T00:00:00.000Z',
+      externalCreatedAt: `${lastYear}-10-02T00:00:00.000Z`,
       externalId,
       id: faker.string.uuid(),
       isPublic: true,
@@ -474,7 +474,7 @@ export const approvedMassDocument: Document = {
           {
             isPublic: true,
             name: DocumentEventAttributeName.INVOICE_DATE,
-            value: '2023-10-02',
+            value: `${lastYear}-10-02`,
           },
           {
             isPublic: true,


### PR DESCRIPTION
### Summary

change nonEmptyString assert

### Details

* [refactor: change nonEmptyString assert](https://github.com/carrot-foundation/methodology-rules/commit/06879216234939a8a9c7a571e47c715fa03de801)
* Ater updating Typia, tests using NonEmptyString started failing. This is because the random function now generates empty strings, which is invalid for NonEmptyString.

### Related links

* Task to be resolved definitively: https://app.clickup.com/t/3005225/CARROT-1947

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Revised field definitions for various metadata elements to use standard string values instead of strictly enforced non-empty strings, simplifying data handling and allowing more flexible input.
- **New Features**
	- Updated date fields in the approved mass document to dynamically reference the previous year, enhancing date management and reducing hardcoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->