### PR TITLE
feat(shared): add optional label to MethodologyDocumentEvent

### DIFF
--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -2,7 +2,10 @@ import { tags } from 'typia';
 
 import type { UnknownObject } from '../common.types';
 import type { MethodologyAddress } from './methodology-address.types';
-import type { MethodologyDocumentEventName } from './methodology-enum.types';
+import type {
+  MethodologyDocumentEventLabel,
+  MethodologyDocumentEventName,
+} from './methodology-enum.types';
 import type {
   MethodologyAuthor,
   MethodologyParticipant,
@@ -49,6 +52,7 @@ export interface MethodologyDocumentEvent {
   externalId?: string | undefined;
   id: string;
   isPublic: boolean;
+  label?: MethodologyDocumentEventLabel | string | undefined;
   metadata?: MethodologyDocumentEventMetadata | undefined;
   name: MethodologyDocumentEventName | string;
   participant: MethodologyParticipant;

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -8,6 +8,10 @@ export enum MethodologyParticipantType {
   ACTOR = 'ACTOR',
 }
 
+export enum MethodologyDocumentEventLabel {
+  RECYCLER = 'Recycler',
+}
+
 export enum MethodologyDocumentEventName {
   ACTOR = 'ACTOR',
   CLOSE = 'CLOSE',


### PR DESCRIPTION
### Summary

Extend `MethodologyDocumentEvent` interface with an optional label field, introducing a new `MethodologyDocumentEventLabel` enum with a `RECYCLER` value to support more detailed event classification

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional label to document events for enhanced contextual information.
  - Introduced a new standardized label option ("Recycler") to improve consistency in event categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->