### PR TITLE
feat(rule): add transport-manifest processor and related components

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
@@ -1,0 +1,49 @@
+import {
+  DocumentEventName,
+  NewDocumentEventAttributeName,
+  NewMeasurementUnit,
+  ReportType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import {
+  MethodologyDocumentEventAttributeFormat,
+  MethodologyDocumentEventLabel,
+} from '@carrot-fndn/shared/types';
+
+const { DOCUMENT_NUMBER, DOCUMENT_TYPE, EXEMPTION_JUSTIFICATION, ISSUE_DATE } =
+  NewDocumentEventAttributeName;
+const { RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
+const { DATE } = MethodologyDocumentEventAttributeFormat;
+const { RECYCLER } = MethodologyDocumentEventLabel;
+const { MTR } = ReportType;
+
+export const RESULT_COMMENTS = {
+  ADDRESS_MISMATCH: `The "${RECYCLING_MANIFEST}" event address does not match the "${RECYCLER}" event address.`,
+  ATTACHMENT_AND_JUSTIFICATION_PROVIDED: `The "${EXEMPTION_JUSTIFICATION}" should not be provided when a "${TRANSPORT_MANIFEST}" attachment is present.`,
+  INCORRECT_ATTACHMENT_LABEL: (label: string) =>
+    `Expected "${TRANSPORT_MANIFEST}" attachment label, but "${label}" was provided.`,
+  INVALID_BR_DOCUMENT_TYPE: (documentType: string) =>
+    `The "${DOCUMENT_TYPE}" must be "${MTR}" for recyclers in Brazil, but "${documentType}" was provided.`,
+  INVALID_EVENT_VALUE: (event: string) =>
+    `The event value must be defined and greater than 0, but "${event}" was provided.`,
+  INVALID_ISSUE_DATE_FORMAT: (dateFormat: string) =>
+    `The "${ISSUE_DATE}" format must be "${DATE}", but the declared format is "${dateFormat}".`,
+  MISSING_ATTRIBUTES: `Either the "${TRANSPORT_MANIFEST}" attachment or an "${EXEMPTION_JUSTIFICATION}" must be provided.`,
+  MISSING_DOCUMENT_NUMBER: `The "${DOCUMENT_NUMBER}" was not provided.`,
+  MISSING_DOCUMENT_TYPE: `The "${DOCUMENT_TYPE}" was not provided.`,
+  MISSING_EVENT: `At least one "${TRANSPORT_MANIFEST}" event must be provided.`,
+  MISSING_ISSUE_DATE: `The "${ISSUE_DATE}" was not provided.`,
+  MISSING_RECYCLER_EVENT: `The "${RECYCLER}" event was not provided.`,
+  PROVIDE_EXEMPTION_JUSTIFICATION: `The "${TRANSPORT_MANIFEST}" attachment was not provided, but an "${EXEMPTION_JUSTIFICATION}" was declared.`,
+  VALID_ATTACHMENT_DECLARATION: ({
+    documentNumber,
+    documentType,
+    issueDate,
+    value,
+  }: {
+    documentNumber: string;
+    documentType: string;
+    issueDate: string;
+    value: number;
+  }) =>
+    `The ${documentType} attachment (No. ${documentNumber}), issued on ${issueDate}, with a value of ${value}${NewMeasurementUnit.KG}, was provided.`,
+} as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
@@ -19,8 +19,7 @@ const { MTR } = ReportType;
 export const RESULT_COMMENTS = {
   ADDRESS_MISMATCH: `The "${RECYCLING_MANIFEST}" event address does not match the "${RECYCLER}" event address.`,
   ATTACHMENT_AND_JUSTIFICATION_PROVIDED: `The "${EXEMPTION_JUSTIFICATION}" should not be provided when a "${TRANSPORT_MANIFEST}" attachment is present.`,
-  INCORRECT_ATTACHMENT_LABEL: (label: string) =>
-    `Expected "${TRANSPORT_MANIFEST}" attachment label, but "${label}" was provided.`,
+  INCORRECT_ATTACHMENT_LABEL: `Expected an attachment with the "${TRANSPORT_MANIFEST}" label, but no one was found.`,
   INVALID_BR_DOCUMENT_TYPE: (documentType: string) =>
     `The "${DOCUMENT_TYPE}" must be "${MTR}" for recyclers in Brazil, but "${documentType}" was provided.`,
   INVALID_EVENT_VALUE: (event: string) =>

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.lambda.e2e.spec.ts
@@ -1,0 +1,55 @@
+import { toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+
+import { documentManifestLambda } from './document-manifest.lambda';
+import {
+  documentManifestTestCases,
+  exceptionTestCases,
+} from './document-manifest.test-cases';
+
+describe('DocumentManifestLambda E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+
+  it.each([...documentManifestTestCases, ...exceptionTestCases])(
+    'should return $resultStatus when $scenario',
+    async ({ documentManifestType, events, resultStatus }) => {
+      const lambda = documentManifestLambda(documentManifestType);
+
+      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
+        .createMassIdDocument({
+          externalEventsMap: events,
+        })
+        .createMassIdAuditDocument()
+        .build();
+
+      prepareEnvironmentTestE2E(
+        [massIdDocument, massIdAuditDocument].map((document) => ({
+          document,
+          documentKey: toDocumentKey({
+            documentId: document.id,
+            documentKeyPrefix,
+          }),
+        })),
+      );
+
+      const response = (await lambda(
+        stubRuleInput({
+          documentKeyPrefix,
+          parentDocumentId: massIdDocument.id,
+        }),
+        stubContext(),
+        () => stubRuleResponse(),
+      )) as RuleOutput;
+
+      expect(response.resultStatus).toBe(resultStatus);
+    },
+  );
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.lambda.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.lambda.ts
@@ -1,0 +1,14 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import {
+  DocumentManifestProcessor,
+  type DocumentManifestType,
+} from './document-manifest.processor';
+
+export const documentManifestLambda = (
+  documentManifestType: DocumentManifestType,
+) => {
+  const instance = new DocumentManifestProcessor(documentManifestType);
+
+  return wrapRuleIntoLambdaHandler(instance);
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.spec.ts
@@ -1,0 +1,50 @@
+import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  type RuleInput,
+  type RuleOutput,
+} from '@carrot-fndn/shared/rule/types';
+import { random } from 'typia';
+
+import { DocumentManifestProcessor } from './document-manifest.processor';
+import {
+  documentManifestTestCases,
+  exceptionTestCases,
+} from './document-manifest.test-cases';
+
+jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
+
+describe('DocumentManifestProcessor', () => {
+  const documentLoaderService = jest.mocked(loadParentDocument);
+
+  it.each([...exceptionTestCases, ...documentManifestTestCases])(
+    'should return $resultStatus when $scenario',
+    async ({ documentManifestType, events, resultComment, resultStatus }) => {
+      const ruleDataProcessor = new DocumentManifestProcessor(
+        documentManifestType,
+      );
+
+      const ruleInput = random<Required<RuleInput>>();
+
+      const { massIdDocument } = new BoldStubsBuilder()
+        .createMassIdDocument({
+          externalEventsMap: events,
+        })
+        .build();
+
+      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+
+      const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+      const expectedRuleOutput: RuleOutput = {
+        requestId: ruleInput.requestId,
+        responseToken: ruleInput.responseToken,
+        responseUrl: ruleInput.responseUrl,
+        resultComment,
+        resultStatus,
+      };
+
+      expect(ruleOutput).toEqual(expectedRuleOutput);
+    },
+  );
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
@@ -85,24 +85,24 @@ export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleS
   ): ValidationResult {
     const rejectedMessages: string[] = [];
 
-    const typeString = documentType?.toString();
-    const numberString = documentNumber?.toString();
+    const documentTypeString = documentType?.toString();
+    const documentNumberString = documentNumber?.toString();
 
-    if (!isNonEmptyString(typeString)) {
+    if (!isNonEmptyString(documentTypeString)) {
       rejectedMessages.push(RESULT_COMMENTS.MISSING_DOCUMENT_TYPE);
     }
 
     if (
-      isNonEmptyString(typeString) &&
-      typeString !== ReportType.MTR.toString() &&
-      recyclerCountryCode !== 'BR'
+      isNonEmptyString(documentTypeString) &&
+      recyclerCountryCode === 'BR' &&
+      documentTypeString !== ReportType.MTR.toString()
     ) {
       rejectedMessages.push(
-        RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE(typeString),
+        RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE(documentTypeString),
       );
     }
 
-    if (!isNonEmptyString(numberString)) {
+    if (!isNonEmptyString(documentNumberString)) {
       rejectedMessages.push(RESULT_COMMENTS.MISSING_DOCUMENT_NUMBER);
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
@@ -70,6 +70,11 @@ export type DocumentManifestType =
   | typeof RECYCLING_MANIFEST
   | typeof TRANSPORT_MANIFEST;
 
+const DOCUMENT_TYPE_MAPPING = {
+  [RECYCLING_MANIFEST]: ReportType.CDF.toString(),
+  [TRANSPORT_MANIFEST]: ReportType.MTR.toString(),
+} as const;
+
 export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleSubject> {
   private readonly documentManifestType: DocumentManifestType;
 
@@ -95,7 +100,7 @@ export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleS
     if (
       isNonEmptyString(documentTypeString) &&
       recyclerCountryCode === 'BR' &&
-      documentTypeString !== ReportType.MTR.toString()
+      documentTypeString !== DOCUMENT_TYPE_MAPPING[this.documentManifestType]
     ) {
       rejectedMessages.push(
         RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE(documentTypeString),

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
@@ -1,0 +1,338 @@
+import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
+
+import {
+  getOrDefault,
+  isNil,
+  isNonEmptyArray,
+  isNonEmptyString,
+} from '@carrot-fndn/shared/helpers';
+import {
+  getEventAttributeByName,
+  getEventAttributeValue,
+  getFirstDocumentEventAttachment,
+} from '@carrot-fndn/shared/methodologies/bold/getters';
+import {
+  and,
+  eventLabelIsAnyOf,
+  eventNameIsAnyOf,
+} from '@carrot-fndn/shared/methodologies/bold/predicates';
+import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/bold/processors';
+import {
+  type Document,
+  type DocumentEvent,
+  DocumentEventAttachmentLabel,
+  DocumentEventName,
+  NewDocumentEventAttributeName,
+  ReportType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import {
+  type MethodologyDocumentEventAttribute,
+  MethodologyDocumentEventAttributeFormat,
+  type MethodologyDocumentEventAttributeValue,
+  MethodologyDocumentEventLabel,
+} from '@carrot-fndn/shared/types';
+import { is } from 'typia';
+
+import { RESULT_COMMENTS } from './document-manifest.constants';
+
+const { ACTOR, RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
+const { DOCUMENT_NUMBER, DOCUMENT_TYPE, EXEMPTION_JUSTIFICATION, ISSUE_DATE } =
+  NewDocumentEventAttributeName;
+const { RECYCLER } = MethodologyDocumentEventLabel;
+const { DATE } = MethodologyDocumentEventAttributeFormat;
+
+interface ValidationResult {
+  approvedMessages: string[];
+  rejectedMessages: string[];
+}
+
+interface DocumentManifestEventSubject {
+  attachmentLabel: DocumentEventAttachmentLabel | string | undefined;
+  documentNumber: MethodologyDocumentEventAttributeValue | string | undefined;
+  documentType: MethodologyDocumentEventAttributeValue | string | undefined;
+  eventAddressId: string | undefined;
+  eventValue: number | undefined;
+  exemptionJustification:
+    | MethodologyDocumentEventAttributeValue
+    | string
+    | undefined;
+  issueDateAttribute: MethodologyDocumentEventAttribute | undefined;
+  recyclerCountryCode: string | undefined;
+}
+
+type RuleSubject = {
+  documentManifestEvents: DocumentManifestEventSubject[];
+  recyclerEvent: DocumentEvent | undefined;
+};
+
+export type DocumentManifestType =
+  | typeof RECYCLING_MANIFEST
+  | typeof TRANSPORT_MANIFEST;
+
+export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleSubject> {
+  private readonly documentManifestType: DocumentManifestType;
+
+  constructor(documentManifestType: DocumentManifestType) {
+    super();
+    this.documentManifestType = documentManifestType;
+  }
+
+  private validateDocumentAttributes(
+    documentType: MethodologyDocumentEventAttributeValue | string | undefined,
+    documentNumber: MethodologyDocumentEventAttributeValue | string | undefined,
+    recyclerCountryCode: string | undefined,
+  ): ValidationResult {
+    const rejectedMessages: string[] = [];
+
+    const typeString = documentType?.toString();
+    const numberString = documentNumber?.toString();
+
+    if (!isNonEmptyString(typeString)) {
+      rejectedMessages.push(RESULT_COMMENTS.MISSING_DOCUMENT_TYPE);
+    }
+
+    if (
+      isNonEmptyString(typeString) &&
+      typeString !== ReportType.MTR.toString() &&
+      recyclerCountryCode !== 'BR'
+    ) {
+      rejectedMessages.push(
+        RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE(typeString),
+      );
+    }
+
+    if (!isNonEmptyString(numberString)) {
+      rejectedMessages.push(RESULT_COMMENTS.MISSING_DOCUMENT_NUMBER);
+    }
+
+    return { approvedMessages: [], rejectedMessages };
+  }
+
+  private validateDocumentManifestEvents(
+    subject: DocumentManifestEventSubject,
+    recyclerEvent: DocumentEvent,
+  ): ValidationResult {
+    const {
+      attachmentLabel,
+      documentNumber,
+      documentType,
+      eventAddressId,
+      eventValue,
+      exemptionJustification,
+      issueDateAttribute,
+      recyclerCountryCode,
+    } = subject;
+
+    if (
+      eventAddressId !== recyclerEvent.address.id &&
+      this.documentManifestType === RECYCLING_MANIFEST
+    ) {
+      return {
+        approvedMessages: [],
+        rejectedMessages: [RESULT_COMMENTS.ADDRESS_MISMATCH],
+      };
+    }
+
+    const exemptionResult = this.validateExemptionAndAttachment(
+      attachmentLabel,
+      exemptionJustification,
+    );
+
+    if (exemptionResult.approvedMessages.length > 0) {
+      return exemptionResult;
+    }
+
+    if (exemptionResult.rejectedMessages.length > 0) {
+      return exemptionResult;
+    }
+
+    const validations = [
+      exemptionResult,
+      this.validateDocumentAttributes(
+        documentType,
+        documentNumber,
+        recyclerCountryCode,
+      ),
+      this.validateIssueDate(issueDateAttribute),
+      this.validateEventValue(eventValue),
+    ];
+
+    const rejectedMessages = validations.flatMap((v) => v.rejectedMessages);
+
+    if (rejectedMessages.length > 0) {
+      return { approvedMessages: [], rejectedMessages };
+    }
+
+    return {
+      approvedMessages: [
+        RESULT_COMMENTS.VALID_ATTACHMENT_DECLARATION({
+          documentNumber: documentNumber as string,
+          documentType: documentType as string,
+          issueDate: issueDateAttribute?.value as string,
+          value: getOrDefault(eventValue, 0),
+        }),
+      ],
+      rejectedMessages: [],
+    };
+  }
+
+  private validateEventValue(eventValue: number | undefined): ValidationResult {
+    if (eventValue === 0) {
+      return {
+        approvedMessages: [],
+        rejectedMessages: [
+          RESULT_COMMENTS.INVALID_EVENT_VALUE(eventValue.toString()),
+        ],
+      };
+    }
+
+    return { approvedMessages: [], rejectedMessages: [] };
+  }
+
+  private validateExemptionAndAttachment(
+    attachmentLabel: string | undefined,
+    exemptionJustification:
+      | MethodologyDocumentEventAttributeValue
+      | string
+      | undefined,
+  ): ValidationResult {
+    const justificationString = exemptionJustification?.toString();
+
+    if (
+      !isNonEmptyString(attachmentLabel) &&
+      isNonEmptyString(justificationString)
+    ) {
+      return {
+        approvedMessages: [RESULT_COMMENTS.PROVIDE_EXEMPTION_JUSTIFICATION],
+        rejectedMessages: [],
+      };
+    }
+
+    if (
+      !isNonEmptyString(justificationString) &&
+      !isNonEmptyString(attachmentLabel)
+    ) {
+      return {
+        approvedMessages: [],
+        rejectedMessages: [RESULT_COMMENTS.MISSING_ATTRIBUTES],
+      };
+    }
+
+    if (
+      isNonEmptyString(justificationString) &&
+      is<DocumentEventAttachmentLabel>(attachmentLabel)
+    ) {
+      return {
+        approvedMessages: [],
+        rejectedMessages: [
+          RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED,
+        ],
+      };
+    }
+
+    if (!is<DocumentEventAttachmentLabel>(attachmentLabel)) {
+      return {
+        approvedMessages: [],
+        rejectedMessages: [
+          RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL(
+            getOrDefault(attachmentLabel, 'undefined'),
+          ),
+        ],
+      };
+    }
+
+    return { approvedMessages: [], rejectedMessages: [] };
+  }
+
+  private validateIssueDate(
+    issueDateAttribute: MethodologyDocumentEventAttribute | undefined,
+  ): ValidationResult {
+    const rejectedMessages: string[] = [];
+
+    if (!isNonEmptyString(issueDateAttribute?.name)) {
+      rejectedMessages.push(RESULT_COMMENTS.MISSING_ISSUE_DATE);
+    } else if (issueDateAttribute.format !== DATE) {
+      rejectedMessages.push(
+        RESULT_COMMENTS.INVALID_ISSUE_DATE_FORMAT(
+          issueDateAttribute.format as string,
+        ),
+      );
+    }
+
+    return { approvedMessages: [], rejectedMessages };
+  }
+
+  protected override evaluateResult(
+    ruleSubject: RuleSubject,
+  ): EvaluateResultOutput | Promise<EvaluateResultOutput> {
+    if (!isNonEmptyArray(ruleSubject.documentManifestEvents)) {
+      return {
+        resultComment: RESULT_COMMENTS.MISSING_EVENT,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    if (isNil(ruleSubject.recyclerEvent)) {
+      return {
+        resultComment: RESULT_COMMENTS.MISSING_RECYCLER_EVENT,
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    const validationResults = ruleSubject.documentManifestEvents.map(
+      (subject) =>
+        this.validateDocumentManifestEvents(
+          subject,
+          ruleSubject.recyclerEvent as DocumentEvent,
+        ),
+    );
+    const allRejectedMessages = validationResults.flatMap(
+      (v) => v.rejectedMessages,
+    );
+    const allApprovedMessages = validationResults.flatMap(
+      (v) => v.approvedMessages,
+    );
+
+    if (allRejectedMessages.length > 0) {
+      return {
+        resultComment: allRejectedMessages.join(' '),
+        resultStatus: RuleOutputStatus.REJECTED,
+      };
+    }
+
+    return {
+      resultComment: allApprovedMessages.join(' '),
+      resultStatus: RuleOutputStatus.APPROVED,
+    };
+  }
+
+  protected override getRuleSubject(document: Document): RuleSubject {
+    const transportManifestEvents = document.externalEvents?.filter(
+      eventNameIsAnyOf([this.documentManifestType]),
+    );
+    const recyclerEvent = document.externalEvents?.find(
+      and(eventNameIsAnyOf([ACTOR]), eventLabelIsAnyOf([RECYCLER])),
+    );
+
+    return {
+      documentManifestEvents: getOrDefault(
+        transportManifestEvents?.map((event) => ({
+          attachmentLabel: getFirstDocumentEventAttachment(event)?.label,
+          documentNumber: getEventAttributeValue(event, DOCUMENT_NUMBER),
+          documentType: getEventAttributeValue(event, DOCUMENT_TYPE),
+          eventAddressId: event.address.id,
+          eventValue: event.value,
+          exemptionJustification: getEventAttributeValue(
+            event,
+            EXEMPTION_JUSTIFICATION,
+          ),
+          issueDateAttribute: getEventAttributeByName(event, ISSUE_DATE),
+          recyclerCountryCode: recyclerEvent?.address.countryCode,
+        })),
+        [],
+      ),
+      recyclerEvent,
+    };
+  }
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
@@ -7,9 +7,9 @@ import {
   isNonEmptyString,
 } from '@carrot-fndn/shared/helpers';
 import {
+  getDocumentEventAttachmentByLabel,
   getEventAttributeByName,
   getEventAttributeValue,
-  getFirstDocumentEventAttachment,
 } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   and,
@@ -20,19 +20,18 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type Document,
   type DocumentEvent,
-  DocumentEventAttachmentLabel,
   DocumentEventName,
   NewDocumentEventAttributeName,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
+  type MethodologyDocumentEventAttachment,
   type MethodologyDocumentEventAttribute,
   MethodologyDocumentEventAttributeFormat,
   type MethodologyDocumentEventAttributeValue,
   MethodologyDocumentEventLabel,
 } from '@carrot-fndn/shared/types';
-import { is } from 'typia';
 
 import { RESULT_COMMENTS } from './document-manifest.constants';
 
@@ -48,7 +47,7 @@ interface ValidationResult {
 }
 
 interface DocumentManifestEventSubject {
-  attachmentLabel: DocumentEventAttachmentLabel | string | undefined;
+  attachment: MethodologyDocumentEventAttachment | undefined;
   documentNumber: MethodologyDocumentEventAttributeValue | string | undefined;
   documentType: MethodologyDocumentEventAttributeValue | string | undefined;
   eventAddressId: string | undefined;
@@ -57,6 +56,7 @@ interface DocumentManifestEventSubject {
     | MethodologyDocumentEventAttributeValue
     | string
     | undefined;
+  hasWrongLabelAttachment: boolean;
   issueDateAttribute: MethodologyDocumentEventAttribute | undefined;
   recyclerCountryCode: string | undefined;
 }
@@ -114,12 +114,13 @@ export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleS
     recyclerEvent: DocumentEvent,
   ): ValidationResult {
     const {
-      attachmentLabel,
+      attachment,
       documentNumber,
       documentType,
       eventAddressId,
       eventValue,
       exemptionJustification,
+      hasWrongLabelAttachment,
       issueDateAttribute,
       recyclerCountryCode,
     } = subject;
@@ -134,8 +135,9 @@ export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleS
     }
 
     const exemptionResult = this.validateExemptionAndAttachment(
-      attachmentLabel,
+      attachment,
       exemptionJustification,
+      hasWrongLabelAttachment,
     );
 
     if (exemptionResult.approvedMessage) {
@@ -187,50 +189,38 @@ export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleS
   }
 
   private validateExemptionAndAttachment(
-    attachmentLabel: string | undefined,
+    attachment: MethodologyDocumentEventAttachment | undefined,
     exemptionJustification:
       | MethodologyDocumentEventAttributeValue
       | string
       | undefined,
+    hasWrongLabelAttachment: boolean,
   ): ValidationResult {
     const justificationString = exemptionJustification?.toString();
 
-    if (
-      !isNonEmptyString(attachmentLabel) &&
-      isNonEmptyString(justificationString)
-    ) {
+    if (hasWrongLabelAttachment) {
+      return {
+        rejectedMessages: [RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL],
+      };
+    }
+
+    if (isNil(attachment) && isNonEmptyString(justificationString)) {
       return {
         approvedMessage: RESULT_COMMENTS.PROVIDE_EXEMPTION_JUSTIFICATION,
         rejectedMessages: [],
       };
     }
 
-    if (
-      !isNonEmptyString(justificationString) &&
-      !isNonEmptyString(attachmentLabel)
-    ) {
+    if (isNil(attachment) && !isNonEmptyString(justificationString)) {
       return {
         rejectedMessages: [RESULT_COMMENTS.MISSING_ATTRIBUTES],
       };
     }
 
-    if (
-      isNonEmptyString(justificationString) &&
-      is<DocumentEventAttachmentLabel>(attachmentLabel)
-    ) {
+    if (isNonEmptyString(justificationString) && !isNil(attachment)) {
       return {
         rejectedMessages: [
           RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED,
-        ],
-      };
-    }
-
-    if (!is<DocumentEventAttachmentLabel>(attachmentLabel)) {
-      return {
-        rejectedMessages: [
-          RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL(
-            getOrDefault(attachmentLabel, 'undefined'),
-          ),
         ],
       };
     }
@@ -310,19 +300,30 @@ export class DocumentManifestProcessor extends ParentDocumentRuleProcessor<RuleS
 
     return {
       documentManifestEvents: getOrDefault(
-        transportManifestEvents?.map((event) => ({
-          attachmentLabel: getFirstDocumentEventAttachment(event)?.label,
-          documentNumber: getEventAttributeValue(event, DOCUMENT_NUMBER),
-          documentType: getEventAttributeValue(event, DOCUMENT_TYPE),
-          eventAddressId: event.address.id,
-          eventValue: event.value,
-          exemptionJustification: getEventAttributeValue(
+        transportManifestEvents?.map((event) => {
+          const correctLabelAttachment = getDocumentEventAttachmentByLabel(
             event,
-            EXEMPTION_JUSTIFICATION,
-          ),
-          issueDateAttribute: getEventAttributeByName(event, ISSUE_DATE),
-          recyclerCountryCode: recyclerEvent?.address.countryCode,
-        })),
+            this.documentManifestType,
+          );
+
+          const hasWrongLabelAttachment =
+            !correctLabelAttachment && isNonEmptyArray(event.attachments);
+
+          return {
+            attachment: correctLabelAttachment,
+            documentNumber: getEventAttributeValue(event, DOCUMENT_NUMBER),
+            documentType: getEventAttributeValue(event, DOCUMENT_TYPE),
+            eventAddressId: event.address.id,
+            eventValue: event.value,
+            exemptionJustification: getEventAttributeValue(
+              event,
+              EXEMPTION_JUSTIFICATION,
+            ),
+            hasWrongLabelAttachment,
+            issueDateAttribute: getEventAttributeByName(event, ISSUE_DATE),
+            recyclerCountryCode: recyclerEvent?.address.countryCode,
+          };
+        }),
         [],
       ),
       recyclerEvent,

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
@@ -108,7 +108,7 @@ export const documentManifestTestCases = [
       }),
       ...defaultEvents,
     },
-    resultComment: RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL('MTR'),
+    resultComment: RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL,
     resultStatus: RuleOutputStatus.REJECTED,
     scenario: `the MassID document has a ${documentManifestType} event with a wrong attachment label`,
   },

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
@@ -136,13 +136,20 @@ export const documentManifestTestCases = [
   {
     documentManifestType,
     events: {
+      [`${ACTOR}-${RECYCLER}`]: stubDocumentEvent({
+        address: {
+          ...sameAddress,
+          countryCode: 'BR',
+        },
+        label: RECYCLER,
+        name: ACTOR,
+      }),
       [documentManifestType]: documentManifestTypeStub[documentManifestType]({
         metadataAttributes: [[DOCUMENT_TYPE, 'EMITIARE']],
         partialDocumentEvent: {
           address: sameAddress,
         },
       }),
-      ...defaultEvents,
     },
     resultComment: RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE('EMITIARE'),
     resultStatus: RuleOutputStatus.REJECTED,

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
@@ -1,0 +1,354 @@
+import {
+  stubAddress,
+  stubBoldMassIdRecyclingManifestEvent,
+  stubBoldMassIdTransportManifestEvent,
+  stubDocumentEvent,
+  stubDocumentEventAttachment,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  DocumentEventName,
+  NewDocumentEventAttributeName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import {
+  MethodologyDocumentEventAttributeFormat,
+  MethodologyDocumentEventLabel,
+} from '@carrot-fndn/shared/types';
+import { random } from 'typia';
+
+import { RESULT_COMMENTS } from './document-manifest.constants';
+import { type DocumentManifestType } from './document-manifest.processor';
+
+const { ACTOR, RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
+
+const { DOCUMENT_NUMBER, DOCUMENT_TYPE, EXEMPTION_JUSTIFICATION, ISSUE_DATE } =
+  NewDocumentEventAttributeName;
+const { RECYCLER } = MethodologyDocumentEventLabel;
+const { CUBIC_METER, DATE } = MethodologyDocumentEventAttributeFormat;
+
+const attributeErrorMessages: Record<string, string> = {
+  [DOCUMENT_NUMBER]: RESULT_COMMENTS.MISSING_DOCUMENT_NUMBER,
+  [DOCUMENT_TYPE]: RESULT_COMMENTS.MISSING_DOCUMENT_TYPE,
+  [ISSUE_DATE]: RESULT_COMMENTS.MISSING_ISSUE_DATE,
+};
+
+const documentManifestType = random<DocumentManifestType>();
+
+const documentManifestTypeStub = {
+  [RECYCLING_MANIFEST]: stubBoldMassIdRecyclingManifestEvent,
+  [TRANSPORT_MANIFEST]: stubBoldMassIdTransportManifestEvent,
+};
+
+const sameAddress = stubAddress();
+
+const defaultEvents = {
+  [`${ACTOR}-${RECYCLER}`]: stubDocumentEvent({
+    address: sameAddress,
+    label: RECYCLER,
+    name: ACTOR,
+  }),
+};
+
+export const documentManifestTestCases = [
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: undefined,
+    },
+    resultComment: RESULT_COMMENTS.MISSING_EVENT,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document does not have a ${documentManifestType} event`,
+  },
+  ...[ISSUE_DATE, DOCUMENT_NUMBER, DOCUMENT_TYPE].map((attribute) => ({
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        metadataAttributes: [[attribute, undefined]],
+        partialDocumentEvent: {
+          address: sameAddress,
+        },
+      }),
+      ...defaultEvents,
+    },
+    // eslint-disable-next-line security/detect-object-injection
+    resultComment: attributeErrorMessages[attribute],
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${documentManifestType} event without a ${attribute}`,
+  })),
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        metadataAttributes: [
+          [DOCUMENT_NUMBER, undefined],
+          [DOCUMENT_TYPE, undefined],
+        ],
+        partialDocumentEvent: {
+          address: sameAddress,
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: `${RESULT_COMMENTS.MISSING_DOCUMENT_TYPE} ${RESULT_COMMENTS.MISSING_DOCUMENT_NUMBER}`,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${documentManifestType} event without a ${DOCUMENT_NUMBER} and ${DOCUMENT_TYPE}`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        partialDocumentEvent: {
+          address: sameAddress,
+          attachments: [
+            stubDocumentEventAttachment({
+              label: 'MTR',
+            }),
+          ],
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL('MTR'),
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${documentManifestType} event with a wrong attachment label`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        metadataAttributes: [
+          {
+            format: CUBIC_METER,
+            name: ISSUE_DATE,
+            value: '2025-03-19',
+          },
+        ],
+        partialDocumentEvent: {
+          address: sameAddress,
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.INVALID_ISSUE_DATE_FORMAT(CUBIC_METER),
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${documentManifestType} event ${ISSUE_DATE} with a wrong format`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        metadataAttributes: [[DOCUMENT_TYPE, 'EMITIARE']],
+        partialDocumentEvent: {
+          address: sameAddress,
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE('EMITIARE'),
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${documentManifestType} event ${DOCUMENT_TYPE} with a wrong format`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        partialDocumentEvent: {
+          address: sameAddress,
+          value: 0,
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.INVALID_EVENT_VALUE('0'),
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${documentManifestType} event with a value of 0`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        partialDocumentEvent: {
+          address: sameAddress,
+          attachments: [
+            stubDocumentEventAttachment({
+              label: documentManifestType,
+            }),
+          ],
+        },
+        withExemptionJustification: true,
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${EXEMPTION_JUSTIFICATION} and a attachment`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        metadataAttributes: [[EXEMPTION_JUSTIFICATION, undefined]],
+        partialDocumentEvent: {
+          address: sameAddress,
+        },
+        withExemptionJustification: true,
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.MISSING_ATTRIBUTES,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has no attachment and no ${EXEMPTION_JUSTIFICATION}`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: undefined,
+    },
+    resultComment: RESULT_COMMENTS.MISSING_RECYCLER_EVENT,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has no ${RECYCLER} event`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        partialDocumentEvent: {
+          address: sameAddress,
+        },
+        withExemptionJustification: true,
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.PROVIDE_EXEMPTION_JUSTIFICATION,
+    resultStatus: RuleOutputStatus.APPROVED,
+    scenario: `the MassID document has a ${EXEMPTION_JUSTIFICATION} without attachment`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+        metadataAttributes: [
+          [DOCUMENT_TYPE, 'MTR'],
+          [DOCUMENT_NUMBER, '0'],
+          {
+            format: DATE,
+            name: ISSUE_DATE,
+            value: '2025-03-20',
+          },
+        ],
+        partialDocumentEvent: {
+          address: sameAddress,
+          attachments: [
+            stubDocumentEventAttachment({
+              label: documentManifestType,
+            }),
+          ],
+          value: 100,
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.VALID_ATTACHMENT_DECLARATION({
+      documentNumber: '0',
+      documentType: 'MTR',
+      issueDate: '2025-03-20',
+      value: 100,
+    }),
+    resultStatus: RuleOutputStatus.APPROVED,
+    scenario: `the MassID document has a valid ${TRANSPORT_MANIFEST} event and attachment`,
+  },
+  {
+    documentManifestType,
+    events: {
+      [`${documentManifestType}-1`]: documentManifestTypeStub[
+        documentManifestType
+      ]({
+        metadataAttributes: [
+          [DOCUMENT_TYPE, 'MTR'],
+          [DOCUMENT_NUMBER, '1'],
+          {
+            format: DATE,
+            name: ISSUE_DATE,
+            value: '2025-03-21',
+          },
+        ],
+        partialDocumentEvent: {
+          address: sameAddress,
+          attachments: [
+            stubDocumentEventAttachment({
+              label: documentManifestType,
+            }),
+          ],
+          value: 1000,
+        },
+      }),
+      [`${documentManifestType}-2`]: documentManifestTypeStub[
+        documentManifestType
+      ]({
+        metadataAttributes: [
+          [DOCUMENT_TYPE, 'MTR'],
+          [DOCUMENT_NUMBER, '2'],
+          {
+            format: DATE,
+            name: ISSUE_DATE,
+            value: '2025-03-18',
+          },
+        ],
+        partialDocumentEvent: {
+          address: sameAddress,
+          attachments: [
+            stubDocumentEventAttachment({
+              label: documentManifestType,
+            }),
+          ],
+          value: 200,
+        },
+      }),
+      [documentManifestType]: undefined,
+      ...defaultEvents,
+    },
+    resultComment: `${RESULT_COMMENTS.VALID_ATTACHMENT_DECLARATION({
+      documentNumber: '1',
+      documentType: 'MTR',
+      issueDate: '2025-03-21',
+      value: 1000,
+    })} ${RESULT_COMMENTS.VALID_ATTACHMENT_DECLARATION({
+      documentNumber: '2',
+      documentType: 'MTR',
+      issueDate: '2025-03-18',
+      value: 200,
+    })}`,
+    resultStatus: RuleOutputStatus.APPROVED,
+    scenario: `the MassID document has two valid ${documentManifestType} events and attachments`,
+  },
+  {
+    documentManifestType: TRANSPORT_MANIFEST as DocumentManifestType,
+    events: {
+      [TRANSPORT_MANIFEST]: documentManifestTypeStub[TRANSPORT_MANIFEST]({
+        metadataAttributes: [[EXEMPTION_JUSTIFICATION, 'Some justification']],
+        partialDocumentEvent: {
+          address: sameAddress,
+          attachments: [
+            stubDocumentEventAttachment({
+              label: TRANSPORT_MANIFEST,
+            }),
+          ],
+        },
+      }),
+      ...defaultEvents,
+    },
+    resultComment: RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has both a valid ${TRANSPORT_MANIFEST} attachment and ${EXEMPTION_JUSTIFICATION}`,
+  },
+];
+
+export const exceptionTestCases = [
+  {
+    documentManifestType: RECYCLING_MANIFEST as DocumentManifestType,
+    events: {},
+    resultComment: RESULT_COMMENTS.ADDRESS_MISMATCH,
+    resultStatus: RuleOutputStatus.REJECTED,
+    scenario: `the MassID document has a ${RECYCLING_MANIFEST} event with a different address than the ${RECYCLER} event`,
+  },
+];

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/index.ts
@@ -1,0 +1,1 @@
+export * from './document-manifest.lambda';

--- a/libs/methodologies/bold/rule-processors/mass-id/src/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/index.ts
@@ -10,3 +10,4 @@ export * from './vehicle-identification';
 export * from './geolocation-precision';
 export * from './local-waste-classification';
 export * from './processor-identification';
+export * from './document-manifest';

--- a/libs/shared/methodologies/bold/getters/src/event.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/event.getters.spec.ts
@@ -15,6 +15,7 @@ import { faker } from '@faker-js/faker';
 
 import {
   getDocumentEventAttachmentByLabel,
+  getEventAttributeByName,
   getEventAttributeValue,
   getEventAttributeValueOrThrow,
   getEventMethodologySlug,
@@ -131,6 +132,41 @@ describe('Event getters', () => {
       const result = getEventMethodologySlug(event);
 
       expect(result).toBe(undefined);
+    });
+  });
+
+  describe('getEventAttributeByName', () => {
+    it('should return the correct attribute', () => {
+      const event = stubDocumentEventWithMetadataAttributes({}, [
+        [ACTOR_TYPE, AUDITOR],
+      ]);
+
+      const result = getEventAttributeByName(event, ACTOR_TYPE);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          name: ACTOR_TYPE,
+          value: AUDITOR,
+        }),
+      );
+    });
+
+    it('should return undefined if the attribute does not exist', () => {
+      const event = stubDocumentEventWithMetadataAttributes({}, [
+        [ACTOR_TYPE, AUDITOR],
+      ]);
+
+      const result = getEventAttributeByName(event, 'missing');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if the event does not have metadata', () => {
+      const event = stubDocumentEvent();
+
+      const result = getEventAttributeByName(event, ACTOR_TYPE);
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/libs/shared/methodologies/bold/getters/src/event.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/event.getters.ts
@@ -1,6 +1,7 @@
 import type {
   Maybe,
   MethodologyDocumentEventAttachment,
+  MethodologyDocumentEventAttribute,
   MethodologyDocumentEventAttributeValue,
 } from '@carrot-fndn/shared/types';
 
@@ -31,6 +32,21 @@ export const getEventAttributeValue = (
   return undefined;
 };
 
+export const getEventAttributeByName = (
+  event: Maybe<DocumentEvent>,
+  attributeName: DocumentEventAttributeName | string,
+): MethodologyDocumentEventAttribute | undefined => {
+  const validation = validateDocumentEventWithMetadata(event);
+
+  if (validation.success) {
+    return validation.data.metadata.attributes.find(
+      (attribute) => attribute.name === attributeName,
+    );
+  }
+
+  return undefined;
+};
+
 export const getEventAttributeValueOrThrow = <T>(
   event: Maybe<DocumentEvent>,
   attributeName: DocumentEventAttributeName | string,
@@ -56,6 +72,18 @@ export const getDocumentEventAttachmentByLabel = (
     return validation.data.attachments.find(
       (attachment) => attachment.label === label,
     );
+  }
+
+  return undefined;
+};
+
+export const getFirstDocumentEventAttachment = (
+  event: DocumentEvent,
+): MethodologyDocumentEventAttachment | undefined => {
+  const validation = validate<DocumentEventWithAttachments>(event);
+
+  if (validation.success) {
+    return validation.data.attachments[0];
   }
 
   return undefined;

--- a/libs/shared/methodologies/bold/getters/src/event.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/event.getters.ts
@@ -77,18 +77,6 @@ export const getDocumentEventAttachmentByLabel = (
   return undefined;
 };
 
-export const getFirstDocumentEventAttachment = (
-  event: DocumentEvent,
-): MethodologyDocumentEventAttachment | undefined => {
-  const validation = validate<DocumentEventWithAttachments>(event);
-
-  if (validation.success) {
-    return validation.data.attachments[0];
-  }
-
-  return undefined;
-};
-
 export const getEventMethodologySlug = (
   event: Maybe<DocumentEvent>,
 ): MethodologyDocumentEventAttributeValue | undefined =>

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -3,6 +3,7 @@ import {
   type Document,
   DocumentCategory,
   type DocumentEvent,
+  DocumentEventAttachmentLabel,
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
@@ -26,6 +27,7 @@ import { random } from 'typia';
 
 import {
   stubDocument,
+  stubDocumentEventAttachment,
   stubDocumentEventWithMetadataAttributes,
 } from '../stubs';
 import {
@@ -135,6 +137,14 @@ export const stubBoldMassIdTransportManifestEvent = ({
 
   return stubDocumentEventWithMetadataAttributes(
     {
+      attachments:
+        withExemptionJustification === true
+          ? []
+          : [
+              stubDocumentEventAttachment({
+                label: DocumentEventAttachmentLabel.TRANSPORT_MANIFEST,
+              }),
+            ],
       ...partialDocumentEvent,
       name: TRANSPORT_MANIFEST,
     },
@@ -230,6 +240,14 @@ export const stubBoldMassIdRecyclingManifestEvent = ({
 
   return stubDocumentEventWithMetadataAttributes(
     {
+      attachments:
+        withExemptionJustification === true
+          ? []
+          : [
+              stubDocumentEventAttachment({
+                label: DocumentEventAttachmentLabel.RECYCLING_MANIFEST,
+              }),
+            ],
       ...partialDocumentEvent,
       name: RECYCLING_MANIFEST,
     },

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -220,7 +220,7 @@ const defaultRecyclingManifestWithExemptionAttributes: MetadataAttributeParamete
 
 const defaultRecyclingManifestAttributes: MetadataAttributeParameter[] = [
   [DOCUMENT_NUMBER, faker.string.uuid()],
-  [DOCUMENT_TYPE, ReportType.MTR],
+  [DOCUMENT_TYPE, ReportType.CDF],
   {
     format: DATE,
     name: ISSUE_DATE,

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -182,6 +182,11 @@ export enum ReportTypeLiteralName {
   MTR = 'MANIFESTO DE TRANSPORTE DE RESÍDUOS',
 }
 
+export enum DocumentEventAttachmentLabel {
+  RECYCLING_MANIFEST = 'Recycling Manifest',
+  TRANSPORT_MANIFEST = 'Transport Manifest',
+}
+
 export enum DocumentEventName {
   ACTOR = MethodologyDocumentEventName.ACTOR,
   CLOSE = MethodologyDocumentEventName.CLOSE,


### PR DESCRIPTION
### Summary

- Introduced the TransportManifestProcessor to handle validation and processing of transport manifest events.
- Added constants, error handling, and test cases for various scenarios related to transport manifests.
- Created necessary files including lambda handler, constants, errors, and test cases to ensure comprehensive coverage and functionality.

### Related links

- https://www.notion.so/carrot-fndn/Recycling-Manifest-1b49703d8e9c80b590c5ce94e18bd071?pvs=4;
- https://www.notion.so/carrot-fndn/Transport-Manifest-1b49703d8e9c801893eee205259514f3?pvs=4

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced document processing with improved validations and tailored feedback to help guide users in resolving submission issues.
  - Improved categorization of document attachments, specifically for recycling and transport manifests.
  - New functions for retrieving event attributes and attachments to streamline document event handling.
  - Introduction of a new lambda function for processing document manifests.
  - Comprehensive set of test cases for validating document events and attributes.
  - New enum for document event attachment labels to enhance categorization.

- **Quality Assurance**
  - Strengthened reliability with comprehensive tests ensuring consistent processing and accurate feedback for various document scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->