### PR TITLE
refactor(shared): introduce BoldStubsBuilder for simplified test data generation

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/check-participants-homologation/check-participants-homologation.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/check-participants-homologation/check-participants-homologation.lambda.e2e.spec.ts
@@ -1,21 +1,4 @@
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
-import { PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH } from '@carrot-fndn/shared/methodologies/bold/matchers';
-import {
-  stubDocumentEvent,
-  stubDocumentEventWithMetadataAttributes,
-  stubMassAuditDocument,
-  stubMassDocument,
-  stubParticipantHomologationDocument,
-} from '@carrot-fndn/shared/methodologies/bold/testing';
-import {
-  type Document,
-  DocumentCategory,
-  DocumentEventAttributeName,
-  DocumentEventName,
-  type DocumentReference,
-  DocumentSubtype,
-  DocumentType,
-} from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleOutput,
   RuleOutputStatus,
@@ -27,114 +10,15 @@ import {
   stubRuleResponse,
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
-import { addDays, formatDate, subDays } from 'date-fns';
 
 import { checkParticipantsHomologationLambda } from './check-participants-homologation.lambda';
-
-const { CLOSE } = DocumentEventName;
-const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } = DocumentEventAttributeName;
+import { createCheckParticipantsHomologationTestData } from './check-participants-homologation.stubs';
 
 describe('CheckParticipantsHomologationProcessor', () => {
   const documentKeyPrefix = faker.string.uuid();
 
-  // TODO: Refac this test to use a builder or a stub that prepares the documents https://app.clickup.com/t/86a36ut5a
-  const massId = faker.string.uuid();
-  const massAuditId = faker.string.uuid();
-  const homologatedParticipants = [
-    DocumentSubtype.HAULER,
-    DocumentSubtype.PROCESSOR,
-    DocumentSubtype.RECYCLER,
-    DocumentSubtype.WASTE_GENERATOR,
-  ];
-
-  const massReference: DocumentReference = {
-    category: DocumentCategory.METHODOLOGY,
-    documentId: massId,
-    type: DocumentType.ORGANIC,
-  };
-  const massAuditReference: DocumentReference = {
-    category: DocumentCategory.METHODOLOGY,
-    documentId: massAuditId,
-    subtype: DocumentSubtype.PROCESS,
-    type: DocumentType.MASS_AUDIT,
-  };
-  const participantsReference: Map<DocumentSubtype, DocumentReference> =
-    new Map(
-      homologatedParticipants.map((subtype) => [
-        subtype,
-        {
-          ...PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.match,
-          documentId: faker.string.uuid(),
-          subtype,
-        },
-      ]),
-    );
-
-  const homologationCloseEvent = stubDocumentEventWithMetadataAttributes(
-    { name: CLOSE },
-    [
-      [HOMOLOGATION_DUE_DATE, formatDate(addDays(new Date(), 2), 'yyyy-MM-dd')],
-      [HOMOLOGATION_DATE, formatDate(subDays(new Date(), 2), 'yyyy-MM-dd')],
-    ],
-  );
-
-  const participantsHomologationDocumentStubs: Map<DocumentSubtype, Document> =
-    new Map(
-      homologatedParticipants.map((subtype) => [
-        subtype,
-        stubParticipantHomologationDocument({
-          externalEvents: [
-            stubDocumentEvent({
-              name: DocumentEventName.OPEN,
-            }),
-            homologationCloseEvent,
-          ],
-          id: participantsReference.get(subtype)?.documentId ?? '',
-          subtype,
-        }),
-      ]),
-    );
-
-  const massDocumentStub = stubMassDocument({
-    externalEvents: [
-      ...homologatedParticipants.map((subtype) =>
-        stubDocumentEventWithMetadataAttributes(
-          {
-            name: DocumentEventName.ACTOR,
-            participant: {
-              id:
-                participantsHomologationDocumentStubs.get(subtype)
-                  ?.primaryParticipant.id ?? '',
-            },
-          },
-          // TODO: update this logic to use the event label when it's available
-          [[DocumentEventAttributeName.ACTOR_TYPE, subtype]],
-        ),
-      ),
-      stubDocumentEvent({
-        name: DocumentEventName.OUTPUT,
-        relatedDocument: massAuditReference,
-      }),
-    ],
-    id: massReference.documentId,
-  });
-  const massAuditDocumentStub = stubMassAuditDocument({
-    externalEvents: homologatedParticipants.map((subtype) =>
-      stubDocumentEvent({
-        name: DocumentEventName.LINK,
-        referencedDocument: participantsReference.get(subtype),
-        relatedDocument: undefined,
-      }),
-    ),
-    id: massAuditReference.documentId,
-    parentDocumentId: massDocumentStub.id,
-  });
-
-  const documents: Document[] = [
-    massAuditDocumentStub,
-    massDocumentStub,
-    ...participantsHomologationDocumentStubs.values(),
-  ];
+  const { documents, massAuditReference } =
+    createCheckParticipantsHomologationTestData();
 
   beforeAll(() => {
     prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/check-participants-homologation/check-participants-homologation.stubs.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/check-participants-homologation/check-participants-homologation.stubs.ts
@@ -1,0 +1,227 @@
+import {
+  stubDocumentEvent,
+  stubDocumentEventWithMetadataAttributes,
+  stubMassAuditDocument,
+  stubMassDocument,
+  stubParticipantHomologationDocument,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  type Document,
+  DocumentCategory,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  type DocumentReference,
+  DocumentSubtype,
+  DocumentType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { faker } from '@faker-js/faker';
+import { addDays, formatDate, subDays } from 'date-fns';
+
+const { CLOSE } = DocumentEventName;
+const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } = DocumentEventAttributeName;
+
+const DATE_FORMAT = 'yyyy-MM-dd';
+
+export const createCheckParticipantsHomologationTestData = (options?: {
+  homologatedParticipants?: DocumentSubtype[];
+  includeExpiredHomologation?: boolean;
+  massAuditId?: string;
+  massId?: string;
+}) => {
+  const massId = options?.massId ?? faker.string.uuid();
+  const massAuditId = options?.massAuditId ?? faker.string.uuid();
+  const homologatedParticipants = options?.homologatedParticipants ?? [
+    DocumentSubtype.HAULER,
+    DocumentSubtype.PROCESSOR,
+    DocumentSubtype.RECYCLER,
+    DocumentSubtype.WASTE_GENERATOR,
+  ];
+
+  const massReference: DocumentReference = {
+    category: DocumentCategory.METHODOLOGY,
+    documentId: massId,
+    type: DocumentType.ORGANIC,
+  };
+
+  const massAuditReference: DocumentReference = {
+    category: DocumentCategory.METHODOLOGY,
+    documentId: massAuditId,
+    subtype: DocumentSubtype.PROCESS,
+    type: DocumentType.MASS_AUDIT,
+  };
+
+  const participantsReference: Map<DocumentSubtype, DocumentReference> =
+    new Map(
+      homologatedParticipants.map((subtype) => [
+        subtype,
+        {
+          category: DocumentCategory.METHODOLOGY,
+          documentId: faker.string.uuid(),
+          subtype,
+          type: DocumentType.PARTICIPANT_HOMOLOGATION,
+        },
+      ]),
+    );
+
+  const expiredHomologationDocumentReference =
+    (options?.includeExpiredHomologation ?? false)
+      ? {
+          category: DocumentCategory.METHODOLOGY,
+          documentId: faker.string.uuid(),
+          subtype: DocumentSubtype.SOURCE,
+          type: DocumentType.PARTICIPANT_HOMOLOGATION,
+        }
+      : undefined;
+
+  const homologationCloseEvent = stubDocumentEventWithMetadataAttributes(
+    { name: CLOSE },
+    [
+      [HOMOLOGATION_DATE, formatDate(subDays(new Date(), 2), DATE_FORMAT)],
+      [HOMOLOGATION_DUE_DATE, formatDate(addDays(new Date(), 2), DATE_FORMAT)],
+    ],
+  );
+
+  const expiredCloseEvent = stubDocumentEventWithMetadataAttributes(
+    { name: CLOSE },
+    [
+      [HOMOLOGATION_DUE_DATE, formatDate(subDays(new Date(), 1), DATE_FORMAT)],
+      [HOMOLOGATION_DATE, formatDate(subDays(new Date(), 4), DATE_FORMAT)],
+    ],
+  );
+
+  const participantsHomologationDocumentStubs: Map<DocumentSubtype, Document> =
+    new Map(
+      homologatedParticipants.map((subtype) => [
+        subtype,
+        stubParticipantHomologationDocument({
+          externalEvents: [
+            stubDocumentEvent({
+              name: DocumentEventName.OPEN,
+            }),
+            homologationCloseEvent,
+          ],
+          id: participantsReference.get(subtype)?.documentId ?? '',
+          subtype,
+        }),
+      ]),
+    );
+
+  const expiredParticipantHomologationDocumentStub =
+    expiredHomologationDocumentReference
+      ? stubParticipantHomologationDocument({
+          externalEvents: [
+            stubDocumentEvent({
+              name: DocumentEventName.OPEN,
+            }),
+            expiredCloseEvent,
+          ],
+          id: expiredHomologationDocumentReference.documentId,
+          subtype: expiredHomologationDocumentReference.subtype,
+        })
+      : undefined;
+
+  const massDocumentStub = stubMassDocument({
+    externalEvents: [
+      ...homologatedParticipants.map((subtype) =>
+        stubDocumentEventWithMetadataAttributes(
+          {
+            name: DocumentEventName.ACTOR,
+            participant: {
+              id:
+                participantsHomologationDocumentStubs.get(subtype)
+                  ?.primaryParticipant.id ?? '',
+            },
+          },
+          [[DocumentEventAttributeName.ACTOR_TYPE, subtype]],
+        ),
+      ),
+      stubDocumentEvent({
+        name: DocumentEventName.OUTPUT,
+        relatedDocument: massAuditReference,
+      }),
+    ],
+    id: massReference.documentId,
+  });
+
+  const massAuditDocumentStub = stubMassAuditDocument({
+    externalEvents: homologatedParticipants.map((subtype) =>
+      stubDocumentEvent({
+        name: DocumentEventName.LINK,
+        referencedDocument: participantsReference.get(subtype),
+        relatedDocument: undefined,
+      }),
+    ),
+    id: massAuditReference.documentId,
+    parentDocumentId: massDocumentStub.id,
+  });
+
+  const sourceParticipantEvent = stubDocumentEvent({
+    name: DocumentEventName.ACTOR,
+    relatedDocument: {
+      category: DocumentCategory.METHODOLOGY,
+      subtype: DocumentSubtype.SOURCE,
+      type: DocumentType.PARTICIPANT_HOMOLOGATION,
+    },
+  });
+
+  const massWithExpiredHomologationStub =
+    expiredParticipantHomologationDocumentStub
+      ? {
+          ...massDocumentStub,
+          externalEvents: [
+            ...(massDocumentStub.externalEvents ?? []),
+            stubDocumentEvent({
+              name: DocumentEventName.ACTOR,
+              participant: {
+                id: expiredParticipantHomologationDocumentStub
+                  .primaryParticipant.id,
+              },
+            }),
+          ],
+        }
+      : undefined;
+
+  const massWithSourceParticipantStub = {
+    ...massDocumentStub,
+    externalEvents: [
+      ...(massDocumentStub.externalEvents ?? []),
+      sourceParticipantEvent,
+    ],
+  };
+
+  const massWithNoEventsStub = {
+    ...massDocumentStub,
+    externalEvents: [],
+  };
+
+  const documents: Document[] = [
+    massAuditDocumentStub,
+    massDocumentStub,
+    ...participantsHomologationDocumentStubs.values(),
+  ];
+
+  if (expiredParticipantHomologationDocumentStub) {
+    documents.push(expiredParticipantHomologationDocumentStub);
+  }
+
+  return {
+    documents,
+    expiredCloseEvent,
+    expiredHomologationDocumentReference,
+    expiredParticipantHomologationDocumentStub,
+    homologatedParticipants,
+    homologationCloseEvent,
+    massAuditDocumentStub,
+    massAuditId,
+    massAuditReference,
+    massDocumentStub,
+    massId,
+    massReference,
+    massWithExpiredHomologationStub,
+    massWithNoEventsStub,
+    massWithSourceParticipantStub,
+    participantsHomologationDocumentStubs,
+    participantsReference,
+    sourceParticipantEvent,
+  };
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.lambda.e2e.spec.ts
@@ -1,16 +1,10 @@
+import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
+import type { NonEmptyString } from '@carrot-fndn/shared/types';
+
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
 import { TRC_CREDIT_MATCH } from '@carrot-fndn/shared/methodologies/bold/matchers';
-import {
-  stubMassAuditDocument,
-  stubMassDocument,
-} from '@carrot-fndn/shared/methodologies/bold/testing';
-import {
-  type Document,
-  DocumentCategory,
-  type DocumentReference,
-  DocumentSubtype,
-  DocumentType,
-} from '@carrot-fndn/shared/methodologies/bold/types';
+import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { DocumentStatus } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleOutput,
   RuleOutputStatus,
@@ -22,41 +16,88 @@ import {
   stubRuleResponse,
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
+import { random } from 'typia';
 
 import { creditAbsenceLambda } from './credit-absence.lambda';
 
-describe('CheckTCCAbsenceProcessor', () => {
+describe('CheckTCCAbsenceProcessor E2E', () => {
   const lambda = creditAbsenceLambda(TRC_CREDIT_MATCH);
   const documentKeyPrefix = faker.string.uuid();
 
-  // TODO: Refac this test to use a builder or a stub that prepares the documents https://app.clickup.com/t/86a36ut5a
-  const massId = faker.string.uuid();
-  const massAuditId = faker.string.uuid();
+  const massIdWithCreditStubs = new BoldStubsBuilder().withCredits().build();
+  const massIdWithoutCreditsStubs = new BoldStubsBuilder().build();
+  const massIdWithMultipleCreditsStubs = new BoldStubsBuilder()
+    .withCredits({
+      count: 4,
+    })
+    .build();
 
-  const massReference: DocumentReference = {
-    category: DocumentCategory.METHODOLOGY,
-    documentId: massId,
-    type: DocumentType.ORGANIC,
-  };
-  const massAuditReference: DocumentReference = {
-    category: DocumentCategory.METHODOLOGY,
-    documentId: massAuditId,
-    subtype: DocumentSubtype.PROCESS,
-    type: DocumentType.MASS_AUDIT,
-  };
-  const massDocumentStub = stubMassDocument({
-    id: massReference.documentId,
-  });
-  const massAuditDocumentStub = stubMassAuditDocument({
-    id: massAuditReference.documentId,
-    parentDocumentId: massDocumentStub.id,
-  });
-
-  const documents: Document[] = [massAuditDocumentStub, massDocumentStub];
-
-  beforeAll(() => {
+  it.each([
+    {
+      documents: [massIdWithoutCreditsStubs.massIdDocumentStub],
+      massIdAuditDocument: massIdWithoutCreditsStubs.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario: 'should return APPROVED when no Credit is linked to the MassID',
+    },
+    {
+      documents: [
+        massIdWithCreditStubs.massIdDocumentStub,
+        {
+          ...(massIdWithCreditStubs.creditDocumentsStubs[0] as Document),
+          status: DocumentStatus.CANCELLED,
+        } as Document,
+      ],
+      massIdAuditDocument: massIdWithCreditStubs.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario:
+        'should return APPROVED when there is a Credit linked to the MassID, but it is cancelled',
+    },
+    {
+      documents: [
+        massIdWithCreditStubs.massIdDocumentStub,
+        ...massIdWithCreditStubs.creditDocumentsStubs,
+      ],
+      massIdAuditDocument: massIdWithCreditStubs.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when a no Cancelled Credit is linked to the MassID',
+    },
+    {
+      documents: [
+        massIdWithMultipleCreditsStubs.massIdDocumentStub,
+        ...massIdWithMultipleCreditsStubs.creditDocumentsStubs.map(
+          (creditDocumentStub) => ({
+            ...creditDocumentStub,
+            status: DocumentStatus.CANCELLED,
+          }),
+        ),
+      ],
+      massIdAuditDocument:
+        massIdWithMultipleCreditsStubs.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario:
+        'should return APPROVED when there are more than one Credit linked to the MassID, but all are cancelled',
+    },
+    {
+      documents: [
+        massIdWithMultipleCreditsStubs.massIdDocumentStub,
+        ...massIdWithMultipleCreditsStubs.creditDocumentsStubs.map(
+          (creditDocumentStub, index) => ({
+            ...creditDocumentStub,
+            status:
+              index === 0 ? random<NonEmptyString>() : DocumentStatus.CANCELLED,
+          }),
+        ),
+      ],
+      massIdAuditDocument:
+        massIdWithMultipleCreditsStubs.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when there are more than one Credit linked to the MassID, but one is not cancelled',
+    },
+  ])('$scenario', async ({ documents, massIdAuditDocument, resultStatus }) => {
     prepareEnvironmentTestE2E(
-      documents.map((document) => ({
+      [...documents, massIdAuditDocument].map((document) => ({
         document,
         documentKey: toDocumentKey({
           documentId: document.id,
@@ -64,18 +105,16 @@ describe('CheckTCCAbsenceProcessor', () => {
         }),
       })),
     );
-  });
 
-  it('should return APPROVED when the MassID has no TCC linked', async () => {
     const response = (await lambda(
       stubRuleInput({
-        documentId: massAuditReference.documentId,
+        documentId: massIdAuditDocument.id,
         documentKeyPrefix,
       }),
       stubContext(),
       () => stubRuleResponse(),
     )) as RuleOutput;
 
-    expect(response.resultStatus).toBe(RuleOutputStatus.APPROVED);
+    expect(response.resultStatus).toBe(resultStatus);
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.spec.ts
@@ -3,28 +3,18 @@ import type { NonEmptyString } from '@carrot-fndn/shared/types';
 import { spyOnDocumentQueryServiceLoad } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { TRC_CREDIT_MATCH } from '@carrot-fndn/shared/methodologies/bold/matchers';
 import {
-  stubCreditDocument,
+  BoldStubsBuilder,
   stubDocument,
-  stubDocumentEvent,
-  stubMassAuditDocument,
-  stubMassDocument,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type Document,
-  DocumentCategory,
-  DocumentEventName,
-  type DocumentReference,
   DocumentStatus,
-  DocumentSubtype,
-  DocumentType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleInput,
   type RuleOutput,
   RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
-import { stubArray } from '@carrot-fndn/shared/testing';
-import { faker } from '@faker-js/faker';
 import { assert, random } from 'typia';
 
 import { CreditAbsenceProcessor } from './credit-absence.processor';
@@ -34,82 +24,31 @@ describe('CreditAbsenceProcessor', () => {
   const ruleDataProcessor = new CreditAbsenceProcessor(TRC_CREDIT_MATCH);
   const processorError = new CreditAbsenceProcessorErrors();
 
-  const massId = faker.string.uuid();
-  const massAuditId = faker.string.uuid();
-
-  const massReference: DocumentReference = {
-    category: DocumentCategory.METHODOLOGY,
-    documentId: massId,
-    type: DocumentType.ORGANIC,
-  };
-  const massAuditReference: DocumentReference = {
-    category: DocumentCategory.METHODOLOGY,
-    documentId: massAuditId,
-    subtype: DocumentSubtype.PROCESS,
-    type: DocumentType.MASS_AUDIT,
-  };
-  const validTCCReferences: DocumentReference[] = stubArray(() => ({
-    category: DocumentCategory.METHODOLOGY,
-    documentId: faker.string.uuid(),
-    subtype: DocumentSubtype.TRC,
-    type: DocumentType.CREDIT,
-  }));
-  const cancelledTCCReferences: DocumentReference[] = stubArray(() => ({
-    category: DocumentCategory.METHODOLOGY,
-    documentId: faker.string.uuid(),
-    subtype: DocumentSubtype.TRC,
-    type: DocumentType.CREDIT,
-  }));
-  const validTCCDocumentsStubs: Map<string, Document> = new Map(
-    validTCCReferences.map((reference) => [
-      reference.documentId,
-      stubCreditDocument({
-        id: reference.documentId,
-        subtype: reference.subtype,
-      }),
-    ]),
-  );
-  const cancelledTCCDocumentsStubs: Map<string, Document> = new Map(
-    cancelledTCCReferences.map((reference) => [
-      reference.documentId,
-      stubCreditDocument({
-        id: reference.documentId,
-        status: DocumentStatus.CANCELLED,
-        subtype: reference.subtype,
-      }),
-    ]),
-  );
-  const massDocumentStub = stubMassDocument({
-    id: massReference.documentId,
-  });
-  const massAuditDocumentStub = stubMassAuditDocument({
-    id: massAuditReference.documentId,
-    parentDocumentId: massDocumentStub.id,
-  });
+  const massIdWithCreditStubs = new BoldStubsBuilder().withCredits().build();
+  const massIdWithoutCreditsStubs = new BoldStubsBuilder().build();
+  const massIdWithMultipleCreditsStubs = new BoldStubsBuilder()
+    .withCredits({
+      count: 4,
+    })
+    .build();
 
   it.each([
     {
-      documents: [massDocumentStub],
+      documents: [massIdWithoutCreditsStubs.massIdDocumentStub],
+      massIdAuditDocument: massIdWithoutCreditsStubs.massIdAuditDocumentStub,
       resultComment: ruleDataProcessor['RESULT_COMMENT'].APPROVED,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario: 'should return APPROVED when no Credit is linked to the MassID',
     },
     {
       documents: [
+        massIdWithCreditStubs.massIdDocumentStub,
         {
-          ...massDocumentStub,
-          externalEvents: [
-            ...(massDocumentStub.externalEvents ?? []),
-            stubDocumentEvent({
-              name: DocumentEventName.RELATED,
-              relatedDocument: cancelledTCCReferences[0],
-            }),
-          ],
-        },
-        cancelledTCCDocumentsStubs.get(
-          cancelledTCCReferences[0]!.documentId,
-        ) as Document,
+          ...massIdWithCreditStubs.creditDocumentsStubs[0],
+          status: DocumentStatus.CANCELLED,
+        } as Document,
       ],
+      massIdAuditDocument: massIdWithCreditStubs.massIdAuditDocumentStub,
       resultComment: ruleDataProcessor['RESULT_COMMENT'].APPROVED,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
@@ -117,20 +56,10 @@ describe('CreditAbsenceProcessor', () => {
     },
     {
       documents: [
-        {
-          ...massDocumentStub,
-          externalEvents: [
-            ...(massDocumentStub.externalEvents ?? []),
-            stubDocumentEvent({
-              name: DocumentEventName.RELATED,
-              relatedDocument: validTCCReferences[0],
-            }),
-          ],
-        },
-        validTCCDocumentsStubs.get(
-          validTCCReferences[0]!.documentId,
-        ) as Document,
+        massIdWithCreditStubs.massIdDocumentStub,
+        ...massIdWithCreditStubs.creditDocumentsStubs,
       ],
+      massIdAuditDocument: massIdWithCreditStubs.massIdAuditDocumentStub,
       resultComment:
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT(
           assert<NonEmptyString>(TRC_CREDIT_MATCH.match.subtype),
@@ -141,20 +70,16 @@ describe('CreditAbsenceProcessor', () => {
     },
     {
       documents: [
-        {
-          ...massDocumentStub,
-          externalEvents: [
-            ...(massDocumentStub.externalEvents ?? []),
-            ...cancelledTCCReferences.map((reference) =>
-              stubDocumentEvent({
-                name: DocumentEventName.RELATED,
-                relatedDocument: reference,
-              }),
-            ),
-          ],
-        },
-        ...cancelledTCCDocumentsStubs.values(),
+        massIdWithMultipleCreditsStubs.massIdDocumentStub,
+        ...massIdWithMultipleCreditsStubs.creditDocumentsStubs.map(
+          (creditDocumentStub: Document) => ({
+            ...creditDocumentStub,
+            status: DocumentStatus.CANCELLED,
+          }),
+        ),
       ],
+      massIdAuditDocument:
+        massIdWithMultipleCreditsStubs.massIdAuditDocumentStub,
       resultComment: ruleDataProcessor['RESULT_COMMENT'].APPROVED,
       resultStatus: RuleOutputStatus.APPROVED,
       scenario:
@@ -162,27 +87,17 @@ describe('CreditAbsenceProcessor', () => {
     },
     {
       documents: [
-        {
-          ...massDocumentStub,
-          externalEvents: [
-            ...(massDocumentStub.externalEvents ?? []),
-            stubDocumentEvent({
-              name: DocumentEventName.RELATED,
-              relatedDocument: validTCCReferences[0],
-            }),
-            ...cancelledTCCReferences.map((reference) =>
-              stubDocumentEvent({
-                name: DocumentEventName.RELATED,
-                relatedDocument: reference,
-              }),
-            ),
-          ],
-        },
-        validTCCDocumentsStubs.get(
-          validTCCReferences[0]!.documentId,
-        ) as Document,
-        ...cancelledTCCDocumentsStubs.values(),
+        massIdWithMultipleCreditsStubs.massIdDocumentStub,
+        ...massIdWithMultipleCreditsStubs.creditDocumentsStubs.map(
+          (creditDocumentStub: Document, index: number) => ({
+            ...creditDocumentStub,
+            status:
+              index === 0 ? random<NonEmptyString>() : DocumentStatus.CANCELLED,
+          }),
+        ),
       ],
+      massIdAuditDocument:
+        massIdWithMultipleCreditsStubs.massIdAuditDocumentStub,
       resultComment:
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT(
           assert<NonEmptyString>(TRC_CREDIT_MATCH.match.subtype),
@@ -191,27 +106,30 @@ describe('CreditAbsenceProcessor', () => {
       scenario:
         'should return REJECTED when there are more than one Credit linked to the MassID, but one is not cancelled',
     },
-  ])('$scenario', async ({ documents, resultComment, resultStatus }) => {
-    spyOnDocumentQueryServiceLoad(stubDocument(), [
-      massAuditDocumentStub,
-      ...documents,
-    ]);
+  ])(
+    '$scenario',
+    async ({ documents, massIdAuditDocument, resultComment, resultStatus }) => {
+      spyOnDocumentQueryServiceLoad(stubDocument(), [
+        ...documents,
+        massIdAuditDocument,
+      ]);
 
-    const ruleInput = {
-      ...random<Required<RuleInput>>(),
-      documentId: massAuditId,
-    };
+      const ruleInput = {
+        ...random<Required<RuleInput>>(),
+        documentId: massIdAuditDocument.id,
+      };
 
-    const ruleOutput = await ruleDataProcessor.process(ruleInput);
+      const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
-    const expectedRuleOutput: RuleOutput = {
-      requestId: ruleInput.requestId,
-      responseToken: ruleInput.responseToken,
-      responseUrl: ruleInput.responseUrl,
-      resultComment,
-      resultStatus,
-    };
+      const expectedRuleOutput: RuleOutput = {
+        requestId: ruleInput.requestId,
+        responseToken: ruleInput.responseToken,
+        responseUrl: ruleInput.responseUrl,
+        resultComment,
+        resultStatus,
+      };
 
-    expect(ruleOutput).toEqual(expectedRuleOutput);
-  });
+      expect(ruleOutput).toEqual(expectedRuleOutput);
+    },
+  );
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.processor.spec.ts
@@ -1,26 +1,14 @@
 import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
-  stubDocument,
-  stubDocumentEvent,
-} from '@carrot-fndn/shared/methodologies/bold/testing';
-import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import {
   type RuleInput,
   RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
-import { addDays, addHours, subDays, subSeconds } from 'date-fns';
 import { random } from 'typia';
 
 import { ProjectPeriodProcessor } from './project-period.processor';
+import { createProjectPeriodTestData } from './project-period.stubs';
 
 jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
-
-const createBRTDateString = (date: Date): string => {
-  const utcDate = new Date(date);
-  const brtAsUtc = addHours(utcDate, 3);
-
-  return brtAsUtc.toISOString();
-};
 
 class TestProjectPeriodProcessor extends ProjectPeriodProcessor {
   public getTestEligibleDate(): Date {
@@ -32,13 +20,22 @@ describe('ProjectPeriodProcessor', () => {
   const ruleDataProcessor = new TestProjectPeriodProcessor();
   const documentLoaderService = jest.mocked(loadParentDocument);
 
-  const { RECYCLED } = DocumentEventName;
-
   const getEligibleDate = () => ruleDataProcessor.getTestEligibleDate();
+
+  // Get test data from stubs
+  const {
+    documentWithAfterEligibleDateEvent,
+    documentWithBRTEligibleDateEvent,
+    documentWithBeforeEligibleDateEvent,
+    documentWithExactBRTEligibleDateEvent,
+    documentWithExactEligibleDateEvent,
+    documentWithMissingExternalCreatedAtEvent,
+    documentWithNoRecycledEvent,
+  } = createProjectPeriodTestData({ eligibleDate: getEligibleDate() });
 
   it.each([
     {
-      externalCreatedAt: addDays(getEligibleDate(), 1).toISOString(),
+      document: documentWithAfterEligibleDateEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT'].ELIGIBLE(getEligibleDate()),
       resultStatus: RuleOutputStatus.APPROVED,
@@ -46,7 +43,7 @@ describe('ProjectPeriodProcessor', () => {
         'should APPROVE the rule if the Recycled event was created after the eligible date',
     },
     {
-      externalCreatedAt: subDays(getEligibleDate(), 1).toISOString(),
+      document: documentWithBeforeEligibleDateEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT'].INELIGIBLE(getEligibleDate()),
       resultStatus: RuleOutputStatus.REJECTED,
@@ -54,7 +51,7 @@ describe('ProjectPeriodProcessor', () => {
         'should REJECT the rule if the Recycled event was created before the eligible date',
     },
     {
-      externalCreatedAt: getEligibleDate().toISOString(),
+      document: documentWithExactEligibleDateEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT'].ELIGIBLE(getEligibleDate()),
       resultStatus: RuleOutputStatus.APPROVED,
@@ -62,7 +59,7 @@ describe('ProjectPeriodProcessor', () => {
         'should APPROVE the rule if the Recycled event was created on the eligible date',
     },
     {
-      externalCreatedAt: getEligibleDate().toISOString(),
+      document: documentWithExactEligibleDateEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT'].ELIGIBLE(getEligibleDate()),
       resultStatus: RuleOutputStatus.APPROVED,
@@ -70,7 +67,7 @@ describe('ProjectPeriodProcessor', () => {
         'should APPROVE the rule if the Recycled event was created on the eligible date',
     },
     {
-      externalCreatedAt: createBRTDateString(subSeconds(getEligibleDate(), 1)),
+      document: documentWithBRTEligibleDateEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT'].ELIGIBLE(getEligibleDate()),
       resultStatus: RuleOutputStatus.APPROVED,
@@ -78,7 +75,7 @@ describe('ProjectPeriodProcessor', () => {
         'should APPROVE the rule if the Recycled event was created 1 second before the eligible date in UTC but appears after in BRT timezone',
     },
     {
-      externalCreatedAt: createBRTDateString(getEligibleDate()),
+      document: documentWithExactBRTEligibleDateEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT'].ELIGIBLE(getEligibleDate()),
       resultStatus: RuleOutputStatus.APPROVED,
@@ -86,7 +83,7 @@ describe('ProjectPeriodProcessor', () => {
         'should APPROVE the rule if the Recycled event was created exactly at the eligible date (BRT timezone)',
     },
     {
-      externalCreatedAt: undefined,
+      document: documentWithMissingExternalCreatedAtEvent,
       resultComment:
         ruleDataProcessor['RESULT_COMMENT']
           .MISSING_RECYCLED_EVENT_EXTERNAL_CREATED_AT,
@@ -94,44 +91,28 @@ describe('ProjectPeriodProcessor', () => {
       scenario:
         'should REJECT the rule if the Recycled event has no externalCreatedAt attribute',
     },
-  ])(
-    '$scenario',
-    async ({ externalCreatedAt, resultComment, resultStatus }) => {
-      const ruleInput = random<Required<RuleInput>>();
+  ])('$scenario', async ({ document, resultComment, resultStatus }) => {
+    const ruleInput = random<Required<RuleInput>>();
 
-      const document = stubDocument({
-        externalEvents: [
-          stubDocumentEvent({
-            externalCreatedAt,
-            name: RECYCLED,
-          }),
-        ],
-      });
+    documentLoaderService.mockResolvedValueOnce(document);
 
-      documentLoaderService.mockResolvedValueOnce(document);
+    const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
-      const ruleOutput = await ruleDataProcessor.process(ruleInput);
+    expect(ruleOutput).toMatchObject({
+      requestId: ruleInput.requestId,
+      responseToken: ruleInput.responseToken,
+      responseUrl: ruleInput.responseUrl,
+      resultComment,
+      resultStatus,
+    });
 
-      expect(ruleOutput).toMatchObject({
-        requestId: ruleInput.requestId,
-        responseToken: ruleInput.responseToken,
-        responseUrl: ruleInput.responseUrl,
-        resultComment,
-        resultStatus,
-      });
-
-      expect(typeof ruleOutput.resultComment).toBe('string');
-    },
-  );
+    expect(typeof ruleOutput.resultComment).toBe('string');
+  });
 
   it('should REJECT the rule if the Recycled event is not found', async () => {
     const ruleInput = random<Required<RuleInput>>();
 
-    const document = stubDocument({
-      externalEvents: [],
-    });
-
-    documentLoaderService.mockResolvedValueOnce(document);
+    documentLoaderService.mockResolvedValueOnce(documentWithNoRecycledEvent);
 
     const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.stubs.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.stubs.ts
@@ -1,0 +1,104 @@
+import {
+  stubDocument,
+  stubDocumentEvent,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
+import { addDays, addHours, subDays, subSeconds } from 'date-fns';
+
+const { RECYCLED } = DocumentEventName;
+
+/**
+ * Creates a BRT timezone date string from a Date object
+ * BRT is UTC-3, so we add 3 hours to convert from UTC to BRT
+ */
+export const createBRTDateString = (date: Date): string => {
+  const utcDate = new Date(date);
+  const brtAsUtc = addHours(utcDate, 3);
+
+  return brtAsUtc.toISOString();
+};
+
+/**
+ * Creates test data for project period tests
+ */
+export const createProjectPeriodTestData = (options?: {
+  eligibleDate?: Date;
+}) => {
+  const eligibleDate = options?.eligibleDate ?? new Date();
+
+  // Create document with recycled event after eligible date
+  const documentWithAfterEligibleDateEvent = stubDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        externalCreatedAt: addDays(eligibleDate, 1).toISOString(),
+        name: RECYCLED,
+      }),
+    ],
+  });
+
+  // Create document with recycled event before eligible date
+  const documentWithBeforeEligibleDateEvent = stubDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        externalCreatedAt: subDays(eligibleDate, 1).toISOString(),
+        name: RECYCLED,
+      }),
+    ],
+  });
+
+  // Create document with recycled event exactly at eligible date
+  const documentWithExactEligibleDateEvent = stubDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        externalCreatedAt: eligibleDate.toISOString(),
+        name: RECYCLED,
+      }),
+    ],
+  });
+
+  // Create document with recycled event 1 second before eligible date in UTC but after in BRT
+  const documentWithBRTEligibleDateEvent = stubDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        externalCreatedAt: createBRTDateString(subSeconds(eligibleDate, 1)),
+        name: RECYCLED,
+      }),
+    ],
+  });
+
+  // Create document with recycled event exactly at eligible date in BRT
+  const documentWithExactBRTEligibleDateEvent = stubDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        externalCreatedAt: createBRTDateString(eligibleDate),
+        name: RECYCLED,
+      }),
+    ],
+  });
+
+  // Create document with recycled event missing externalCreatedAt
+  const documentWithMissingExternalCreatedAtEvent = stubDocument({
+    externalEvents: [
+      stubDocumentEvent({
+        externalCreatedAt: undefined,
+        name: RECYCLED,
+      }),
+    ],
+  });
+
+  // Create document with no recycled event
+  const documentWithNoRecycledEvent = stubDocument({
+    externalEvents: [],
+  });
+
+  return {
+    documentWithAfterEligibleDateEvent,
+    documentWithBRTEligibleDateEvent,
+    documentWithBeforeEligibleDateEvent,
+    documentWithExactBRTEligibleDateEvent,
+    documentWithExactEligibleDateEvent,
+    documentWithMissingExternalCreatedAtEvent,
+    documentWithNoRecycledEvent,
+    eligibleDate,
+  };
+};

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -1,0 +1,275 @@
+import type { NonEmptyArray } from '@carrot-fndn/shared/types';
+
+import {
+  type Document,
+  DocumentCategory,
+  DocumentEventName,
+  type DocumentReference,
+  DocumentSubtype,
+  DocumentType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { stubArray } from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+
+import {
+  stubCreditDocument,
+  stubDocumentEvent,
+  stubMassAuditDocument,
+  stubMassDocument,
+  stubMethodologyDefinitionDocument,
+  stubParticipantHomologationDocument,
+  stubParticipantHomologationGroupDocument,
+} from '../stubs';
+
+export interface BoldStubsBuilderOptions {
+  massIdAuditDocumentId?: string;
+  massIdDocumentId?: string;
+}
+
+export interface BoldStubsBuilderResult {
+  baseDocuments: Document[];
+  creditDocumentsStubs: Document[];
+  massIdAuditDocumentStub: Document;
+  massIdAuditId: string;
+  massIdDocumentId: string;
+  massIdDocumentStub: Document;
+  methodologyDocumentStub?: Document;
+}
+
+export class BoldStubsBuilder {
+  private creditDocumentsStubs: Document[] = [];
+
+  private creditReferences: DocumentReference[] = [];
+
+  private massAuditDocumentStub: Document;
+
+  private massAuditReference: DocumentReference;
+
+  private massIdAuditDocumentId: string;
+
+  private massIdDocumentId: string;
+
+  private massIdDocumentStub: Document;
+
+  private massIdReference: DocumentReference;
+
+  private methodologyDocumentStub: Document;
+
+  private methodologyDocumentsCreated = false;
+
+  private methodologyReference: DocumentReference;
+
+  private participantHomologationGroupDocumentStub: Document;
+
+  private participantHomologationGroupReference: DocumentReference;
+
+  private participantsHomologationDocumentStubs: Map<string, Document> =
+    new Map();
+
+  private participantsHomologationReferences: Map<string, DocumentReference> =
+    new Map();
+
+  constructor(options: BoldStubsBuilderOptions = {}) {
+    this.massIdDocumentId = options.massIdDocumentId ?? faker.string.uuid();
+    this.massIdAuditDocumentId =
+      options.massIdAuditDocumentId ?? faker.string.uuid();
+
+    this.massIdReference = {
+      category: DocumentCategory.MASS_ID,
+      documentId: this.massIdDocumentId,
+      subtype: DocumentSubtype.FOOD_WASTE,
+      type: DocumentType.ORGANIC,
+    };
+
+    this.massAuditReference = {
+      category: DocumentCategory.METHODOLOGY,
+      documentId: this.massIdAuditDocumentId,
+      subtype: DocumentSubtype.PROCESS,
+      type: DocumentType.MASS_ID_AUDIT,
+    };
+
+    this.massIdDocumentStub = stubMassDocument({
+      externalEvents: [
+        stubDocumentEvent({
+          name: DocumentEventName.OUTPUT,
+          relatedDocument: this.massAuditReference,
+        }),
+      ],
+      id: this.massIdReference.documentId,
+    });
+
+    this.massAuditDocumentStub = stubMassAuditDocument({
+      externalEvents: [
+        stubDocumentEvent({
+          name: DocumentEventName.LINK,
+          referencedDocument: this.massIdReference,
+          relatedDocument: undefined,
+        }),
+      ],
+      id: this.massAuditReference.documentId,
+      parentDocumentId: this.massIdDocumentStub.id,
+    });
+  }
+
+  build(): BoldStubsBuilderResult {
+    const result: BoldStubsBuilderResult = {
+      baseDocuments: [this.massAuditDocumentStub, this.massIdDocumentStub],
+      creditDocumentsStubs: this.creditDocumentsStubs,
+      massIdAuditDocumentStub: this.massAuditDocumentStub,
+      massIdAuditId: this.massIdAuditDocumentId,
+      massIdDocumentId: this.massIdDocumentId,
+      massIdDocumentStub: this.massIdDocumentStub,
+      methodologyDocumentStub: this.methodologyDocumentStub,
+    };
+
+    return result;
+  }
+
+  createMethodologyDocuments(): BoldStubsBuilder {
+    this.methodologyReference = {
+      category: DocumentCategory.METHODOLOGY,
+      documentId: faker.string.uuid(),
+      type: DocumentType.DEFINITION,
+    };
+
+    this.participantHomologationGroupReference = {
+      category: DocumentCategory.METHODOLOGY,
+      documentId: faker.string.uuid(),
+      subtype: DocumentSubtype.GROUP,
+      type: DocumentType.PARTICIPANT_HOMOLOGATION,
+    };
+
+    this.participantHomologationGroupDocumentStub =
+      stubParticipantHomologationGroupDocument({
+        id: this.participantHomologationGroupReference.documentId,
+        parentDocumentId: this.methodologyReference.documentId,
+      });
+
+    this.methodologyDocumentStub = stubMethodologyDefinitionDocument({
+      externalEvents: [
+        stubDocumentEvent({
+          name: DocumentEventName.OUTPUT,
+          relatedDocument: this.participantHomologationGroupReference,
+        }),
+      ],
+      id: this.methodologyReference.documentId,
+    });
+
+    this.massAuditDocumentStub = {
+      ...this.massAuditDocumentStub,
+      externalEvents: [
+        ...(this.massAuditDocumentStub.externalEvents ?? []),
+        stubDocumentEvent({
+          name: DocumentEventName.LINK,
+          referencedDocument: this.methodologyReference,
+          relatedDocument: undefined,
+        }),
+      ],
+    };
+
+    this.methodologyDocumentsCreated = true;
+
+    return this;
+  }
+
+  createParticipantHomologationDocuments(
+    homologationSubtypes: NonEmptyArray<DocumentSubtype>,
+  ): BoldStubsBuilder {
+    if (!this.methodologyDocumentsCreated) {
+      throw new Error(
+        'Methodology documents must be created first. Call createMethodologyDocuments() before this method.',
+      );
+    }
+
+    for (const subtype of homologationSubtypes) {
+      this.participantsHomologationReferences.set(subtype, {
+        category: DocumentCategory.METHODOLOGY,
+        documentId: faker.string.uuid(),
+        subtype,
+        type: DocumentType.PARTICIPANT_HOMOLOGATION,
+      });
+
+      this.participantsHomologationDocumentStubs.set(
+        subtype,
+        stubParticipantHomologationDocument({
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          id: this.participantsHomologationReferences.get(subtype)!.documentId,
+          parentDocumentId:
+            this.participantHomologationGroupReference.documentId,
+        }),
+      );
+
+      this.participantHomologationGroupDocumentStub = {
+        ...this.participantHomologationGroupDocumentStub,
+        externalEvents: [
+          ...(this.participantHomologationGroupDocumentStub.externalEvents ??
+            []),
+          stubDocumentEvent({
+            name: DocumentEventName.OUTPUT,
+            relatedDocument:
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              this.participantsHomologationReferences.get(subtype)!,
+          }),
+        ],
+      };
+
+      this.massAuditDocumentStub = {
+        ...this.massAuditDocumentStub,
+        externalEvents: [
+          ...(this.massAuditDocumentStub.externalEvents ?? []),
+          stubDocumentEvent({
+            name: DocumentEventName.LINK,
+            referencedDocument:
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              this.participantsHomologationReferences.get(subtype)!,
+            relatedDocument: undefined,
+          }),
+        ],
+      };
+    }
+
+    return this;
+  }
+
+  withCredits({
+    count = 1,
+    creditType = DocumentSubtype.TRC,
+  }: {
+    count?: number;
+    creditType?: DocumentSubtype.TCC | DocumentSubtype.TRC;
+  } = {}): BoldStubsBuilder {
+    const creditCount = Math.max(1, count);
+
+    this.creditReferences = stubArray(
+      () => ({
+        category: DocumentCategory.METHODOLOGY,
+        documentId: faker.string.uuid(),
+        subtype: creditType,
+        type: DocumentType.CREDIT,
+      }),
+      { max: creditCount },
+    );
+
+    this.creditDocumentsStubs = this.creditReferences.map((reference) =>
+      stubCreditDocument({
+        id: reference.documentId,
+        subtype: reference.subtype,
+      }),
+    );
+
+    this.massIdDocumentStub = {
+      ...this.massIdDocumentStub,
+      externalEvents: [
+        ...(this.massIdDocumentStub.externalEvents ?? []),
+        ...this.creditReferences.map((reference) =>
+          stubDocumentEvent({
+            name: DocumentEventName.RELATED,
+            relatedDocument: reference,
+          }),
+        ),
+      ],
+    };
+
+    return this;
+  }
+}

--- a/libs/shared/methodologies/bold/testing/src/builders/index.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/index.ts
@@ -1,0 +1,1 @@
+export * from './bold-stub.builder';

--- a/libs/shared/methodologies/bold/testing/src/index.ts
+++ b/libs/shared/methodologies/bold/testing/src/index.ts
@@ -1,3 +1,4 @@
 export * from './stubs';
 export * from './documents';
 export * from './utils';
+export * from './builders';

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -2,6 +2,7 @@ import { MethodologyDocumentEventName } from '@carrot-fndn/shared/types';
 
 export enum DocumentCategory {
   MASS = 'Mass',
+  MASS_ID = 'MassID',
   METHODOLOGY = 'Methodology',
 }
 
@@ -16,6 +17,7 @@ export enum DocumentType {
   MASS_AUDIT = 'Mass Audit',
   MASS_CERTIFICATE = 'Mass Certificate',
   MASS_CERTIFICATE_AUDIT = 'Mass Certificate Audit',
+  MASS_ID_AUDIT = 'MassID Audit',
   ORGANIC = 'Organic',
   PARTICIPANT_HOMOLOGATION = 'Participant Homologation',
 }


### PR DESCRIPTION
### Summary

This commit introduces a new `BoldStubsBuilder` in the shared testing library to simplify the creation of complex test data across multiple rule processors. The builder provides a flexible and reusable way to generate stubs for MassID, methodology, and credit documents.

### Details

Key changes:
- Added `BoldStubsBuilder` with methods to create methodology, participant homologation, and credit documents
- Updated project-period, credit-absence, and check-participants-homologation tests to use the new builder
- Created stubs files for project-period and check-participants-homologation to improve test organization
- Added new document category and type for MassID related documents

The new builder reduces boilerplate code in tests and provides a more consistent approach to creating test data.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced simulation of various document processing scenarios, including credit absence, participant verification, and project period handling to ensure robust validations.
  
- **Refactor**
  - Consolidated multiple test data setups into unified utilities, improving maintainability and reducing redundancy.
  
- **New Features**
  - Expanded document categorization with additional types for more precise classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->