### PR TITLE
Update mass audit document matching criteria

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass-certificate/mass-audit-document/src/lib/mass-audit-document.processor.ts
+++ b/apps/methodologies/bold/rule-processors/mass-certificate/mass-audit-document/src/lib/mass-audit-document.processor.ts
@@ -10,7 +10,10 @@ import {
   type DocumentQuery,
   DocumentQueryService,
 } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { MASS_AUDIT } from '@carrot-fndn/shared/methodologies/bold/matchers';
+import {
+  MASS_ID_AUDIT,
+  RECYCLED_ID,
+} from '@carrot-fndn/shared/methodologies/bold/matchers';
 import {
   type Document,
   type DocumentReference,
@@ -75,10 +78,14 @@ export class MassAuditDocumentProcessor extends RuleDataProcessor {
         s3KeyPrefix: documentKeyPrefix,
       },
       criteria: {
-        parentDocument: {
-          omit: true,
-          relatedDocuments: [MASS_AUDIT.match],
-        },
+        relatedDocuments: [
+          {
+            ...RECYCLED_ID.match,
+            parentDocument: {
+              ...MASS_ID_AUDIT.match,
+            },
+          },
+        ],
       },
       documentId,
     });

--- a/libs/shared/methodologies/bold/matchers/src/document.matchers.ts
+++ b/libs/shared/methodologies/bold/matchers/src/document.matchers.ts
@@ -39,6 +39,16 @@ export const MASS_AUDIT = new DocumentMatcher({
   type: DocumentType.MASS_AUDIT,
 });
 
+export const MASS_ID_AUDIT = new DocumentMatcher({
+  category: DocumentCategory.METHODOLOGY,
+  type: DocumentType.MASS_ID_AUDIT,
+});
+
+export const RECYCLED_ID = new DocumentMatcher({
+  category: DocumentCategory.METHODOLOGY,
+  type: DocumentType.RECYCLED_ID,
+});
+
 export const MASS_CERTIFICATE = new DocumentMatcher({
   category: DocumentCategory.METHODOLOGY,
   type: DocumentType.MASS_CERTIFICATE,

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -20,6 +20,7 @@ export enum DocumentType {
   MASS_ID_AUDIT = 'MassID Audit',
   ORGANIC = 'Organic',
   PARTICIPANT_HOMOLOGATION = 'Participant Homologation',
+  RECYCLED_ID = 'RecycledID',
 }
 
 export enum DocumentSubtype {


### PR DESCRIPTION
### Summary

Refactored the mass audit document matching logic to use more specific document types and improved the query structure.

### Details

- Updated document matching criteria in MassAuditDocumentProcessor
- Added new document matchers: MASS_ID_AUDIT and RECYCLED_ID
- Added new document type: RECYCLED_ID to enum types
- Improved query structure by using nested related documents instead of parent document omission

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced additional document types for enhanced categorization, offering refined tracking for audit records.
  
- **Refactor**
  - Streamlined the document query process to improve how related records are identified and associated.

These updates enhance document management capabilities and provide a smoother, more efficient workflow experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->