### PR TITLE
feat(shared): add new attributes and enums for methodology document events

### DIFF
--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -3,6 +3,8 @@ import { tags } from 'typia';
 import type { UnknownObject } from '../common.types';
 import type { MethodologyAddress } from './methodology-address.types';
 import type {
+  MethodologyDocumentEventAttributeFormat,
+  MethodologyDocumentEventAttributeType,
   MethodologyDocumentEventLabel,
   MethodologyDocumentEventName,
 } from './methodology-enum.types';
@@ -11,7 +13,13 @@ import type {
   MethodologyParticipant,
 } from './methodology-participant.types';
 
+export interface MethodologyDocumentEventAttributeReference {
+  documentId: string;
+  eventId: string;
+}
+
 export type MethodologyDocumentEventAttributeValue =
+  | MethodologyDocumentEventAttributeReference
   | UnknownObject
   | boolean
   | null
@@ -20,8 +28,11 @@ export type MethodologyDocumentEventAttributeValue =
   | unknown[];
 
 export interface MethodologyDocumentEventAttribute {
+  format?: MethodologyDocumentEventAttributeFormat | undefined;
   isPublic: boolean;
   name: string;
+  sensitive?: boolean | undefined;
+  type?: MethodologyDocumentEventAttributeType | undefined;
   value: MethodologyDocumentEventAttributeValue;
 }
 
@@ -47,6 +58,7 @@ export interface MethodologyDocumentEvent {
   address: MethodologyAddress;
   attachments?: MethodologyDocumentEventAttachment[] | undefined;
   author: MethodologyAuthor;
+  deduplicationId?: string | undefined;
   documentSideEffectUpdates?: UnknownObject | undefined;
   externalCreatedAt?: (string & tags.Format<'date-time'>) | undefined;
   externalId?: string | undefined;

--- a/libs/shared/types/src/methodology/methodology-document.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document.types.ts
@@ -20,6 +20,7 @@ export interface MethodologyDocument {
   createdAt: string & tags.Format<'date-time'>;
   currentValue: number & tags.Minimum<0> & tags.Type<'float'>;
   dataSetName: DataSetName;
+  deduplicationId?: string | undefined;
   externalCreatedAt: string & tags.Format<'date-time'>;
   externalEvents?: MethodologyDocumentEvent[] | undefined;
   externalId?: string | undefined;

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -31,3 +31,14 @@ export enum MethodologyDocumentEventName {
 export enum MethodologyEvaluationResult {
   APPROVED = 'APPROVED',
 }
+
+export enum MethodologyDocumentEventAttributeFormat {
+  CUBIC_METER = 'CUBIC_METER',
+  DATE = 'DATE',
+  KILOGRAM = 'KILOGRAM',
+  LITRE = 'LITRE',
+}
+
+export enum MethodologyDocumentEventAttributeType {
+  REFERENCE = 'REFERENCE',
+}


### PR DESCRIPTION
### Summary

- Introduced `MethodologyDocumentEventAttributeReference` interface to reference document and event IDs.
- Updated `MethodologyDocumentEventAttribute` interface to include optional `format`, `sensitive`, and `type` properties.
- Added `deduplicationId` to `MethodologyDocument` and `MethodologyDocumentEvent` interfaces for better event tracking.
- Created new enums `MethodologyDocumentEventAttributeFormat` and `MethodologyDocumentEventAttributeType` to define attribute formats and types.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event and document management with an optional tracking identifier for improved data monitoring.
  - Expanded attribute options now offer refined formatting and type selection, supporting precise measurement and date representations.
  - Introduced a linking mechanism to seamlessly associate related records, ensuring better connectivity between documents and events.
  - These updates provide a more robust platform for scalable data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->