### PR TITLE
refactor: use MeasurementUnit enum for weight values

### DIFF
--- a/apps/methodologies/bold/rule-processors/mass/numeric-weight-values/src/lib/numeric-weight-values.stubs.ts
+++ b/apps/methodologies/bold/rule-processors/mass/numeric-weight-values/src/lib/numeric-weight-values.stubs.ts
@@ -6,6 +6,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventMoveType,
   DocumentEventName,
+  MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { faker } from '@faker-js/faker';
 
@@ -24,17 +25,17 @@ export const stubWeighingMoveEvent = (
         {
           isPublic: true,
           name: DocumentEventAttributeName.VEHICLE_GROSS_WEIGHT,
-          value: `${faker.number.float()} KG`,
+          value: `${faker.number.float()} ${MeasurementUnit.KG}`,
         },
         {
           isPublic: true,
           name: DocumentEventAttributeName.VEHICLE_WEIGHT,
-          value: `${faker.number.float()} KG`,
+          value: `${faker.number.float()} ${MeasurementUnit.KG}`,
         },
         {
           isPublic: true,
           name: DocumentEventAttributeName.LOAD_NET_WEIGHT,
-          value: `${faker.number.float()} KG`,
+          value: `${faker.number.float()} ${MeasurementUnit.KG}`,
         },
       ],
     },

--- a/libs/shared/methodologies/bold/predicates/src/event.predicates.spec.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicates.spec.ts
@@ -9,6 +9,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventMoveType,
   DocumentEventName,
+  MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { CARROT_PARTICIPANT_BY_ENVIRONMENT } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { stubArray, stubEnumValue } from '@carrot-fndn/shared/testing';
@@ -365,7 +366,7 @@ describe('Event Predicates', () => {
 
   describe('hasWeightFormat', () => {
     it('should return true if the weight format is valid', () => {
-      const weight = `${faker.number.float()} KG`;
+      const weight = `${faker.number.float()} ${MeasurementUnit.KG}`;
 
       const result = hasWeightFormat(weight);
 

--- a/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
@@ -9,6 +9,7 @@ import {
   DocumentEventActorType,
   DocumentEventAttributeName,
   DocumentEventName,
+  MeasurementUnit,
   NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { CARROT_PARTICIPANT_BY_ENVIRONMENT } from '@carrot-fndn/shared/methodologies/bold/utils';
@@ -69,7 +70,11 @@ export const hasWeightFormat = (
 ): boolean => {
   const parts = unparsedWeightValue?.split(' ');
 
-  return parts?.length === 2 && !Number.isNaN(parts[0]) && parts[1] === 'KG';
+  return (
+    parts?.length === 2 &&
+    !Number.isNaN(parts[0]) &&
+    parts[1] === MeasurementUnit.KG
+  );
 };
 
 export const eventsHasSameMetadataAttributeValue = (

--- a/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
+++ b/libs/shared/methodologies/bold/testing/src/documents/approved-mass-document.ts
@@ -6,6 +6,7 @@ import {
   DocumentEventName,
   DocumentSubtype,
   DocumentType,
+  MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   DataSetName,
@@ -140,7 +141,7 @@ export const approvedMassDocument: Document = {
           {
             isPublic: true,
             name: DocumentEventAttributeName.VEHICLE_VOLUME_CAPACITY,
-            value: '131000.00 KG',
+            value: `131000.00 ${MeasurementUnit.KG}`,
           },
           {
             isPublic: true,
@@ -343,17 +344,17 @@ export const approvedMassDocument: Document = {
           {
             isPublic: true,
             name: DocumentEventAttributeName.VEHICLE_GROSS_WEIGHT,
-            value: '128901.00 KG',
+            value: `128901.00 ${MeasurementUnit.KG}`,
           },
           {
             isPublic: true,
             name: DocumentEventAttributeName.VEHICLE_WEIGHT,
-            value: '19700.00 KG',
+            value: `19700.00 ${MeasurementUnit.KG}`,
           },
           {
             isPublic: true,
             name: DocumentEventAttributeName.LOAD_NET_WEIGHT,
-            value: '109201.00 KG',
+            value: `109201.00 ${MeasurementUnit.KG}`,
           },
         ],
       },
@@ -433,17 +434,17 @@ export const approvedMassDocument: Document = {
           {
             isPublic: true,
             name: DocumentEventAttributeName.VEHICLE_GROSS_WEIGHT,
-            value: '128900.00 KG',
+            value: `128900.00 ${MeasurementUnit.KG}`,
           },
           {
             isPublic: true,
             name: DocumentEventAttributeName.VEHICLE_WEIGHT,
-            value: '19700.00 KG',
+            value: `19700.00 ${MeasurementUnit.KG}`,
           },
           {
             isPublic: true,
             name: DocumentEventAttributeName.LOAD_NET_WEIGHT,
-            value: '109200.00 KG',
+            value: `109200.00 ${MeasurementUnit.KG}`,
           },
         ],
       },
@@ -504,12 +505,12 @@ export const approvedMassDocument: Document = {
           {
             isPublic: true,
             name: DocumentEventAttributeName.INVOICE_TOTAL_WEIGHT,
-            value: '136410.00 KG',
+            value: `136410.00 ${MeasurementUnit.KG}`,
           },
           {
             isPublic: true,
             name: DocumentEventAttributeName.INVOICE_WEIGHT_MASSID_ASSOCIATED,
-            value: '109200.00 KG',
+            value: `109200.00 ${MeasurementUnit.KG}`,
           },
         ],
       },
@@ -587,7 +588,7 @@ export const approvedMassDocument: Document = {
   id: faker.string.uuid(),
   isPublic: true,
   isPubliclySearchable: true,
-  measurementUnit: 'kg',
+  measurementUnit: MeasurementUnit.KG,
   permissions: [
     {
       id: faker.string.uuid(),


### PR DESCRIPTION
### Summary

This PR refactors the code to use the `MeasurementUnit` enum instead of hardcoded 'KG' strings for weight values in the BOLD methodology. This change improves code maintainability and type safety by centralizing the weight unit representation.

### Details

The changes include:
- Added `MeasurementUnit` import from bold types
- Updated weight value generation in `numeric-weight-values.stubs.ts` to use `MeasurementUnit.KG`
- Modified `hasWeightFormat` function in `event.predicates.ts` to validate against `MeasurementUnit.KG`
- Improved code formatting for better readability

Files changed:
- `apps/methodologies/bold/rule-processors/mass/numeric-weight-values/src/lib/numeric-weight-values.stubs.ts`
- `libs/shared/methodologies/bold/predicates/src/event.predicates.ts`

This refactoring:
- Reduces risk of typos in weight unit strings
- Makes the code more maintainable
- Provides better type safety through enum usage
- No functional changes to the existing behavior

### Related links

- Branch: `fix/numeric-weight-values-rule`
- Related to BOLD methodology weight validation rules

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Weight measurements are now displayed using a standardized unit across the application. Values such as gross weight and net load now consistently include the unit (KG), ensuring clearer and more uniform measurement information for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->