### PR TITLE
fix(rule): trim whitespace in local waste classification description comparison

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts
@@ -89,7 +89,7 @@ export class LocalWasteClassificationProcessor extends ParentDocumentRuleProcess
         id as keyof typeof WASTE_CLASSIFICATION_IDS.BR
       ].description;
 
-    if (description !== expectedDescription) {
+    if (description.trim() !== expectedDescription.trim()) {
       return this.isRejected(
         RESULT_COMMENTS.INVALID_CLASSIFICATION_DESCRIPTION,
       );


### PR DESCRIPTION
### Summary

_Summarize the suggested changes with this PR._

### Details

_Add more context to describe the changes and screenshots if appropriate._

### Related links

_Insert links related to this change, such as Notion pages, ClickUp tasks, or any other relevant sources._

---

- [ ] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved description matching by ignoring leading and trailing whitespace, reducing false mismatches during classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->