### PR TITLE
feat(shared): add getOrDefault and getOrUndefined utility functions

### DIFF
--- a/libs/shared/helpers/src/common.helpers.spec.ts
+++ b/libs/shared/helpers/src/common.helpers.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 
-import { isNil, pick } from './common.helpers';
+import { getOrDefault, getOrUndefined, isNil, pick } from './common.helpers';
 
 describe('common helpers', () => {
   describe('isNil', () => {
@@ -15,6 +15,37 @@ describe('common helpers', () => {
     it('should return false if the value is not null or undefined', () => {
       expect(isNil(123)).toBe(false);
     });
+  });
+
+  describe('getOrDefault', () => {
+    it.each([
+      { expected: 'test', value: 'test' },
+      { expected: 'defaultValue', value: undefined },
+      { expected: 'defaultValue', value: null },
+    ])(
+      'should return $expected when value is $value',
+      ({ expected, value }) => {
+        const defaultValue = 'defaultValue';
+        const result = getOrDefault(value, defaultValue);
+
+        expect(result).toBe(expected);
+      },
+    );
+  });
+
+  describe('getOrUndefined', () => {
+    it.each([
+      { expected: 'test', value: 'test' },
+      { expected: undefined, value: undefined },
+      { expected: undefined, value: null },
+    ])(
+      'should return $expected when value is $value',
+      ({ expected, value }) => {
+        const result = getOrUndefined(value);
+
+        expect(result).toBe(expected);
+      },
+    );
   });
 
   describe('pick', () => {

--- a/libs/shared/helpers/src/common.helpers.ts
+++ b/libs/shared/helpers/src/common.helpers.ts
@@ -1,3 +1,5 @@
+import type { NonNullableOrNullOrUndefined } from '@carrot-fndn/shared/types';
+
 export const isNil = (value: unknown): value is null | undefined =>
   value === null || value === undefined;
 
@@ -14,3 +16,18 @@ export const pick = <T, K extends keyof T>(
 
   return pickedObject;
 };
+
+export const getOrDefault = <T, D extends NonNullableOrNullOrUndefined<T>>(
+  value: T | null | undefined,
+  defaultValue: D,
+): NonNullableOrNullOrUndefined<T> => {
+  if (isNil(value)) {
+    return defaultValue as NonNullableOrNullOrUndefined<T>;
+  }
+
+  return value as NonNullableOrNullOrUndefined<T>;
+};
+
+export const getOrUndefined = <T>(
+  value: T | null | undefined,
+): NonNullable<T> | undefined => value ?? undefined;

--- a/libs/shared/types/src/index.ts
+++ b/libs/shared/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './common.types';
+export * from './primitives.types';
 export * from './utils.types';
 export * from './string.types';
 export * from './number.types';

--- a/libs/shared/types/src/primitives.types.ts
+++ b/libs/shared/types/src/primitives.types.ts
@@ -1,0 +1,5 @@
+export type NonNullableOrNullOrUndefined<T> = T extends null
+  ? null
+  : T extends undefined
+    ? undefined
+    : T;


### PR DESCRIPTION
### Summary

- Introduced enhanced utilities for handling missing or null values, ensuring consistent and predictable behavior.
- Improved type precision with newly added type definitions to support robust value processing.

### Details

The changes add two new helper functions, `getOrDefault` and `getOrUndefined`, in the shared helpers module along with corresponding parameterized tests. The new functions handle null and undefined values by returning either a provided default or undefined. Additionally, a new type alias, `NonNullableOrNullOrUndefined`, is introduced and exported via the shared types module to support these functions.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**