### PR TITLE
feat(rule): add project size rule processor

### DIFF
--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/.eslintrc.js
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/.eslintrc.js
@@ -1,0 +1,7 @@
+const {
+  getBaseEslintConfig,
+} = require('../../../../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/README.md
@@ -1,0 +1,30 @@
+<div align="center">
+
+# Project Size
+
+Methodology: **BOLD-RECYCLING-ORGANIC**
+
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/carrot-foundation/methodology-rules/check-and-deploy.yaml)](https://github.com/carrot-foundation/smaug/actions)
+
+</div>
+
+## 📄 Description
+
+<!-- TODO: Update README rule descriptions <https://app.clickup.com/t/3005225/CARROT-1943> -->
+
+## 📂 Implementation
+
+- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.processor.ts)**
+
+## 👥 Contributors
+
+[![AMarcosCastelo](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/43973049?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/AMarcosCastelo)
+[![andtankian](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/12521890?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/andtankian)
+[![cris-santos](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/7927374?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/cris-santos)
+[![gabrielsl96](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/49005645?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/gabrielsl96)
+[![GLGuilherme](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/26340386?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/GLGuilherme)
+[![sangalli](https://images.weserv.nl/?url=avatars.githubusercontent.com/u/11515359?v=4&h=60&w=60&fit=cover&mask=circle&maxage=7d)](https://github.com/sangalli)
+
+## 🔑 License
+
+[License](https://github.com/carrot-foundation/methodology-rules/blob/main/LICENSE)

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/jest.config.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/jest.config.ts
@@ -1,0 +1,3 @@
+import { getJestBaseConfig } from '../../../../../../.jest/config/jest.base.config';
+
+export default getJestBaseConfig(__dirname);

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/package.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@carrot-fndn/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size",
+  "version": "0.0.0"
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/project.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/project.json
@@ -1,0 +1,14 @@
+{
+  "name": "methodologies-bold-carbon-organic-rule-processors-mass-id-project-size",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["methodology:bold", "processor:mass-id", "type:app"],
+  "sourceRoot": "apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/src",
+  "projectType": "application",
+  "targets": {
+    "build-lambda": {},
+    "lint": {},
+    "package-lambda": {},
+    "upload-lambda": {},
+    "ts": {}
+  }
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/src/lambda.ts
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/src/lambda.ts
@@ -1,0 +1,1 @@
+export { projectSizeLambda as handler } from '@carrot-fndn/methodologies/bold/rule-processors/mass-id';

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.build.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "./tsconfig.json",
+    "../../../../../../.tsconfig/tsconfig.build.json"
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.eslint.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.spec.json
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-size/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../../../.tsconfig/tsconfig.spec.json"
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/src/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/index.ts
@@ -1,3 +1,4 @@
 export * from './project-period';
 export * from './credit-absence';
 export * from './check-participants-homologation';
+export * from './project-size';

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-size/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-size/index.ts
@@ -1,0 +1,1 @@
+export * from './project-size.lambda';

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.errors.ts
@@ -1,0 +1,12 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class ProjectSizeProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    HOMOLOGATION_DOCUMENT_DOES_NOT_CONTAIN_EVENTS:
+      'Recycler homologation document does not contain events',
+    HOMOLOGATION_DOCUMENT_DOES_NOT_CONTAIN_PROJECT_SIZE:
+      'Recycler homologation document does not contain project size',
+    HOMOLOGATION_DOCUMENT_NOT_FOUND: 'Recycler homologation document not found',
+    REJECTED_BY_ERROR: 'Unable to check recycler homologation project size',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.lambda.e2e.spec.ts
@@ -1,0 +1,140 @@
+import { toDocumentKey } from '@carrot-fndn/shared/helpers';
+import {
+  BoldStubsBuilder,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import {
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+
+import { projectSizeLambda } from './project-size.lambda';
+
+const { BUSINESS_DOCUMENT } = DocumentEventName;
+const { PROJECT_SIZE } = DocumentEventAttributeName;
+
+describe('ProjectSizeProcessor E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+
+  const massIdAuditWithHomologations = new BoldStubsBuilder()
+    .createMethodologyDocuments()
+    .createParticipantHomologationDocuments()
+    .build();
+
+  it.each([
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+          DocumentSubtype.RECYCLER,
+        )!,
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario:
+        'should return APPROVED when the recycler homologation document contains a project size less than 60,000',
+    },
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        {
+          ...massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+            DocumentSubtype.RECYCLER,
+          )!,
+          externalEvents: [
+            stubDocumentEventWithMetadataAttributes(
+              { name: BUSINESS_DOCUMENT },
+              [[PROJECT_SIZE, 60_001]],
+            ),
+          ],
+        },
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document contains a project size greater than 60,000',
+    },
+    {
+      documents: [massIdAuditWithHomologations.massIdDocumentStub],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document is not found',
+    },
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        {
+          ...massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+            DocumentSubtype.RECYCLER,
+          )!,
+          externalEvents: [],
+        },
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document does not contain events',
+    },
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        {
+          ...massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+            DocumentSubtype.RECYCLER,
+          )!,
+          externalEvents: [
+            stubDocumentEventWithMetadataAttributes({
+              name: BUSINESS_DOCUMENT,
+            }),
+          ],
+        },
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document does not contain a project size metadata attribute',
+    },
+  ])(
+    '$scenario',
+    async ({ documents, massIdAuditDocumentStub, resultStatus }) => {
+      prepareEnvironmentTestE2E(
+        [...documents, massIdAuditDocumentStub].map((document) => ({
+          document,
+          documentKey: toDocumentKey({
+            documentId: document.id,
+            documentKeyPrefix,
+          }),
+        })),
+      );
+
+      const response = (await projectSizeLambda(
+        stubRuleInput({
+          documentId: massIdAuditDocumentStub.id,
+          documentKeyPrefix,
+        }),
+        stubContext(),
+        () => stubRuleResponse(),
+      )) as RuleOutput;
+
+      expect(response.resultStatus).toBe(resultStatus);
+    },
+  );
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.lambda.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.lambda.ts
@@ -1,0 +1,7 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { ProjectSizeProcessor } from './project-size.processor';
+
+const instance = new ProjectSizeProcessor();
+
+export const projectSizeLambda = wrapRuleIntoLambdaHandler(instance);

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.processor.spec.ts
@@ -1,0 +1,155 @@
+import { spyOnDocumentQueryServiceLoad } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import {
+  BoldStubsBuilder,
+  stubDocument,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import { random } from 'typia';
+
+import { ProjectSizeProcessorErrors } from './project-size.errors';
+import { ProjectSizeProcessor } from './project-size.processor';
+
+const { BUSINESS_DOCUMENT } = DocumentEventName;
+const { PROJECT_SIZE } = DocumentEventAttributeName;
+
+describe('ProjectSizeProcessor', () => {
+  const ruleDataProcessor = new ProjectSizeProcessor();
+  const projectSizeProcessorErrors = new ProjectSizeProcessorErrors();
+
+  const massIdAuditWithHomologations = new BoldStubsBuilder()
+    .createMethodologyDocuments()
+    .createParticipantHomologationDocuments()
+    .build();
+
+  it.each([
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+          DocumentSubtype.RECYCLER,
+        )!,
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultComment: ruleDataProcessor['RESULT_COMMENT'].APPROVED,
+      resultStatus: RuleOutputStatus.APPROVED,
+      scenario:
+        'should return APPROVED when the recycler homologation document contains a project size less than 60,000',
+    },
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        {
+          ...massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+            DocumentSubtype.RECYCLER,
+          )!,
+          externalEvents: [
+            stubDocumentEventWithMetadataAttributes(
+              { name: BUSINESS_DOCUMENT },
+              [[PROJECT_SIZE, 60_001]],
+            ),
+          ],
+        },
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultComment: ruleDataProcessor['RESULT_COMMENT'].REJECTED,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document contains a project size greater than 60,000',
+    },
+    {
+      documents: [massIdAuditWithHomologations.massIdDocumentStub],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultComment:
+        projectSizeProcessorErrors.ERROR_MESSAGE
+          .HOMOLOGATION_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document is not found',
+    },
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        {
+          ...massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+            DocumentSubtype.RECYCLER,
+          )!,
+          externalEvents: [],
+        },
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultComment:
+        projectSizeProcessorErrors.ERROR_MESSAGE
+          .HOMOLOGATION_DOCUMENT_DOES_NOT_CONTAIN_EVENTS,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document does not contain events',
+    },
+    {
+      documents: [
+        massIdAuditWithHomologations.massIdDocumentStub,
+        {
+          ...massIdAuditWithHomologations.participantsHomologationDocumentStubs.get(
+            DocumentSubtype.RECYCLER,
+          )!,
+          externalEvents: [
+            stubDocumentEventWithMetadataAttributes({
+              name: BUSINESS_DOCUMENT,
+            }),
+          ],
+        },
+      ],
+      massIdAuditDocumentStub:
+        massIdAuditWithHomologations.massIdAuditDocumentStub,
+      resultComment:
+        projectSizeProcessorErrors.ERROR_MESSAGE
+          .HOMOLOGATION_DOCUMENT_DOES_NOT_CONTAIN_PROJECT_SIZE,
+      resultStatus: RuleOutputStatus.REJECTED,
+      scenario:
+        'should return REJECTED when the recycler homologation document does not contain a project size metadata attribute',
+    },
+  ])(
+    '$scenario',
+    async ({
+      documents,
+      massIdAuditDocumentStub,
+      resultComment,
+      resultStatus,
+    }) => {
+      spyOnDocumentQueryServiceLoad(stubDocument(), [
+        massIdAuditDocumentStub,
+        ...documents,
+      ]);
+
+      const ruleInput = {
+        ...random<Required<RuleInput>>(),
+        documentId: massIdAuditDocumentStub.id,
+      };
+
+      const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+      const expectedRuleOutput: RuleOutput = {
+        requestId: ruleInput.requestId,
+        responseToken: ruleInput.responseToken,
+        responseUrl: ruleInput.responseUrl,
+        resultComment,
+        resultStatus,
+      };
+
+      expect(ruleOutput).toEqual(expectedRuleOutput);
+    },
+  );
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-size/project-size.processor.ts
@@ -1,0 +1,157 @@
+import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
+
+import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import {
+  getOrUndefined,
+  isNil,
+  isNonEmptyArray,
+} from '@carrot-fndn/shared/helpers';
+import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
+import {
+  type DocumentQuery,
+  DocumentQueryService,
+} from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH } from '@carrot-fndn/shared/methodologies/bold/matchers';
+import {
+  type Document,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  DocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+
+import { ProjectSizeProcessorErrors } from './project-size.errors';
+
+export interface RuleSubject {
+  projectSize: number;
+}
+
+export class ProjectSizeProcessor extends RuleDataProcessor {
+  private readonly RESULT_COMMENT = {
+    APPROVED:
+      'The recycler meets the criterion of a maximum reduction of 60,000 metric tons of CO2 in one year.',
+    REJECTED:
+      'The recycler does not meet the criterion of a maximum reduction of 60,000 metric tons of CO2 in one year.',
+  } as const;
+
+  readonly errorProcessor = new ProjectSizeProcessorErrors();
+
+  private evaluateResult({ projectSize }: RuleSubject): EvaluateResultOutput {
+    if (projectSize > 60_000) {
+      return {
+        resultComment: this.RESULT_COMMENT.REJECTED,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    return {
+      resultComment: this.RESULT_COMMENT.APPROVED,
+      resultStatus: RuleOutputStatus.APPROVED,
+    };
+  }
+
+  private getProjectSize(recyclerHomologationDocument: Document): number {
+    if (!isNonEmptyArray(recyclerHomologationDocument.externalEvents)) {
+      throw this.errorProcessor.getKnownError(
+        this.errorProcessor.ERROR_MESSAGE
+          .HOMOLOGATION_DOCUMENT_DOES_NOT_CONTAIN_EVENTS,
+      );
+    }
+
+    const businessDocumentEvent =
+      recyclerHomologationDocument.externalEvents.find(
+        (event) =>
+          event.name === DocumentEventName.BUSINESS_DOCUMENT.toString(),
+      );
+
+    const projectSize = getEventAttributeValue(
+      businessDocumentEvent,
+      DocumentEventAttributeName.PROJECT_SIZE,
+    );
+
+    if (isNil(projectSize)) {
+      throw this.errorProcessor.getKnownError(
+        this.errorProcessor.ERROR_MESSAGE
+          .HOMOLOGATION_DOCUMENT_DOES_NOT_CONTAIN_PROJECT_SIZE,
+      );
+    }
+
+    return Number(projectSize);
+  }
+
+  private async getRuleSubject(
+    documentQuery: DocumentQuery<Document> | undefined,
+  ): Promise<RuleSubject> {
+    let recyclerHomologationDocument: Document | undefined;
+
+    await documentQuery?.iterator().each(({ document }) => {
+      const documentReference = mapDocumentReference(document);
+
+      if (
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches({
+          ...documentReference,
+          subtype: DocumentSubtype.RECYCLER,
+        })
+      ) {
+        recyclerHomologationDocument = document;
+      }
+    });
+
+    if (isNil(recyclerHomologationDocument)) {
+      throw this.errorProcessor.getKnownError(
+        this.errorProcessor.ERROR_MESSAGE.HOMOLOGATION_DOCUMENT_NOT_FOUND,
+      );
+    }
+
+    return {
+      projectSize: this.getProjectSize(recyclerHomologationDocument),
+    };
+  }
+
+  protected async generateDocumentQuery(ruleInput: RuleInput) {
+    const documentQueryService = new DocumentQueryService(
+      provideDocumentLoaderService,
+    );
+
+    return documentQueryService.load({
+      context: {
+        s3KeyPrefix: ruleInput.documentKeyPrefix,
+      },
+      criteria: {
+        parentDocument: {},
+        relatedDocuments: [
+          {
+            ...PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.match,
+            subtype: DocumentSubtype.RECYCLER,
+          },
+        ],
+      },
+      documentId: ruleInput.documentId,
+    });
+  }
+
+  async process(ruleInput: RuleInput): Promise<RuleOutput> {
+    try {
+      const documentsQuery = await this.generateDocumentQuery(ruleInput);
+
+      const ruleSubject = await this.getRuleSubject(documentsQuery);
+
+      const { resultComment, resultStatus } = this.evaluateResult(ruleSubject);
+
+      return mapToRuleOutput(ruleInput, resultStatus, {
+        resultComment: getOrUndefined(resultComment),
+      });
+    } catch (error: unknown) {
+      return mapToRuleOutput(ruleInput, RuleOutputStatus.REJECTED, {
+        resultComment: this.errorProcessor.getResultCommentFromError(error),
+      });
+    }
+  }
+}

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -25,8 +25,10 @@ import {
   stubParticipantHomologationGroupDocument,
 } from '../stubs';
 
-const { ACTOR, CLOSE, LINK, OUTPUT, RELATED } = DocumentEventName;
-const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } = DocumentEventAttributeName;
+const { ACTOR, BUSINESS_DOCUMENT, CLOSE, LINK, OUTPUT, RELATED } =
+  DocumentEventName;
+const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE, PROJECT_SIZE } =
+  DocumentEventAttributeName;
 const { MASS_ID, METHODOLOGY } = DocumentCategory;
 const { CREDIT, DEFINITION, MASS_ID_AUDIT, ORGANIC, PARTICIPANT_HOMOLOGATION } =
   DocumentType;
@@ -229,6 +231,14 @@ export class BoldStubsBuilder {
 
       const documentStub = stubParticipantHomologationDocument({
         externalEvents: [
+          ...(subtype === DocumentSubtype.RECYCLER
+            ? [
+                stubDocumentEventWithMetadataAttributes(
+                  { name: BUSINESS_DOCUMENT },
+                  [[PROJECT_SIZE, Math.floor(Math.random() * 60_000)]],
+                ),
+              ]
+            : []),
           stubDocumentEventWithMetadataAttributes({ name: CLOSE }, [
             [
               HOMOLOGATION_DATE,

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -100,6 +100,7 @@ export enum DocumentEventAttributeName {
   MOVE_TYPE = 'move-type',
   NFT_DESCRIPTION = 'nft-description',
   NFT_IMAGE = 'nft-image',
+  PROJECT_SIZE = 'Project Size',
   REPORT_DATE_ISSUED = 'report-date-issued',
   REPORT_NUMBER = 'report-number',
   REPORT_TYPE = 'report-type',
@@ -134,8 +135,13 @@ export enum ReportTypeLiteralName {
   MTR = 'MANIFESTO DE TRANSPORTE DE RESÍDUOS',
 }
 
+export enum HomologationDocumentEventName {
+  BUSINESS_DOCUMENT = 'Business Document',
+}
+
 export enum DocumentEventName {
   ACTOR = MethodologyDocumentEventName.ACTOR,
+  BUSINESS_DOCUMENT = HomologationDocumentEventName.BUSINESS_DOCUMENT,
   CLOSE = MethodologyDocumentEventName.CLOSE,
   END = 'END',
   LINK = MethodologyDocumentEventName.LINK,


### PR DESCRIPTION
### Summary

Implement a new rule processor to validate recycler project size, ensuring it does not exceed 60,000 metric tons of CO2 reduction per year. The implementation includes:

- Project size processor with validation logic
- Error handling for various scenarios
- E2E and unit tests for comprehensive coverage
- Updated testing utilities to support project size attribute
- Enum extensions for new event names and attributes

### Details

Verify if the `Project Size` field in the `Recycler Homologation` document is `$le: 60000`.

### Related links

https://app.clickup.com/t/3005225/CARROT-1954

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability for evaluating project size, providing clear outcomes based on specified thresholds.
  - Enhanced error feedback when required project size data is missing or invalid.

- **Tests**
  - Added comprehensive end-to-end and unit tests to validate the new functionality under various scenarios.

- **Documentation**
  - Released new documentation detailing the project size feature, including usage, implementation, and contributor information.

- **Chores**
  - Updated configuration files for linting, testing, and build processes to support the new feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->