### PR TITLE
refactor(rule): accept IBAMA codes without space

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.constants.ts
@@ -8,7 +8,7 @@ const PAPER_CARDBOARD = 'Papel e cartão';
 const WASHING_CLEANING_SLUDGE = 'Lodos provenientes da lavagem e limpeza';
 const WASTE_FROM_SCREENING = 'Resíduos retirados da fase de gradeamento';
 
-export const WASTE_CLASSIFICATION_IDS = {
+export const WASTE_CLASSIFICATION_CODES = {
   BR: {
     '02 01 01': {
       CDM_CODE: '8.7B',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.spec.ts
@@ -18,7 +18,7 @@ describe('LocalWasteClassificationProcessor', () => {
 
   it.each(localWasteClassificationTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ events, resultComment, resultStatus }) => {
+    async ({ events, resultComment, resultContent, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
@@ -36,6 +36,7 @@ describe('LocalWasteClassificationProcessor', () => {
         responseToken: ruleInput.responseToken,
         responseUrl: ruleInput.responseUrl,
         resultComment,
+        resultContent,
         resultStatus,
       };
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.ts
@@ -15,11 +15,12 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
+  type AnyObject,
   type MethodologyDocumentEventAttributeValue,
   MethodologyDocumentEventLabel,
 } from '@carrot-fndn/shared/types';
 
-import { WASTE_CLASSIFICATION_IDS } from './local-waste-classification.constants';
+import { WASTE_CLASSIFICATION_CODES } from './local-waste-classification.constants';
 import { LocalWasteClassificationProcessorErrors } from './local-waste-classification.errors';
 
 const {
@@ -50,53 +51,71 @@ export class LocalWasteClassificationProcessor extends ParentDocumentRuleProcess
   protected readonly processorErrors =
     new LocalWasteClassificationProcessorErrors();
 
-  private isRejected(resultComment: string): EvaluateResultOutput {
+  private isRejected(
+    resultComment: string,
+    resultContent?: AnyObject,
+  ): EvaluateResultOutput {
     return {
       resultComment,
+      ...(resultContent && { resultContent }),
       resultStatus: RuleOutputStatus.REJECTED,
     };
   }
 
-  protected override evaluateResult({
-    description,
-    id,
-    recyclerCountryCode,
-  }: Subject): EvaluateResultOutput | Promise<EvaluateResultOutput> {
+  protected override evaluateResult(
+    subject: Subject,
+  ): EvaluateResultOutput | Promise<EvaluateResultOutput> {
+    const { description, id, recyclerCountryCode } = subject;
+
     if (recyclerCountryCode !== 'BR') {
       return this.isRejected(
         RESULT_COMMENTS.UNSUPPORTED_COUNTRY(recyclerCountryCode),
+        subject,
       );
     }
 
     if (!isNonEmptyString(id)) {
-      return this.isRejected(RESULT_COMMENTS.CLASSIFICATION_ID_MISSING);
+      return this.isRejected(
+        RESULT_COMMENTS.CLASSIFICATION_ID_MISSING,
+        subject,
+      );
     }
 
     if (!isNonEmptyString(description)) {
       return this.isRejected(
         RESULT_COMMENTS.CLASSIFICATION_DESCRIPTION_MISSING,
+        subject,
       );
     }
 
-    const validClassificationIds = Object.keys(WASTE_CLASSIFICATION_IDS.BR);
+    const validClassificationIds = Object.keys(WASTE_CLASSIFICATION_CODES.BR);
 
-    if (!validClassificationIds.includes(id)) {
-      return this.isRejected(RESULT_COMMENTS.INVALID_CLASSIFICATION_ID);
+    const normalizedId = validClassificationIds.find(
+      (validId) => validId.replaceAll(/\s+/g, '') === id.replaceAll(/\s+/g, ''),
+    );
+
+    if (!normalizedId) {
+      return this.isRejected(
+        RESULT_COMMENTS.INVALID_CLASSIFICATION_ID,
+        subject,
+      );
     }
 
     const expectedDescription =
-      WASTE_CLASSIFICATION_IDS.BR[
-        id as keyof typeof WASTE_CLASSIFICATION_IDS.BR
+      WASTE_CLASSIFICATION_CODES.BR[
+        normalizedId as keyof typeof WASTE_CLASSIFICATION_CODES.BR
       ].description;
 
     if (description.trim() !== expectedDescription.trim()) {
       return this.isRejected(
         RESULT_COMMENTS.INVALID_CLASSIFICATION_DESCRIPTION,
+        subject,
       );
     }
 
     return {
       resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+      resultContent: subject,
       resultStatus: RuleOutputStatus.APPROVED,
     };
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.test-cases.ts
@@ -11,7 +11,7 @@ import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
-import { WASTE_CLASSIFICATION_IDS } from './local-waste-classification.constants';
+import { WASTE_CLASSIFICATION_CODES } from './local-waste-classification.constants';
 import { RESULT_COMMENTS } from './local-waste-classification.processor';
 
 const {
@@ -22,6 +22,8 @@ const {
 const { ACTOR, PICK_UP } = DocumentEventName;
 const { RECYCLER } = MethodologyDocumentEventLabel;
 
+const randomId = faker.lorem.word();
+const randomDescription = faker.lorem.sentence();
 const brazilianRecyclerEvent = stubDocumentEvent({
   address: stubAddress({
     countryCode: 'BR',
@@ -46,12 +48,17 @@ export const localWasteClassificationTestCases = [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [
             LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_IDS.BR['02 01 01'].description,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
           ],
         ],
       }),
     },
     resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+      id: '02 01 01',
+      recyclerCountryCode: 'BR',
+    },
     resultStatus: RuleOutputStatus.APPROVED,
     scenario:
       'the local waste classification ID and description match an IBAMA code.',
@@ -61,15 +68,43 @@ export const localWasteClassificationTestCases = [
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
       [PICK_UP]: stubBoldMassIdPickUpEvent({
         metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '020101'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+          ],
+        ],
+      }),
+    },
+    resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+      id: '020101',
+      recyclerCountryCode: 'BR',
+    },
+    resultStatus: RuleOutputStatus.APPROVED,
+    scenario:
+      'the local waste classification ID and description match the IBAMA code without spaces.',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, undefined],
           [
             LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_IDS.BR['02 01 01'].description,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
           ],
         ],
       }),
     },
     resultComment: RESULT_COMMENTS.CLASSIFICATION_ID_MISSING,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+      id: undefined,
+      recyclerCountryCode: 'BR',
+    },
     resultStatus: RuleOutputStatus.REJECTED,
     scenario: 'the local waste classification ID is missing.',
   },
@@ -84,6 +119,11 @@ export const localWasteClassificationTestCases = [
       }),
     },
     resultComment: RESULT_COMMENTS.CLASSIFICATION_DESCRIPTION_MISSING,
+    resultContent: {
+      description: undefined,
+      id: '02 01 01',
+      recyclerCountryCode: 'BR',
+    },
     resultStatus: RuleOutputStatus.REJECTED,
     scenario: 'the local waste classification description is missing.',
   },
@@ -93,11 +133,16 @@ export const localWasteClassificationTestCases = [
       [PICK_UP]: stubBoldMassIdPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, faker.lorem.sentence()],
+          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
         ],
       }),
     },
     resultComment: RESULT_COMMENTS.INVALID_CLASSIFICATION_DESCRIPTION,
+    resultContent: {
+      description: randomDescription,
+      id: '02 01 01',
+      recyclerCountryCode: 'BR',
+    },
     resultStatus: RuleOutputStatus.REJECTED,
     scenario:
       'the local waste classification description does not match the expected IBAMA code.',
@@ -108,11 +153,16 @@ export const localWasteClassificationTestCases = [
       [PICK_UP]: stubBoldMassIdPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, faker.lorem.sentence()],
+          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
         ],
       }),
     },
     resultComment: RESULT_COMMENTS.UNSUPPORTED_COUNTRY('US'),
+    resultContent: {
+      description: randomDescription,
+      id: '02 01 01',
+      recyclerCountryCode: 'US',
+    },
     resultStatus: RuleOutputStatus.REJECTED,
     scenario: 'the recycler is not from Brazil.',
   },
@@ -121,12 +171,17 @@ export const localWasteClassificationTestCases = [
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
       [PICK_UP]: stubBoldMassIdPickUpEvent({
         metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, faker.lorem.word()],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, faker.lorem.sentence()],
+          [LOCAL_WASTE_CLASSIFICATION_ID, randomId],
+          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
         ],
       }),
     },
     resultComment: RESULT_COMMENTS.INVALID_CLASSIFICATION_ID,
+    resultContent: {
+      description: randomDescription,
+      id: randomId,
+      recyclerCountryCode: 'BR',
+    },
     resultStatus: RuleOutputStatus.REJECTED,
     scenario: 'the local waste classification ID is not valid.',
   },


### PR DESCRIPTION
### Summary

This PR renames the constant `WASTE_CLASSIFICATION_IDS` to `WASTE_CLASSIFICATION_CODES` for better clarity and consistency. Additionally, it updates the logic in the processor and test cases to reflect this change, ensuring that the classification codes are correctly referenced throughout the codebase. The modifications also include enhancements to the test cases by adding `resultContent` to provide more detailed output for validation scenarios.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced validation now accepts classification IDs with or without spaces and provides more detailed feedback in rejection and approval cases.
- **Bug Fixes**
  - Improved consistency in test cases by using predefined random values and ensuring all relevant fields are included in test outputs.
- **Tests**
  - Added new test case for classification IDs without spaces and updated all test cases to include detailed result content.
- **Refactor**
  - Updated naming for classification codes and streamlined method signatures for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->