### PR TITLE
fix: change measurement unit to lowercase

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/document-measurement-unit/README.md
+++ b/apps/methodologies/bold/rule-processors/mass/document-measurement-unit/README.md
@@ -10,7 +10,7 @@ Methodology: **BOLD**
 
 ## 📄 Description
 
-Check if the unit of measurement declared in the document is KG
+Check if the unit of measurement declared in the document is kg
 
 ### 📂 Implementation
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
@@ -1,7 +1,7 @@
 import {
   DocumentEventName,
+  MeasurementUnit,
   NewDocumentEventAttributeName,
-  NewMeasurementUnit,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -44,5 +44,5 @@ export const RESULT_COMMENTS = {
     issueDate: string;
     value: number;
   }) =>
-    `The ${documentType} attachment (No. ${documentNumber}), issued on ${issueDate}, with a value of ${value}${NewMeasurementUnit.KG}, was provided.`,
+    `The ${documentType} attachment (No. ${documentNumber}), issued on ${issueDate}, with a value of ${value}${MeasurementUnit.KG}, was provided.`,
 } as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts
@@ -7,7 +7,7 @@ import {
   DocumentCategory,
   DocumentType,
   MassSubtype,
-  NewMeasurementUnit,
+  MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
@@ -16,7 +16,7 @@ import { MassDefinitionProcessorErrors } from './mass-definition.errors';
 const ALLOWED_SUBTYPES: string[] = Object.values(MassSubtype);
 
 const { MASS_ID } = DocumentCategory;
-const { KG } = NewMeasurementUnit;
+const { KG } = MeasurementUnit;
 const { ORGANIC } = DocumentType;
 
 export const RESULT_COMMENTS = {

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -11,8 +11,8 @@ import {
   DocumentEventWeighingCaptureMethod,
   DocumentType,
   MassSubtype,
+  MeasurementUnit,
   NewDocumentEventAttributeName,
-  NewMeasurementUnit,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubEnumValue } from '@carrot-fndn/shared/testing';
@@ -352,7 +352,7 @@ export const stubBoldMassIdDocument = ({
           ...mergedEventsMap.values(),
           ...(partialDocument?.externalEvents ?? []),
         ],
-        measurementUnit: NewMeasurementUnit.KG,
+        measurementUnit: MeasurementUnit.KG,
         subtype: stubEnumValue(MassSubtype),
         type: DocumentType.ORGANIC,
       },

--- a/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
+++ b/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
@@ -587,7 +587,7 @@ export const approvedMassDocument: Document = {
   id: faker.string.uuid(),
   isPublic: true,
   isPubliclySearchable: true,
-  measurementUnit: 'KG',
+  measurementUnit: 'kg',
   permissions: [
     {
       id: faker.string.uuid(),

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -67,13 +67,7 @@ export enum MassSubtype {
   WOOD_AND_WOOD_PRODUCTS = DocumentSubtype.WOOD_AND_WOOD_PRODUCTS,
 }
 
-// TODO: Remove this enum after finish the rules development
 export enum MeasurementUnit {
-  KG = 'kg',
-}
-
-// TODO: Rename this enum after finish the rules development
-export enum NewMeasurementUnit {
   KG = 'kg',
 }
 

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -69,7 +69,7 @@ export enum MassSubtype {
 
 // TODO: Remove this enum after finish the rules development
 export enum MeasurementUnit {
-  KG = 'KG',
+  KG = 'kg',
 }
 
 // TODO: Rename this enum after finish the rules development


### PR DESCRIPTION
### Summary

Upstream services have been changed to use `kg` lowercase, so we are also changing it here.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated descriptive text to display the measurement unit in lowercase ("kg") for improved consistency.
  
- **Refactor**
	- Standardized measurement unit references across various components, tests, and configurations to ensure a uniform presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->