### PR TITLE
chore(rule): add mass ID rule generator script

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.lambda.e2e.spec.ts
@@ -7,7 +7,7 @@ import {
   stubRuleInput,
   stubRuleResponse,
 } from '@carrot-fndn/shared/testing';
-import { faker } from '@faker-js/faker/.';
+import { faker } from '@faker-js/faker';
 
 import { massDefinitionLambda } from './mass-definition.lambda';
 import { massDefinitionTestCases } from './mass-definition.test-cases';

--- a/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.spec.ts
@@ -8,7 +8,7 @@ import {
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
-import { faker } from '@faker-js/faker/.';
+import { faker } from '@faker-js/faker';
 import { addDays, formatDate, subDays } from 'date-fns';
 
 import {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build-lambda:affected": "nx affected --target build-lambda",
     "build-lambda:all": "nx run-many --target build-lambda",
     "commit": "czg",
+    "create-mass-id-rule": "node tools/create-mass-id-rule.js",
     "fix-project-format": "node scripts/fix-project-json-format.js",
     "lint": "nx lint",
     "lint:affected": "nx affected --target lint --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14332,7 +14332,7 @@ snapshots:
       npm-run-path: 4.0.1
       open: 8.4.2
       ora: 5.3.0
-      semver: 7.6.3
+      semver: 7.7.1
       string-width: 4.2.3
       strong-log-transformer: 2.1.0
       tar-stream: 2.2.0

--- a/tools/create-mass-id-rule.js
+++ b/tools/create-mass-id-rule.js
@@ -52,28 +52,6 @@ const fileName = ruleName;
 const projectRoot = 'libs/methodologies/bold/rule-processors/mass-id';
 const targetDirectory = path.join(projectRoot, 'src', ruleName);
 
-if (!fs.existsSync(targetDirectory)) {
-  try {
-    fs.mkdirSync(targetDirectory, { recursive: true });
-  } catch (error) {
-    console.error(
-      `Error creating directory ${targetDirectory}: ${error.message}`,
-    );
-    process.exit(1);
-  }
-} else {
-  const filesExist = templates.some((template) =>
-    fs.existsSync(path.join(targetDirectory, template.name)),
-  );
-
-  if (filesExist) {
-    console.error(
-      `Error: Files for rule '${ruleName}' already exist. Use a different name or remove existing files.`,
-    );
-    process.exit(1);
-  }
-}
-
 // Define the template files
 const templates = [
   {
@@ -278,6 +256,28 @@ describe('${pascalCase}Lambda E2E', () => {
 });\n`,
   },
 ];
+
+if (!fs.existsSync(targetDirectory)) {
+  try {
+    fs.mkdirSync(targetDirectory, { recursive: true });
+  } catch (error) {
+    console.error(
+      `Error creating directory ${targetDirectory}: ${error.message}`,
+    );
+    process.exit(1);
+  }
+} else {
+  const filesExist = templates.some((template) =>
+    fs.existsSync(path.join(targetDirectory, template.name)),
+  );
+
+  if (filesExist) {
+    console.error(
+      `Error: Files for rule '${ruleName}' already exist. Use a different name or remove existing files.`,
+    );
+    process.exit(1);
+  }
+}
 
 // Write the template files to the target directory
 templates.forEach((template) => {

--- a/tools/create-mass-id-rule.js
+++ b/tools/create-mass-id-rule.js
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+/**
+ * Mass ID Rule Generator
+ *
+ * This script generates a new rule for the mass-id library with all necessary files.
+ * It creates the rule structure based on the mass-definition example.
+ *
+ * Usage:
+ *   pnpm create-mass-id-rule <rule-name> [description]
+ *
+ * Example:
+ *   pnpm create-mass-id-rule vehicle-definition "Validates the vehicle definition in the mass-id document"
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Get the rule name from command line arguments
+const ruleName = process.argv[2];
+
+// Check for help flag
+if (!ruleName || ruleName === '--help' || ruleName === '-h') {
+  console.log(`
+Mass ID Rule Generator
+
+Usage: create-mass-id-rule <rule-name> [description]
+
+Arguments:
+  rule-name    The name of the rule (required)
+  description  A brief description of the rule (optional)
+
+Example:
+  create-mass-id-rule vehicle-definition "Validates the vehicle definition in the mass-id document"
+  `);
+  process.exit(0);
+}
+
+const description = process.argv[3] || 'The rule validation is compliant.';
+
+// Convert rule name to different formats
+const camelCase = ruleName.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+const pascalCase = camelCase.charAt(0).toUpperCase() + camelCase.slice(1);
+const fileName = ruleName;
+
+// Define the target directory
+const projectRoot = 'libs/methodologies/bold/rule-processors/mass-id';
+const targetDirectory = path.join(projectRoot, 'src', ruleName);
+
+// Create the target directory if it doesn't exist
+if (!fs.existsSync(targetDirectory)) {
+  fs.mkdirSync(targetDirectory, { recursive: true });
+}
+
+// Define the template files
+const templates = [
+  {
+    name: 'index.ts',
+    content: `export * from './${fileName}.lambda';\n`,
+  },
+  {
+    name: `${fileName}.lambda.ts`,
+    content: `import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { ${pascalCase}Processor } from './${fileName}.processor';
+
+const instance = new ${pascalCase}Processor();
+
+export const ${camelCase}Lambda = wrapRuleIntoLambdaHandler(instance);\n`,
+  },
+  {
+    name: `${fileName}.processor.ts`,
+    content: `import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
+
+import { isNil } from '@carrot-fndn/shared/helpers';
+import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/bold/processors';
+import {
+  type Document,
+  DocumentCategory,
+  DocumentType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+
+import { ${pascalCase}ProcessorErrors } from './${fileName}.errors';
+
+export const RESULT_COMMENTS = {
+  APPROVED: '${description}',
+  REJECTED: 'The rule validation failed.',
+} as const;
+
+export class ${pascalCase}Processor extends ParentDocumentRuleProcessor<Document> {
+  protected readonly processorErrors = new ${pascalCase}ProcessorErrors();
+
+  private get RESULT_COMMENT() {
+    return RESULT_COMMENTS;
+  }
+
+  private validateRequiredFields(
+    document: Document,
+  ): EvaluateResultOutput | undefined {
+    if (isNil(document.type)) {
+      return {
+        resultComment:
+          this.processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    return undefined;
+  }
+
+  protected override evaluateResult(
+    document: Document,
+  ): EvaluateResultOutput | Promise<EvaluateResultOutput> {
+    const validationResult = this.validateRequiredFields(document);
+
+    if (validationResult) {
+      return validationResult;
+    }
+
+    // TODO: Implement your rule validation logic here
+    const isValid = true; // Replace with actual validation
+
+    return {
+      resultComment: isValid
+        ? this.RESULT_COMMENT.APPROVED
+        : this.RESULT_COMMENT.REJECTED,
+      resultStatus: isValid
+        ? RuleOutputStatus.APPROVED
+        : RuleOutputStatus.REJECTED,
+    };
+  }
+
+  protected override getRuleSubject(document: Document): Document | undefined {
+    return document;
+  }
+}\n`,
+  },
+  {
+    name: `${fileName}.errors.ts`,
+    content: `import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class ${pascalCase}ProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    DOCUMENT_TYPE_NOT_FOUND: 'Document type not found.',
+    REJECTED_BY_ERROR: 'Unable to validate the ${ruleName}.',
+  } as const;
+}\n`,
+  },
+  {
+    name: `${fileName}.processor.spec.ts`,
+    content: `import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
+
+import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import {
+  type RuleInput,
+  type RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
+import { stubEnumValue } from '@carrot-fndn/shared/testing';
+import { random } from 'typia';
+
+import { ${pascalCase}Processor, RESULT_COMMENTS } from './${fileName}.processor';
+import { ${camelCase}TestCases } from './${fileName}.test-cases';
+
+jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
+
+describe('${pascalCase}Processor', () => {
+  const ruleDataProcessor = new ${pascalCase}Processor();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(ruleDataProcessor).toBeDefined();
+  });
+
+  describe('process', () => {
+    it('should return REJECTED when document is not found', async () => {
+      // Arrange
+      const ruleInput = random<RuleInput>();
+      const mockLoadParentDocument = loadParentDocument as jest.Mock;
+      mockLoadParentDocument.mockResolvedValueOnce(undefined);
+
+      // Act
+      const result = await ruleDataProcessor.process(ruleInput);
+
+      // Assert
+      expect(result).toEqual<RuleOutput>({
+        resultComment: expect.any(String),
+        resultStatus: RuleOutputStatus.REJECTED,
+      });
+    });
+
+    it.each(${camelCase}TestCases)(
+      'should return $resultStatus when $scenario',
+      async ({ massIdDocument, resultComment, resultStatus }) => {
+        // Arrange
+        const ruleInput = random<RuleInput>();
+        const mockLoadParentDocument = loadParentDocument as jest.Mock;
+        mockLoadParentDocument.mockResolvedValueOnce(massIdDocument);
+
+        // Act
+        const result = await ruleDataProcessor.process(ruleInput);
+
+        // Assert
+        expect(result).toEqual<RuleOutput>({
+          resultComment,
+          resultStatus,
+        });
+      },
+    );
+  });
+});\n`,
+  },
+  {
+    name: `${fileName}.test-cases.ts`,
+    content: `import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+
+import { ${pascalCase}ProcessorErrors } from './${fileName}.errors';
+import { RESULT_COMMENTS } from './${fileName}.processor';
+
+const massIdStubs = new BoldStubsBuilder().build();
+const processorErrors = new ${pascalCase}ProcessorErrors();
+
+export const ${camelCase}TestCases = [
+  {
+    massIdDocument: massIdStubs.massIdDocumentStub,
+    resultComment: RESULT_COMMENTS.APPROVED,
+    resultStatus: RuleOutputStatus.APPROVED,
+    scenario: 'all the criteria are met',
+  },
+  // Add more test cases as needed
+];\n`,
+  },
+  {
+    name: `${fileName}.lambda.e2e.spec.ts`,
+    content: `import { toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker/.';
+
+import { ${camelCase}Lambda } from './${fileName}.lambda';
+import { ${camelCase}TestCases } from './${fileName}.test-cases';
+
+describe('${pascalCase}Lambda E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+
+  const massId = new BoldStubsBuilder().build();
+
+  it.each(${camelCase}TestCases)(
+    'should return $resultStatus when $scenario',
+    async ({ massIdDocument, resultComment, resultStatus }) => {
+      // Arrange
+      const documentKey = toDocumentKey(
+        documentKeyPrefix,
+        massIdDocument.documentId,
+      );
+
+      const ruleInput = stubRuleInput({
+        documentKey,
+      });
+
+      const context = stubContext();
+
+      prepareEnvironmentTestE2E({
+        documentKey,
+        document: massIdDocument,
+      });
+
+      // Act
+      const result = await ${camelCase}Lambda(ruleInput, context);
+
+      // Assert
+      expect(result).toEqual(
+        stubRuleResponse({
+          resultComment,
+          resultStatus,
+        }),
+      );
+    },
+  );
+});\n`,
+  },
+];
+
+// Write the template files to the target directory
+templates.forEach((template) => {
+  const filePath = path.join(targetDirectory, template.name);
+  fs.writeFileSync(filePath, template.content);
+  console.log(`Created ${filePath}`);
+});
+
+// Update the main index.ts file to export the new rule
+const indexPath = path.join(projectRoot, 'src', 'index.ts');
+if (fs.existsSync(indexPath)) {
+  const indexContent = fs.readFileSync(indexPath, 'utf-8');
+  const newExport = `export * from './${ruleName}';\n`;
+
+  // Check if the export already exists to avoid duplicates
+  if (!indexContent.includes(newExport)) {
+    fs.writeFileSync(indexPath, indexContent + newExport);
+    console.log(`Updated ${indexPath}`);
+  }
+}
+
+console.log(`\nSuccessfully created rule: ${ruleName}`);
+console.log(`\nNext steps:`);
+console.log(
+  `1. Implement your rule validation logic in ${targetDirectory}/${fileName}.processor.ts`,
+);
+console.log(
+  `2. Add appropriate test cases in ${targetDirectory}/${fileName}.test-cases.ts`,
+);
+console.log(`3. Run tests with: pnpm test ${projectRoot}`);

--- a/tools/create-mass-id-rule.js
+++ b/tools/create-mass-id-rule.js
@@ -253,7 +253,7 @@ import {
   stubRuleInput,
   stubRuleResponse,
 } from '@carrot-fndn/shared/testing';
-import { faker } from '@faker-js/faker/.';
+import { faker } from '@faker-js/faker';
 
 import { ${camelCase}Lambda } from './${fileName}.lambda';
 import { ${camelCase}TestCases } from './${fileName}.test-cases';

--- a/tools/create-mass-id-rule.js
+++ b/tools/create-mass-id-rule.js
@@ -49,7 +49,14 @@ const targetDirectory = path.join(projectRoot, 'src', ruleName);
 
 // Create the target directory if it doesn't exist
 if (!fs.existsSync(targetDirectory)) {
-  fs.mkdirSync(targetDirectory, { recursive: true });
+  try {
+    fs.mkdirSync(targetDirectory, { recursive: true });
+  } catch (error) {
+    console.error(
+      `Error creating directory ${targetDirectory}: ${error.message}`,
+    );
+    process.exit(1);
+  }
 }
 
 // Define the template files
@@ -295,20 +302,30 @@ describe('${pascalCase}Lambda E2E', () => {
 // Write the template files to the target directory
 templates.forEach((template) => {
   const filePath = path.join(targetDirectory, template.name);
-  fs.writeFileSync(filePath, template.content);
-  console.log(`Created ${filePath}`);
+  try {
+    fs.writeFileSync(filePath, template.content);
+    console.log(`Created ${filePath}`);
+  } catch (error) {
+    console.error(`Error writing file ${filePath}: ${error.message}`);
+    process.exit(1);
+  }
 });
 
 // Update the main index.ts file to export the new rule
 const indexPath = path.join(projectRoot, 'src', 'index.ts');
 if (fs.existsSync(indexPath)) {
-  const indexContent = fs.readFileSync(indexPath, 'utf-8');
-  const newExport = `export * from './${ruleName}';\n`;
+  try {
+    const indexContent = fs.readFileSync(indexPath, 'utf-8');
+    const newExport = `export * from './${ruleName}';\n`;
 
-  // Check if the export already exists to avoid duplicates
-  if (!indexContent.includes(newExport)) {
-    fs.writeFileSync(indexPath, indexContent + newExport);
-    console.log(`Updated ${indexPath}`);
+    // Check if the export already exists to avoid duplicates
+    if (!indexContent.includes(newExport)) {
+      fs.writeFileSync(indexPath, indexContent + newExport);
+      console.log(`Updated ${indexPath}`);
+    }
+  } catch (error) {
+    console.error(`Error updating index file ${indexPath}: ${error.message}`);
+    process.exit(1);
   }
 }
 

--- a/tools/create-mass-id-rule.js
+++ b/tools/create-mass-id-rule.js
@@ -20,7 +20,12 @@ const path = require('path');
 const ruleName = process.argv[2];
 
 // Check for help flag
-if (!ruleName || ruleName === '--help' || ruleName === '-h') {
+if (
+  !ruleName ||
+  ruleName.trim() === '' ||
+  ruleName === '--help' ||
+  ruleName === '-h'
+) {
   console.log(`
 Mass ID Rule Generator
 
@@ -47,13 +52,23 @@ const fileName = ruleName;
 const projectRoot = 'libs/methodologies/bold/rule-processors/mass-id';
 const targetDirectory = path.join(projectRoot, 'src', ruleName);
 
-// Create the target directory if it doesn't exist
 if (!fs.existsSync(targetDirectory)) {
   try {
     fs.mkdirSync(targetDirectory, { recursive: true });
   } catch (error) {
     console.error(
       `Error creating directory ${targetDirectory}: ${error.message}`,
+    );
+    process.exit(1);
+  }
+} else {
+  const filesExist = templates.some((template) =>
+    fs.existsSync(path.join(targetDirectory, template.name)),
+  );
+
+  if (filesExist) {
+    console.error(
+      `Error: Files for rule '${ruleName}' already exist. Use a different name or remove existing files.`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
### Summary

Introduces a new CLI tool to streamline the creation of mass ID rule processors. The script automates the generation of:
- Processor implementation
- Lambda handler
- Error handling
- Test cases
- E2E tests

Adds a new npm script `create-mass-id-rule` to facilitate rule generation and updates package.json accordingly.

Output Example:

![CleanShot 2025-03-12 at 10 05 24](https://github.com/user-attachments/assets/096fa2ec-7c40-4f04-b665-e36853724e21)

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line tool accessible via npm that automates the scaffolding of mass id rules.
  - The tool validates inputs, formats rule names appropriately, and generates a complete set of components—including tests and configuration updates—to streamline rule creation and integration.

- **Bug Fixes**
  - Corrected import paths for the `faker` library in test files to ensure proper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->