### PR TITLE
refactor(rule): update credit absence processor to use credit subtype

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.errors.ts
@@ -2,8 +2,8 @@ import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/proc
 
 export class CreditAbsenceProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
-    MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT: (creditType: string) =>
-      `There is already a ${creditType} linked to this MassID`,
+    MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT: (creditSubtype: string) =>
+      `There is already a ${creditSubtype} linked to this MassID`,
     REJECTED_BY_ERROR: 'Unable to validate Credit Absence',
   } as const;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.spec.ts
@@ -133,7 +133,7 @@ describe('CreditAbsenceProcessor', () => {
       ],
       resultComment:
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT(
-          assert<NonEmptyString>(TRC_CREDIT_MATCH.match.type),
+          assert<NonEmptyString>(TRC_CREDIT_MATCH.match.subtype),
         ),
       resultStatus: RuleOutputStatus.REJECTED,
       scenario:
@@ -185,7 +185,7 @@ describe('CreditAbsenceProcessor', () => {
       ],
       resultComment:
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT(
-          assert<NonEmptyString>(TRC_CREDIT_MATCH.match.type),
+          assert<NonEmptyString>(TRC_CREDIT_MATCH.match.subtype),
         ),
       resultStatus: RuleOutputStatus.REJECTED,
       scenario:

--- a/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.ts
@@ -41,7 +41,7 @@ export class CreditAbsenceProcessor extends RuleDataProcessor {
 
   private get RESULT_COMMENT() {
     return {
-      APPROVED: `The MassID is not linked to a valid ${this.creditMatch.match.type}`,
+      APPROVED: `The MassID is not linked to a valid ${this.creditMatch.match.subtype}`,
     } as const;
   }
 
@@ -56,7 +56,7 @@ export class CreditAbsenceProcessor extends RuleDataProcessor {
     if (hasNoCancelledCreditDocuments) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT(
-          assert<NonEmptyString>(this.creditMatch.match.type),
+          assert<NonEmptyString>(this.creditMatch.match.subtype),
         ),
       );
     }


### PR DESCRIPTION
### Summary

_Summarize the suggested changes with this PR._

### Details

_Add more context to describe the changes and screenshots if appropriate._

### Related links

_Insert links related to this change, such as Notion pages, ClickUp tasks, or any other relevant sources._

---

- [ ] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated user-facing messages to consistently reference credit subtypes, ensuring that notifications and result displays present clearer and more uniform information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->