### PR TITLE
chore: enhance GitHub workflows by adding required secrets for AWS account IDs

### DIFF
--- a/.github/workflows/check-and-deploy.yaml
+++ b/.github/workflows/check-and-deploy.yaml
@@ -45,4 +45,7 @@ jobs:
     needs: [affected, backend-check]
     if: ${{ github.ref_name == 'main' && needs.affected.outputs.upload-lambda == 'true' && (needs.backend-check.result == 'success' || needs.backend-check.result == 'skipped') }}
     uses: ./.github/workflows/deploy.yaml
-    secrets: inherit
+    secrets:
+      AWS_ACCOUNT_ID_PRODUCTION: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
+      AWS_ACCOUNT_ID_DEVELOPMENT: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
+      ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,13 @@ permissions: write-all
 
 on:
   workflow_call:
+    secrets:
+      AWS_ACCOUNT_ID_PRODUCTION:
+        required: true
+      AWS_ACCOUNT_ID_DEVELOPMENT:
+        required: true
+      ADMIN_GITHUB_TOKEN:
+        required: true
 
 jobs:
   upload-lambda:
@@ -16,12 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - environment: production
-            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
-
-          - environment: development
-            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
+        environment: [production, development]
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -31,10 +33,19 @@ jobs:
 
       - uses: ./.github/actions/prepare-to-run-nx
 
+      - name: Set AWS Account ID
+        id: set-aws-account
+        run: |
+          if [[ "${{ matrix.environment }}" == "production" ]]; then
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}" >> $GITHUB_ENV
+          else
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}" >> $GITHUB_ENV
+          fi
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.AWS_ACCOUNT_ID }}:role/GitHubActions-methodology-rules
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/GitHubActions-methodology-rules
           aws-region: ${{ env.AWS_REGION }}
 
       - run: pnpm upload-lambdas-and-metadata ${{ matrix.environment }}


### PR DESCRIPTION
### Summary

GitHub Actions doesn't allow the use of secrets directly in matrix definitions like this. The error is occurring because we can't reference `secrets.AWS_ACCOUNT_ID_PRODUCTION` and `secrets.AWS_ACCOUNT_ID_DEVELOPMENT` within the matrix values.

### The Solution

We need to modify the `deploy.yaml`file to handle secrets differently. Instead of trying to use secrets directly in the matrix, we'll modify the workflow to use environment variables or a different approach

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved deployment security by explicitly specifying required secrets.
  - Simplified deployment workflows with dynamic environment configuration for smoother production and development operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->