### PR TITLE
feat(shared): implement getParticipantActorType function and related tests

### DIFF
--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -10,7 +10,7 @@ import {
   DocumentEventActorType,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIDDocumentActorType,
+  MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 
@@ -24,7 +24,7 @@ import {
 const { ACTOR, DROP_OFF, OPEN, PICK_UP, RULES_METADATA } = DocumentEventName;
 const { AUDITOR } = DocumentEventActorType;
 const { ACTOR_TYPE } = DocumentEventAttributeName;
-const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
+const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
 describe('Document getters', () => {
   describe('getAuditorActorEvent', () => {

--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -5,7 +5,7 @@ import {
   DocumentEventActorType,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIDDocumentActorType,
+  MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { getEventAttributeValue } from './event.getters';
@@ -13,7 +13,7 @@ import { getEventAttributeValue } from './event.getters';
 const { ACTOR, DROP_OFF, OPEN, PICK_UP, RULES_METADATA } = DocumentEventName;
 const { AUDITOR } = DocumentEventActorType;
 const { ACTOR_TYPE } = DocumentEventAttributeName;
-const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
+const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
 export const getAuditorActorEvent = (
   document: Document,
@@ -42,7 +42,7 @@ export const getParticipantActorType = ({
 }: {
   document: Document;
   event: DocumentEvent;
-}): MassIDDocumentActorType | undefined => {
+}): MassIdDocumentActorType | undefined => {
   const events = document.externalEvents;
 
   if (!isNonEmptyArray(events)) {

--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -1,16 +1,19 @@
+import { isNonEmptyArray } from '@carrot-fndn/shared/helpers';
 import {
   type Document,
   type DocumentEvent,
   DocumentEventActorType,
   DocumentEventAttributeName,
   DocumentEventName,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { getEventAttributeValue } from './event.getters';
 
-const { ACTOR } = DocumentEventName;
+const { ACTOR, DROP_OFF, OPEN, PICK_UP, RULES_METADATA } = DocumentEventName;
 const { AUDITOR } = DocumentEventActorType;
 const { ACTOR_TYPE } = DocumentEventAttributeName;
+const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
 
 export const getAuditorActorEvent = (
   document: Document,
@@ -24,13 +27,49 @@ export const getAuditorActorEvent = (
 export const getOpenEvent = (
   document: Document | undefined,
 ): DocumentEvent | undefined =>
-  document?.externalEvents?.find(
-    (event) => event.name === DocumentEventName.OPEN.toString(),
-  );
+  document?.externalEvents?.find((event) => event.name === OPEN.toString());
 
 export const getRulesMetadataEvent = (
   document: Document | undefined,
 ): DocumentEvent | undefined =>
   document?.externalEvents?.find(
-    (event) => event.name === DocumentEventName.RULES_METADATA.toString(),
+    (event) => event.name === RULES_METADATA.toString(),
   );
+
+export const getParticipantActorType = ({
+  document,
+  event,
+}: {
+  document: Document;
+  event: DocumentEvent;
+}): MassIDDocumentActorType | undefined => {
+  const events = document.externalEvents;
+
+  if (!isNonEmptyArray(events)) {
+    return undefined;
+  }
+
+  const pickUpEvents = events.filter((e) => e.name === PICK_UP.toString());
+  const dropOffEvents = events.filter((e) => e.name === DROP_OFF.toString());
+
+  if (!isNonEmptyArray(pickUpEvents) || !isNonEmptyArray(dropOffEvents)) {
+    return undefined;
+  }
+
+  const sourcePickUp = pickUpEvents[0] as DocumentEvent;
+  const finalDropOff = dropOffEvents.at(-1) as DocumentEvent;
+
+  if (sourcePickUp.id === event.id) {
+    return WASTE_GENERATOR;
+  }
+
+  if (finalDropOff.id === event.id) {
+    return RECYCLER;
+  }
+
+  if (event.name === PICK_UP.toString() || event.name === DROP_OFF.toString()) {
+    return PROCESSOR;
+  }
+
+  return undefined;
+};

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -45,6 +45,13 @@ export enum DocumentSubtype {
   WOOD_AND_WOOD_PRODUCTS = 'Wood and Wood Products',
 }
 
+export enum MassIDDocumentActorType {
+  HAULER = DocumentSubtype.HAULER,
+  PROCESSOR = DocumentSubtype.PROCESSOR,
+  RECYCLER = DocumentSubtype.RECYCLER,
+  WASTE_GENERATOR = DocumentSubtype.WASTE_GENERATOR,
+}
+
 export enum MassSubtype {
   AGRO_INDUSTRIAL = DocumentSubtype.AGRO_INDUSTRIAL,
   ANIMAL_MANURE = DocumentSubtype.ANIMAL_MANURE,

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -45,7 +45,7 @@ export enum DocumentSubtype {
   WOOD_AND_WOOD_PRODUCTS = 'Wood and Wood Products',
 }
 
-export enum MassIDDocumentActorType {
+export enum MassIdDocumentActorType {
   HAULER = DocumentSubtype.HAULER,
   PROCESSOR = DocumentSubtype.PROCESSOR,
   RECYCLER = DocumentSubtype.RECYCLER,


### PR DESCRIPTION
### Summary

- Added the `getParticipantActorType` function to determine the actor type (`WASTE_GENERATOR`, `PROCESSOR`, `RECYCLER`) based on document events.
- Enhanced document getters tests to cover various scenarios for participant actor type retrieval.
- Introduced `MassIDDocumentActorType` enum to categorize actor types.
- Updated existing document getters to utilize new constants for event names.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to determine participant roles based on document events, enhancing event processing accuracy.
  - Added new constants to support the expanded functionality related to document events.

- **Tests**
  - Expanded test coverage for the new functionality, validating various scenarios and edge cases in event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->