### PR TITLE
[STACKED] refactor/rename attribute names enum

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.ts
@@ -19,8 +19,8 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/matchers';
 import {
   type Document,
+  DocumentEventAttributeName,
   DocumentSubtype,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
@@ -32,7 +32,7 @@ import {
 
 import { AvoidedEmissionsProcessorErrors } from './avoided-emissions.errors';
 
-const { PROJECT_EMISSION_CALCULATION_INDEX } = NewDocumentEventAttributeName;
+const { PROJECT_EMISSION_CALCULATION_INDEX } = DocumentEventAttributeName;
 
 export const RESULT_COMMENTS = {
   APPROVED: (

--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.test-cases.ts
@@ -3,9 +3,9 @@ import {
   stubBoldHomologationDocumentCloseEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
@@ -14,7 +14,7 @@ import { RESULT_COMMENTS } from './avoided-emissions.processor';
 
 const {
   PROJECT_EMISSION_CALCULATION_INDEX: PROJECT_EMISION_CALCULATION_INDEX,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 const { RECYCLER } = MassIdDocumentActorType;
 const { CLOSE } = DocumentEventName;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.constants.ts
@@ -1,7 +1,7 @@
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   MeasurementUnit,
-  NewDocumentEventAttributeName,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -10,7 +10,7 @@ import {
 } from '@carrot-fndn/shared/types';
 
 const { DOCUMENT_NUMBER, DOCUMENT_TYPE, EXEMPTION_JUSTIFICATION, ISSUE_DATE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 const { RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
 const { DATE } = MethodologyDocumentEventAttributeFormat;
 const { RECYCLER } = MethodologyDocumentEventLabel;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts
@@ -20,8 +20,8 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -37,7 +37,7 @@ import { RESULT_COMMENTS } from './document-manifest.constants';
 
 const { ACTOR, RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
 const { DOCUMENT_NUMBER, DOCUMENT_TYPE, EXEMPTION_JUSTIFICATION, ISSUE_DATE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { DATE } = MethodologyDocumentEventAttributeFormat;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.test-cases.ts
@@ -6,8 +6,8 @@ import {
   stubDocumentEventAttachment,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
@@ -22,7 +22,7 @@ import { type DocumentManifestType } from './document-manifest.processor';
 const { ACTOR, RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
 
 const { DOCUMENT_NUMBER, DOCUMENT_TYPE, EXEMPTION_JUSTIFICATION, ISSUE_DATE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { CUBIC_METER, DATE } = MethodologyDocumentEventAttributeFormat;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.ts
@@ -7,9 +7,9 @@ import { eventHasName } from '@carrot-fndn/shared/methodologies/bold/predicates'
 import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/bold/processors';
 import {
   type Document,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
@@ -17,7 +17,7 @@ const {
   DRIVER_IDENTIFIER,
   DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION,
   VEHICLE_TYPE,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 const { PICK_UP } = DocumentEventName;
 const { SLUDGE_PIPES } = DocumentEventVehicleType;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.test-cases.ts
@@ -1,7 +1,7 @@
 import { stubBoldMassIdPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { faker } from '@faker-js/faker';
@@ -12,7 +12,7 @@ const {
   DRIVER_IDENTIFIER,
   DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION,
   VEHICLE_TYPE,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 const { BICYCLE, BOAT, SLUDGE_PIPES, TRUCK } = DocumentEventVehicleType;
 
 const someJustification = faker.lorem.sentence();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.ts
@@ -11,8 +11,8 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
@@ -22,7 +22,7 @@ import {
 
 const { ACTOR, DROP_OFF } = DocumentEventName;
 const { RECYCLER } = MethodologyDocumentEventLabel;
-const { RECEIVING_OPERATOR_IDENTIFIER } = NewDocumentEventAttributeName;
+const { RECEIVING_OPERATOR_IDENTIFIER } = DocumentEventAttributeName;
 
 export const RESULT_COMMENTS = {
   ADDRESS_MISMATCH: `The "${DROP_OFF}" event address does not match the "${RECYCLER}" event address.`,

--- a/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.test-cases.ts
@@ -4,8 +4,8 @@ import {
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -14,7 +14,7 @@ import { RESULT_COMMENTS } from './drop-off-at-recycling-facility.processor';
 
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { ACTOR, DROP_OFF } = DocumentEventName;
-const { RECEIVING_OPERATOR_IDENTIFIER } = NewDocumentEventAttributeName;
+const { RECEIVING_OPERATOR_IDENTIFIER } = DocumentEventAttributeName;
 
 const sameRecyclerAndDropOffAddress = stubAddress();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.helpers.spec.ts
@@ -5,8 +5,8 @@ import {
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
@@ -18,7 +18,7 @@ import {
 
 const { OPEN } = DocumentEventName;
 const { CAPTURED_GPS_LATITUDE, CAPTURED_GPS_LONGITUDE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 
 describe('GeolocationPrecisionHelpers', () => {
   describe('getHomologatedAddressByParticipantId', () => {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.helpers.ts
@@ -5,8 +5,8 @@ import { eventNameIsAnyOf } from '@carrot-fndn/shared/methodologies/bold/predica
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type Geolocation,
@@ -42,11 +42,11 @@ export const getEventGpsGeolocation = (
 ): Geolocation | undefined => {
   const gpsLatitude = getEventAttributeValue(
     event,
-    NewDocumentEventAttributeName.CAPTURED_GPS_LATITUDE,
+    DocumentEventAttributeName.CAPTURED_GPS_LATITUDE,
   );
   const gpsLongitude = getEventAttributeValue(
     event,
-    NewDocumentEventAttributeName.CAPTURED_GPS_LONGITUDE,
+    DocumentEventAttributeName.CAPTURED_GPS_LONGITUDE,
   );
 
   if (is<Latitude>(gpsLatitude) && is<Longitude>(gpsLongitude)) {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.test-cases.ts
@@ -13,9 +13,9 @@ import {
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { faker } from '@faker-js/faker';
@@ -26,7 +26,7 @@ import { RESULT_COMMENTS } from './geolocation-precision.processor';
 const { RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 const { ACTOR, DROP_OFF, OPEN, PICK_UP } = DocumentEventName;
 const { CAPTURED_GPS_LATITUDE, CAPTURED_GPS_LONGITUDE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 
 const actorParticipants = new Map(
   ACTOR_PARTICIPANTS.map((subtype) => [

--- a/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.ts
@@ -12,16 +12,16 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 const { ACTOR, PICK_UP } = DocumentEventName;
 const { HAULER } = MethodologyDocumentEventLabel;
-const { VEHICLE_TYPE } = NewDocumentEventAttributeName;
+const { VEHICLE_TYPE } = DocumentEventAttributeName;
 
 type Subject = {
   haulerEvent: DocumentEvent | undefined;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.test-cases.ts
@@ -3,9 +3,9 @@ import {
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -17,7 +17,7 @@ import {
 
 const { ACTOR, PICK_UP } = DocumentEventName;
 const { HAULER } = MethodologyDocumentEventLabel;
-const { VEHICLE_TYPE } = NewDocumentEventAttributeName;
+const { VEHICLE_TYPE } = DocumentEventAttributeName;
 const { TRUCK } = DocumentEventVehicleType;
 
 export const haulerIdentificationTestCases = [

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts
@@ -10,8 +10,8 @@ import {
 import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/bold/processors';
 import {
   type Document,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
@@ -22,7 +22,7 @@ import {
 import { LocalWasteClassificationProcessorErrors } from './local-waste-classification.errors';
 
 const { LOCAL_WASTE_CLASSIFICATION_DESC, LOCAL_WASTE_CLASSIFICATION_ID } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 const { ACTOR, PICK_UP } = DocumentEventName;
 const { RECYCLER } = MethodologyDocumentEventLabel;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.test-cases.ts
@@ -4,8 +4,8 @@ import {
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -17,7 +17,7 @@ import {
 } from './local-waste-classification.processor';
 
 const { LOCAL_WASTE_CLASSIFICATION_DESC, LOCAL_WASTE_CLASSIFICATION_ID } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 
 const { ACTOR, PICK_UP } = DocumentEventName;
 const { RECYCLER } = MethodologyDocumentEventLabel;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.errors.ts
@@ -1,15 +1,15 @@
 import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
 import {
   DocumentCategory,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { MASS_ID } = DocumentCategory;
 const { SORTING } = DocumentEventName;
-const { SORTING_FACTOR } = NewDocumentEventAttributeName;
+const { SORTING_FACTOR } = DocumentEventAttributeName;
 
 export class MassSortingProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.ts
@@ -24,9 +24,9 @@ import {
 import { eventNameIsAnyOf } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import {
   type Document,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentSubtype,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
@@ -40,7 +40,7 @@ import { type MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared
 import { MassSortingProcessorErrors } from './mass-sorting.errors';
 
 const { SORTING } = DocumentEventName;
-const { DESCRIPTION, SORTING_FACTOR } = NewDocumentEventAttributeName;
+const { DESCRIPTION, SORTING_FACTOR } = DocumentEventAttributeName;
 const SORTING_TOLERANCE = 0.1;
 
 export const RESULT_COMMENTS = {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.test-cases.ts
@@ -9,9 +9,9 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type Document,
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -24,7 +24,7 @@ const processorErrors = new MassSortingProcessorErrors();
 
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { CLOSE, DROP_OFF, OPEN, SORTING } = DocumentEventName;
-const { DESCRIPTION, SORTING_FACTOR } = NewDocumentEventAttributeName;
+const { DESCRIPTION, SORTING_FACTOR } = DocumentEventAttributeName;
 
 const sortingFactor = faker.number.float({ max: 1, min: 0 });
 const valueBeforeSorting = faker.number.float({ min: 1 });

--- a/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.test-cases.ts
@@ -3,9 +3,9 @@ import {
   stubBoldHomologationDocumentCloseEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { formatDate, subDays } from 'date-fns';
@@ -15,8 +15,7 @@ import { RESULT_COMMENTS } from './participant-homologations.processor';
 
 const { HAULER } = MassIdDocumentActorType;
 const { CLOSE } = DocumentEventName;
-const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } =
-  NewDocumentEventAttributeName;
+const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } = DocumentEventAttributeName;
 
 const processorError = new ParticipantHomologationsProcessorErrors();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.errors.ts
@@ -1,12 +1,12 @@
 import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 const { DROP_OFF, PICK_UP } = DocumentEventName;
-const { VEHICLE_LICENSE_PLATE } = NewDocumentEventAttributeName;
+const { VEHICLE_LICENSE_PLATE } = DocumentEventAttributeName;
 const { RECYCLER, WASTE_GENERATOR } = MethodologyDocumentEventLabel;
 
 export class UniquenessCheckProcessorErrors extends BaseProcessorErrors {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.e2e.spec.ts
@@ -9,8 +9,8 @@ import {
   stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type LicensePlate,
@@ -28,7 +28,7 @@ import {
 const { ACTOR } = DocumentEventName;
 const { RECYCLER, WASTE_GENERATOR } = MethodologyDocumentEventLabel;
 const { DROP_OFF, MOVE, OPEN, PICK_UP } = DocumentEventName;
-const { VEHICLE_LICENSE_PLATE } = NewDocumentEventAttributeName;
+const { VEHICLE_LICENSE_PLATE } = DocumentEventAttributeName;
 
 describe('Uniqueness Check Helpers E2E', () => {
   let auditApiService: AuditApiService;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.ts
@@ -5,15 +5,15 @@ import {
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   MethodologyDocumentEventLabel,
   type NonEmptyString,
 } from '@carrot-fndn/shared/types';
 
-const { VEHICLE_LICENSE_PLATE } = NewDocumentEventAttributeName;
+const { VEHICLE_LICENSE_PLATE } = DocumentEventAttributeName;
 const { ACTOR, DROP_OFF, MOVE, OPEN, PICK_UP } = DocumentEventName;
 const { RECYCLER, WASTE_GENERATOR } = MethodologyDocumentEventLabel;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts
@@ -16,9 +16,9 @@ import {
   type Document,
   DocumentCategory,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentStatus,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
@@ -40,7 +40,7 @@ import {
 
 const { ACTOR, DROP_OFF, PICK_UP } = DocumentEventName;
 const { RECYCLER, WASTE_GENERATOR } = MethodologyDocumentEventLabel;
-const { VEHICLE_LICENSE_PLATE } = NewDocumentEventAttributeName;
+const { VEHICLE_LICENSE_PLATE } = DocumentEventAttributeName;
 const { MASS_ID } = DocumentCategory;
 
 export const RESULT_COMMENTS = {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.test-cases.ts
@@ -3,9 +3,9 @@ import {
   stubBoldMassIdPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentStatus,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -16,7 +16,7 @@ import { RESULT_COMMENTS } from './uniqueness-check.processor';
 const { CANCELLED, OPEN } = DocumentStatus;
 const { DROP_OFF, PICK_UP } = DocumentEventName;
 const { RECYCLER, WASTE_GENERATOR } = MethodologyDocumentEventLabel;
-const { VEHICLE_LICENSE_PLATE } = NewDocumentEventAttributeName;
+const { VEHICLE_LICENSE_PLATE } = DocumentEventAttributeName;
 
 export const uniquenessCheckTestCases = [
   {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.ts
@@ -14,15 +14,15 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { is } from 'typia';
 
 const { VEHICLE_DESCRIPTION, VEHICLE_LICENSE_PLATE, VEHICLE_TYPE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 const { BICYCLE, CART, OTHERS, SLUDGE_PIPES } = DocumentEventVehicleType;
 const { PICK_UP } = DocumentEventName;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.test-cases.ts
@@ -2,9 +2,9 @@ import type { LicensePlate } from '@carrot-fndn/shared/types';
 
 import { stubBoldMassIdPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { random } from 'typia';
@@ -15,7 +15,7 @@ import {
 } from './vehicle-identification.processor';
 
 const { VEHICLE_DESCRIPTION, VEHICLE_LICENSE_PLATE, VEHICLE_TYPE } =
-  NewDocumentEventAttributeName;
+  DocumentEventAttributeName;
 const { PICK_UP } = DocumentEventName;
 const { OTHERS, TRUCK } = DocumentEventVehicleType;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.ts
@@ -11,9 +11,9 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventAttributeValue,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
@@ -58,7 +58,7 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
 
     const wasteOrigin = getEventAttributeValue(
       pickUpEvent,
-      NewDocumentEventAttributeName.WASTE_ORIGIN,
+      DocumentEventAttributeName.WASTE_ORIGIN,
     );
     const hasWasteGenerator = !isNil(wasteGeneratorEvents?.[0]);
     const isUnidentified = wasteOrigin === UNIDENTIFIED;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.test-cases.ts
@@ -3,9 +3,9 @@ import {
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventAttributeValue,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -13,7 +13,7 @@ import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 import { RESULT_COMMENT } from './waste-origin-identification.processor';
 
 const { ACTOR, PICK_UP } = DocumentEventName;
-const { WASTE_ORIGIN } = NewDocumentEventAttributeName;
+const { WASTE_ORIGIN } = DocumentEventAttributeName;
 const { UNIDENTIFIED } = DocumentEventAttributeValue;
 const { WASTE_GENERATOR } = MethodologyDocumentEventLabel;
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.constants.ts
@@ -1,9 +1,9 @@
 import {
+  DocumentEventAttributeName,
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
   DocumentEventVehicleType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { MethodologyDocumentEventAttributeFormat } from '@carrot-fndn/shared/types';
 
@@ -21,7 +21,7 @@ const {
   VEHICLE_LICENSE_PLATE,
   VEHICLE_TYPE,
   WEIGHING_CAPTURE_METHOD,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 const { TRUCK } = DocumentEventVehicleType;
 
 export const NET_WEIGHT_CALCULATION_TOLERANCE = 0.1;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.helpers.ts
@@ -13,12 +13,12 @@ import {
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
   DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type MethodologyDocumentEventAttribute,
@@ -48,7 +48,7 @@ const {
   VEHICLE_LICENSE_PLATE,
   VEHICLE_TYPE,
   WEIGHING_CAPTURE_METHOD,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 
 export interface WeighingEventValues {
   containerCapacityAttribute: MethodologyDocumentEventAttribute | undefined;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.ts
@@ -20,9 +20,9 @@ import {
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventWeighingCaptureMethod,
   DocumentSubtype,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
@@ -63,7 +63,7 @@ const {
   SCALE_TYPE,
   VEHICLE_LICENSE_PLATE,
   WEIGHING_CAPTURE_METHOD,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 
 interface RuleSubject {
   recyclerHomologationDocument: Document;

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
@@ -6,13 +6,13 @@ import {
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
   DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventAttributeFormat } from '@carrot-fndn/shared/types';
@@ -40,7 +40,7 @@ const {
   VEHICLE_LICENSE_PLATE,
   VEHICLE_TYPE,
   WEIGHING_CAPTURE_METHOD,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 const { RECYCLER } = MassIdDocumentActorType;
 const { CAR, TRUCK } = DocumentEventVehicleType;
 const { KILOGRAM } = MethodologyDocumentEventAttributeFormat;

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -7,9 +7,9 @@ import {
   stubMassIdDocument,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
@@ -23,7 +23,7 @@ import {
 } from './document.getters';
 
 const { DROP_OFF, OPEN, PICK_UP, RULES_METADATA } = DocumentEventName;
-const { SORTING_FACTOR } = NewDocumentEventAttributeName;
+const { SORTING_FACTOR } = DocumentEventAttributeName;
 const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
 describe('Document getters', () => {

--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -4,9 +4,9 @@ import { isNonEmptyArray } from '@carrot-fndn/shared/helpers';
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { getEventAttributeValue } from './event.getters';
@@ -22,7 +22,7 @@ export const getDocumentEventById = (
 
 export const getFirstDocumentEventAttributeValue = (
   document: Document | undefined,
-  attributeName: NewDocumentEventAttributeName,
+  attributeName: DocumentEventAttributeName,
 ): MethodologyDocumentEventAttributeValue | undefined => {
   if (!document) {
     return undefined;

--- a/libs/shared/methodologies/bold/getters/src/event.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/event.getters.spec.ts
@@ -6,8 +6,8 @@ import {
   stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { validateNonEmptyString } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { faker } from '@faker-js/faker';
@@ -21,7 +21,7 @@ import {
 } from './event.getters';
 
 const { ACTOR } = DocumentEventName;
-const { DESCRIPTION, METHODOLOGY_SLUG } = NewDocumentEventAttributeName;
+const { DESCRIPTION, METHODOLOGY_SLUG } = DocumentEventAttributeName;
 
 describe('Event getters', () => {
   describe('getEventAttributeValue', () => {

--- a/libs/shared/methodologies/bold/getters/src/event.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/event.getters.ts
@@ -8,8 +8,8 @@ import type {
 import { getNonEmptyString } from '@carrot-fndn/shared/helpers';
 import {
   type DocumentEvent,
+  DocumentEventAttributeName,
   type DocumentEventWithAttachments,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { createValidate, validate } from 'typia';
 
@@ -17,7 +17,7 @@ import { validateDocumentEventWithMetadata } from './event.getters.typia';
 
 export const getEventAttributeValue = (
   event: Maybe<DocumentEvent>,
-  attributeName: NewDocumentEventAttributeName | string,
+  attributeName: DocumentEventAttributeName | string,
 ): MethodologyDocumentEventAttributeValue | undefined => {
   const validation = validateDocumentEventWithMetadata(event);
 
@@ -34,7 +34,7 @@ export const getEventAttributeValue = (
 
 export const getEventAttributeByName = (
   event: Maybe<DocumentEvent>,
-  attributeName: NewDocumentEventAttributeName | string,
+  attributeName: DocumentEventAttributeName | string,
 ): MethodologyDocumentEventAttribute | undefined => {
   const validation = validateDocumentEventWithMetadata(event);
 
@@ -49,7 +49,7 @@ export const getEventAttributeByName = (
 
 export const getEventAttributeValueOrThrow = <T>(
   event: Maybe<DocumentEvent>,
-  attributeName: NewDocumentEventAttributeName | string,
+  attributeName: DocumentEventAttributeName | string,
   validateValue: ReturnType<typeof createValidate<T>>,
 ): T => {
   const value = getEventAttributeValue(event, attributeName);
@@ -81,8 +81,5 @@ export const getEventMethodologySlug = (
   event: Maybe<DocumentEvent>,
 ): MethodologyDocumentEventAttributeValue | undefined =>
   getNonEmptyString(
-    getEventAttributeValue(
-      event,
-      NewDocumentEventAttributeName.METHODOLOGY_SLUG,
-    ),
+    getEventAttributeValue(event, DocumentEventAttributeName.METHODOLOGY_SLUG),
   );

--- a/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.spec.ts
@@ -4,8 +4,8 @@ import {
   stubParticipantHomologationDocument,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
@@ -16,8 +16,7 @@ import {
   isHomologationActive,
 } from './homologation-document.helpers';
 
-const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } =
-  NewDocumentEventAttributeName;
+const { HOMOLOGATION_DATE, HOMOLOGATION_DUE_DATE } = DocumentEventAttributeName;
 const { CLOSE } = DocumentEventName;
 
 describe('Homologation Document Helpers', () => {

--- a/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.ts
+++ b/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.ts
@@ -6,8 +6,8 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import {
   type Document,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type NonEmptyString } from '@carrot-fndn/shared/types';
 import { format } from 'date-fns';
@@ -37,11 +37,11 @@ export const isHomologationActive = (document: Document): boolean => {
 
   const homologationDate = getEventAttributeValue(
     closeEvent,
-    NewDocumentEventAttributeName.HOMOLOGATION_DATE,
+    DocumentEventAttributeName.HOMOLOGATION_DATE,
   );
   const homologationDueDate = getEventAttributeValue(
     closeEvent,
-    NewDocumentEventAttributeName.HOMOLOGATION_DUE_DATE,
+    DocumentEventAttributeName.HOMOLOGATION_DUE_DATE,
   );
 
   if (

--- a/libs/shared/methodologies/bold/predicates/src/event.predicate-factories.spec.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicate-factories.spec.ts
@@ -4,8 +4,8 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
@@ -102,7 +102,7 @@ describe('Predicate Factories', () => {
 
   describe('metadataAttributeNameIsAnyOf', () => {
     it('should return true if the event has any of the specified metadata attribute names', () => {
-      const { DESCRIPTION, DOCUMENT_NUMBER } = NewDocumentEventAttributeName;
+      const { DESCRIPTION, DOCUMENT_NUMBER } = DocumentEventAttributeName;
       const event = stubDocumentEventWithMetadataAttributes(undefined, [
         [DESCRIPTION, faker.string.sample()],
       ]);
@@ -114,7 +114,7 @@ describe('Predicate Factories', () => {
 
     it('should return false if the event has none of the specified metadata attribute names', () => {
       const { CONTAINER_TYPE, DESCRIPTION, DOCUMENT_NUMBER } =
-        NewDocumentEventAttributeName;
+        DocumentEventAttributeName;
       const event = stubDocumentEventWithMetadataAttributes(undefined, [
         [DESCRIPTION, faker.string.sample()],
       ]);
@@ -127,7 +127,7 @@ describe('Predicate Factories', () => {
 
   describe('metadataAttributeValueIsAnyOf', () => {
     it('should return true if the metadata attribute has any of the specified values', () => {
-      const { DESCRIPTION } = NewDocumentEventAttributeName;
+      const { DESCRIPTION } = DocumentEventAttributeName;
       const description = faker.string.sample();
       const event = stubDocumentEventWithMetadataAttributes(undefined, [
         [DESCRIPTION, description],
@@ -142,7 +142,7 @@ describe('Predicate Factories', () => {
     });
 
     it('should return false if the metadata attribute has none of the specified values', () => {
-      const { DESCRIPTION } = NewDocumentEventAttributeName;
+      const { DESCRIPTION } = DocumentEventAttributeName;
       const event = stubDocumentEventWithMetadataAttributes(undefined, [
         [DESCRIPTION, faker.string.sample()],
       ]);
@@ -158,7 +158,7 @@ describe('Predicate Factories', () => {
 
   describe('metadataAttributeValueIsNotEmpty', () => {
     it('should return true if the metadata attribute value is not empty', () => {
-      const { DESCRIPTION } = NewDocumentEventAttributeName;
+      const { DESCRIPTION } = DocumentEventAttributeName;
       const event = stubDocumentEventWithMetadataAttributes(undefined, [
         [DESCRIPTION, faker.string.sample()],
       ]);
@@ -167,7 +167,7 @@ describe('Predicate Factories', () => {
     });
 
     it('should return false if the metadata attribute value is empty', () => {
-      const { DESCRIPTION } = NewDocumentEventAttributeName;
+      const { DESCRIPTION } = DocumentEventAttributeName;
       const event = stubDocumentEventWithMetadataAttributes(undefined, [
         [DESCRIPTION, undefined as any], // necessary cast to reuse stub
       ]);

--- a/libs/shared/methodologies/bold/predicates/src/event.predicate-factories.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicate-factories.ts
@@ -2,8 +2,8 @@ import type { UnknownArray } from 'type-fest';
 
 import {
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type NonEmptyString,
@@ -45,7 +45,7 @@ export const eventLabelIsAnyOf =
 
 export const metadataAttributeNameIsAnyOf =
   (
-    metadataNames: Array<NewDocumentEventAttributeName>,
+    metadataNames: Array<DocumentEventAttributeName>,
   ): PredicateCallback<DocumentEvent> =>
   (event) =>
     metadataNames.some((metadataName) =>
@@ -54,7 +54,7 @@ export const metadataAttributeNameIsAnyOf =
 
 export const metadataAttributeValueIsAnyOf =
   (
-    metadataName: NewDocumentEventAttributeName,
+    metadataName: DocumentEventAttributeName,
     metadataValues: UnknownArray,
   ): PredicateCallback<DocumentEvent> =>
   (event) =>
@@ -62,7 +62,7 @@ export const metadataAttributeValueIsAnyOf =
 
 export const metadataAttributeValueIsNotEmpty =
   (
-    metadataName: NewDocumentEventAttributeName,
+    metadataName: DocumentEventAttributeName,
   ): PredicateCallback<DocumentEvent> =>
   (event) =>
     eventHasNonEmptyStringAttribute(event, metadataName);

--- a/libs/shared/methodologies/bold/predicates/src/event.predicates.spec.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicates.spec.ts
@@ -5,9 +5,9 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   MeasurementUnit,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { CARROT_PARTICIPANT_BY_ENVIRONMENT } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { stubArray, stubEnumValue } from '@carrot-fndn/shared/testing';
@@ -148,7 +148,7 @@ describe('Event Predicates', () => {
 
   describe('eventHasNonEmptyStringAttribute', () => {
     it('should return true if the attribute is a non-empty string', () => {
-      const name = stubEnumValue(NewDocumentEventAttributeName);
+      const name = stubEnumValue(DocumentEventAttributeName);
       const attribute = stubDocumentEventAttribute({
         name,
         value: faker.string.sample(),
@@ -163,7 +163,7 @@ describe('Event Predicates', () => {
     });
 
     it('should return false if the attribute is an empty string', () => {
-      const name = stubEnumValue(NewDocumentEventAttributeName);
+      const name = stubEnumValue(DocumentEventAttributeName);
       const attribute = stubDocumentEventAttribute({ name, value: '' });
       const event = stubDocumentEvent({
         metadata: { attributes: [attribute] },
@@ -175,7 +175,7 @@ describe('Event Predicates', () => {
     });
 
     it('should return false if the attribute is not a string', () => {
-      const name = stubEnumValue(NewDocumentEventAttributeName);
+      const name = stubEnumValue(DocumentEventAttributeName);
       const attribute = stubDocumentEventAttribute({
         name,
         value: faker.number.int(),
@@ -190,7 +190,7 @@ describe('Event Predicates', () => {
     });
 
     it('should return false if the event metadata is undefined', () => {
-      const name = stubEnumValue(NewDocumentEventAttributeName);
+      const name = stubEnumValue(DocumentEventAttributeName);
       const event = stubDocumentEvent({
         metadata: undefined,
       });
@@ -229,14 +229,14 @@ describe('Event Predicates', () => {
     it('should return true if the event has the metadata attribute name', () => {
       const event = stubDocumentEventWithMetadata([
         stubDocumentEventAttribute({
-          name: NewDocumentEventAttributeName.WASTE_ORIGIN,
+          name: DocumentEventAttributeName.WASTE_ORIGIN,
           value: faker.string.sample(),
         }),
       ]);
 
       const result = eventHasMetadataAttribute({
         event,
-        metadataName: NewDocumentEventAttributeName.WASTE_ORIGIN,
+        metadataName: DocumentEventAttributeName.WASTE_ORIGIN,
       });
 
       expect(result).toBe(true);
@@ -245,7 +245,7 @@ describe('Event Predicates', () => {
     it('should return false if the event is undefined', () => {
       const result = eventHasMetadataAttribute({
         event: {} as DocumentEvent,
-        metadataName: NewDocumentEventAttributeName.WASTE_ORIGIN,
+        metadataName: DocumentEventAttributeName.WASTE_ORIGIN,
       });
 
       expect(result).toBe(false);
@@ -257,7 +257,7 @@ describe('Event Predicates', () => {
       const result = eventHasMetadataAttribute({
         event,
         eventNames: [DocumentEventName.ACTOR],
-        metadataName: NewDocumentEventAttributeName.WASTE_ORIGIN,
+        metadataName: DocumentEventAttributeName.WASTE_ORIGIN,
       });
 
       expect(result).toBe(false);
@@ -266,14 +266,14 @@ describe('Event Predicates', () => {
     it('should return false if the event metadata name is not equal to the metadata value', () => {
       const event = stubDocumentEventWithMetadata([
         stubDocumentEventAttribute({
-          name: NewDocumentEventAttributeName.WASTE_ORIGIN,
+          name: DocumentEventAttributeName.WASTE_ORIGIN,
           value: faker.string.sample(),
         }),
       ]);
 
       const result = eventHasMetadataAttribute({
         event,
-        metadataName: NewDocumentEventAttributeName.WASTE_ORIGIN,
+        metadataName: DocumentEventAttributeName.WASTE_ORIGIN,
         metadataValues: faker.string.sample(),
       });
 
@@ -285,18 +285,18 @@ describe('Event Predicates', () => {
       const description2 = faker.string.sample();
       const event = stubDocumentEventWithMetadata([
         stubDocumentEventAttribute({
-          name: NewDocumentEventAttributeName.DESCRIPTION,
+          name: DocumentEventAttributeName.DESCRIPTION,
           value: description1,
         }),
         stubDocumentEventAttribute({
-          name: NewDocumentEventAttributeName.DESCRIPTION,
+          name: DocumentEventAttributeName.DESCRIPTION,
           value: description2,
         }),
       ]);
 
       const result = eventHasMetadataAttribute({
         event,
-        metadataName: NewDocumentEventAttributeName.DESCRIPTION,
+        metadataName: DocumentEventAttributeName.DESCRIPTION,
         metadataValues: [description1, description2],
       });
 
@@ -308,7 +308,7 @@ describe('Event Predicates', () => {
       const event = stubDocumentEvent({
         ...stubDocumentEventWithMetadata([
           stubDocumentEventAttribute({
-            name: NewDocumentEventAttributeName.DESCRIPTION,
+            name: DocumentEventAttributeName.DESCRIPTION,
             value: description,
           }),
         ]),
@@ -318,7 +318,7 @@ describe('Event Predicates', () => {
       const result = eventHasMetadataAttribute({
         event,
         eventNames: [DocumentEventName.OPEN, DocumentEventName.MOVE],
-        metadataName: NewDocumentEventAttributeName.DESCRIPTION,
+        metadataName: DocumentEventAttributeName.DESCRIPTION,
         metadataValues: [description],
       });
 
@@ -331,7 +331,7 @@ describe('Event Predicates', () => {
       const events = stubArray(() =>
         stubDocumentEventWithMetadata([
           stubDocumentEventAttribute({
-            name: NewDocumentEventAttributeName.WASTE_ORIGIN,
+            name: DocumentEventAttributeName.WASTE_ORIGIN,
             value: 1234,
           }),
         ]),
@@ -339,7 +339,7 @@ describe('Event Predicates', () => {
 
       const result = eventsHasSameMetadataAttributeValue(
         events,
-        NewDocumentEventAttributeName.WASTE_ORIGIN,
+        DocumentEventAttributeName.WASTE_ORIGIN,
       );
 
       expect(result).toBe(true);
@@ -350,7 +350,7 @@ describe('Event Predicates', () => {
         () =>
           stubDocumentEventWithMetadata([
             stubDocumentEventAttribute({
-              name: NewDocumentEventAttributeName.WASTE_ORIGIN,
+              name: DocumentEventAttributeName.WASTE_ORIGIN,
               value: faker.number.float(),
             }),
           ]),
@@ -359,7 +359,7 @@ describe('Event Predicates', () => {
 
       const result = eventsHasSameMetadataAttributeValue(
         events,
-        NewDocumentEventAttributeName.WASTE_ORIGIN,
+        DocumentEventAttributeName.WASTE_ORIGIN,
       );
 
       expect(result).toBe(false);
@@ -370,7 +370,7 @@ describe('Event Predicates', () => {
 
       const result = eventsHasSameMetadataAttributeValue(
         events,
-        NewDocumentEventAttributeName.WASTE_ORIGIN,
+        DocumentEventAttributeName.WASTE_ORIGIN,
       );
 
       expect(result).toBe(false);

--- a/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
@@ -6,9 +6,9 @@ import {
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   MeasurementUnit,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { CARROT_PARTICIPANT_BY_ENVIRONMENT } from '@carrot-fndn/shared/methodologies/bold/utils';
 import {
@@ -44,7 +44,7 @@ export const eventHasActorParticipant = (event: DocumentEvent): boolean =>
 
 export const eventHasNonEmptyStringAttribute = (
   event: DocumentEvent,
-  attributeName: NewDocumentEventAttributeName,
+  attributeName: DocumentEventAttributeName,
 ): boolean => isNonEmptyString(getEventAttributeValue(event, attributeName));
 
 export const hasWeightFormat = (
@@ -61,7 +61,7 @@ export const hasWeightFormat = (
 
 export const eventsHasSameMetadataAttributeValue = (
   events: Array<DocumentEvent>,
-  metadataName: NewDocumentEventAttributeName,
+  metadataName: DocumentEventAttributeName,
 ): boolean => {
   if (isNonEmptyArray<DocumentEvent>(events)) {
     return events.every(
@@ -77,7 +77,7 @@ export const eventsHasSameMetadataAttributeValue = (
 export const eventHasMetadataAttribute = (options: {
   event: DocumentEvent;
   eventNames?: Array<DocumentEventName>;
-  metadataName: NewDocumentEventAttributeName | string;
+  metadataName: DocumentEventAttributeName | string;
   metadataValues?: unknown;
 }): boolean => {
   const { event, eventNames, metadataName, metadataValues } = options;

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -4,6 +4,7 @@ import {
   DocumentCategory,
   type DocumentEvent,
   DocumentEventAttachmentLabel,
+  DocumentEventAttributeName,
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
@@ -12,7 +13,6 @@ import {
   DocumentType,
   MassSubtype,
   MeasurementUnit,
-  NewDocumentEventAttributeName,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubEnumValue } from '@carrot-fndn/shared/testing';
@@ -78,7 +78,7 @@ const {
   VEHICLE_TYPE,
   WASTE_ORIGIN,
   WEIGHING_CAPTURE_METHOD,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 const { DATE, KILOGRAM } = MethodologyDocumentEventAttributeFormat;
 
 const defaultPickUpAttributes: MetadataAttributeParameter[] = [

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-participant-homologation.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-participant-homologation.stubs.ts
@@ -6,9 +6,9 @@ import type {
 import { isNil } from '@carrot-fndn/shared/helpers';
 import {
   DocumentCategory,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentType,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { faker } from '@faker-js/faker';
 import { addDays, formatDate, subDays } from 'date-fns';
@@ -35,7 +35,7 @@ const {
   PROJECT_EMISSION_CALCULATION_INDEX,
   SCALE_TYPE,
   SORTING_FACTOR,
-} = NewDocumentEventAttributeName;
+} = DocumentEventAttributeName;
 
 const defaultCloseEventMetadataAttributes: MetadataAttributeParameter[] = [
   [HOMOLOGATION_DATE, formatDate(subDays(new Date(), 2), 'yyyy-MM-dd')],

--- a/libs/shared/methodologies/bold/testing/src/builders/bold.builder.helpers.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold.builder.helpers.ts
@@ -5,8 +5,8 @@ import type {
 import type { MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared/types';
 
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 export type MergeEventsMapsParameter =
@@ -52,12 +52,12 @@ export const mergeEventsMaps = <T extends DocumentEventName | string>(
 };
 
 export type MetadataAttributeTupleParameter = [
-  NewDocumentEventAttributeName,
+  DocumentEventAttributeName,
   MethodologyDocumentEventAttributeValue | undefined,
 ];
 
 export type MetadataAttributeTupleResponse = [
-  NewDocumentEventAttributeName,
+  DocumentEventAttributeName,
   MethodologyDocumentEventAttributeValue,
 ];
 

--- a/libs/shared/methodologies/bold/testing/src/stubs/document-event.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/stubs/document-event.stubs.ts
@@ -3,9 +3,9 @@ import type { PartialDeep } from 'type-fest';
 import {
   type DocumentEvent,
   type DocumentEventAttribute,
+  DocumentEventAttributeName,
   DocumentEventName,
   type DocumentReference,
-  NewDocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type AnyObject,
@@ -89,7 +89,7 @@ export const stubDocumentEventWithMetadataAttributes = (
   partialEvent?: PartialDeep<DocumentEvent>,
   attributes?: Array<
     | [
-        NewDocumentEventAttributeName | string,
+        DocumentEventAttributeName | string,
         MethodologyDocumentEventAttributeValue,
       ]
     | Omit<DocumentEventAttribute, 'isPublic'>

--- a/libs/shared/methodologies/bold/types/src/document-event.types.ts
+++ b/libs/shared/methodologies/bold/types/src/document-event.types.ts
@@ -7,15 +7,15 @@ import type {
 
 import type {
   DocumentCategory,
+  DocumentEventAttributeName,
   DocumentEventName,
   DocumentSubtype,
   DocumentType,
-  NewDocumentEventAttributeName,
 } from './enum.types';
 
 export interface DocumentEventAttribute
   extends MethodologyDocumentEventAttribute {
-  name: NewDocumentEventAttributeName | string;
+  name: DocumentEventAttributeName | string;
 }
 
 export interface DocumentEventMetadata

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -72,7 +72,7 @@ export enum DocumentEventRuleSlug {
   REWARDS_DISTRIBUTION = 'rewards-distribution',
 }
 
-export enum NewDocumentEventAttributeName {
+export enum DocumentEventAttributeName {
   CAPTURED_GPS_LATITUDE = 'Captured GPS Latitude',
   CAPTURED_GPS_LONGITUDE = 'Captured GPS Longitude',
   CONTAINER_CAPACITY = 'Container Capacity',

--- a/libs/shared/testing/src/helpers/metadata.helpers.ts
+++ b/libs/shared/testing/src/helpers/metadata.helpers.ts
@@ -2,12 +2,12 @@ import type { MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared
 
 import {
   type DocumentEvent,
-  NewDocumentEventAttributeName,
+  DocumentEventAttributeName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 export const replaceMetadataAttributeValue = (
   documentEvent: DocumentEvent,
-  attributeName: NewDocumentEventAttributeName,
+  attributeName: DocumentEventAttributeName,
   newValue: MethodologyDocumentEventAttributeValue,
 ): DocumentEvent => {
   const attributes = documentEvent.metadata?.attributes?.map((attribute) => {


### PR DESCRIPTION
- **refactor(shared): replace deprecated NewDocumentEventAttributeName with DocumentEventAttributeName**

### Summary

Replace deprecated NewDocumentEventAttributeName with DocumentEventAttributeName

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal document and attribute handling to improve consistency and maintainability.
- **Chore**
  - Removed deprecated modules, tests, and redundancy to simplify the codebase.

These under-the-hood improvements ensure that core functionalities remain unchanged, offering a cleaner and more robust system without impacting your experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->