### PR TITLE
chore: update README files to include direct links to main implementation files

### DIFF
--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/avoided-emissions/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/avoided-emissions/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/composting-cycle-timeframe/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/composting-cycle-timeframe/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/driver-identification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/driver-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/drop-off-at-recycling-facility/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/drop-off-at-recycling-facility/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/geolocation-precision/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/geolocation-precision/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/hauler-identification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/hauler-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/local-waste-classification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/local-waste-classification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/mass-definition/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/mass-definition/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/mass-sorting/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/mass-sorting/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/participant-homologations/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/participant-homologations/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/processor-identification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/processor-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-boundary/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-boundary/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-period/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-period/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-period/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-period/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/audit-eligibility-check/audit-eligibility-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-period/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/project-period/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/audit-eligibility-check/audit-eligibility-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/audit-eligibility-check/audit-eligibility-check.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/recycler-identification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/recycler-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/recycling-manifest/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/recycling-manifest/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/tcc-absence/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/tcc-absence/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/transport-manifest/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/transport-manifest/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/uniqueness-check/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/uniqueness-check/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/vehicle-identification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/vehicle-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/waste-origin-identification/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/waste-origin-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/weighing/README.md
+++ b/apps/methodologies/bold-carbon-organic/rule-processors/mass-id/weighing/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-CARBON-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/composting-cycle-timeframe/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/composting-cycle-timeframe/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/driver-identification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/driver-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/drop-off-at-recycling-facility/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/drop-off-at-recycling-facility/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/geolocation-precision/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/geolocation-precision/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/hauler-identification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/hauler-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/local-waste-classification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/local-waste-classification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/mass-definition/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/mass-definition/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/mass-sorting/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/mass-sorting/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/participant-homologations/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/participant-homologations/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/processor-identification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/processor-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/project-period/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/project-period/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/audit-eligibility-check/audit-eligibility-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/audit-eligibility-check/audit-eligibility-check.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/project-period/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/project-period/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/project-period/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/project-period/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/audit-eligibility-check/audit-eligibility-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/recycler-identification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/recycler-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/recycling-manifest/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/recycling-manifest/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/transport-manifest/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/transport-manifest/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/trc-absence/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/trc-absence/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/uniqueness-check/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/uniqueness-check/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/uniqueness-check/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/uniqueness-check/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/vehicle-identification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/vehicle-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/waste-origin-identification/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/waste-origin-identification/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.ts)**
 
 ## 👥 Contributors
 

--- a/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/weighing/README.md
+++ b/apps/methodologies/bold-recycling-organic/rule-processors/mass-id/weighing/README.md
@@ -14,7 +14,7 @@ Methodology: **BOLD-RECYCLING-ORGANIC**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.ts)**
 
 ## 👥 Contributors
 

--- a/tools/apply-methodology-rule.js
+++ b/tools/apply-methodology-rule.js
@@ -131,7 +131,7 @@ Methodology: **BOLD-${methodologyName.toUpperCase()}**
 
 ## 📂 Implementation
 
-- **[Main Implementation File](libs/methodologies/bold/rule-processors/${scope}/src/${ruleName}/${ruleName}.processor.ts)**
+- **[Main Implementation File](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors/${scope}/src/${ruleName}/${ruleName}.processor.ts)**
 
 ## 👥 Contributors
 


### PR DESCRIPTION
### Summary

Update `Main Implementation File` links to use the `main` link. 

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated all documentation links across multiple modules to use absolute URLs instead of relative paths. This change provides direct access to implementation details in the GitHub repository, improving clarity and ensuring that users can effortlessly navigate to the correct resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->