### PR TITLE
refactor(rule): update event filtering in ParticipantHomologationsProcessor to use eventLabelIsAnyOf

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.processor.ts
@@ -1,5 +1,4 @@
 import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
-import type { NonEmptyString } from '@carrot-fndn/shared/types';
 
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
 import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
@@ -17,7 +16,7 @@ import {
   MASS_ID,
   PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH,
 } from '@carrot-fndn/shared/methodologies/bold/matchers';
-import { isActorEvent } from '@carrot-fndn/shared/methodologies/bold/predicates';
+import { eventLabelIsAnyOf } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
@@ -26,6 +25,10 @@ import {
   type RuleOutput,
   RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
+import {
+  MethodologyDocumentEventLabel,
+  type NonEmptyString,
+} from '@carrot-fndn/shared/types';
 import { assert } from 'typia';
 
 import { ParticipantHomologationsProcessorErrors } from './participant-homologations.errors';
@@ -122,7 +125,14 @@ export class ParticipantHomologationsProcessor extends RuleDataProcessor {
 
     const actorParticipants: Map<string, string> = new Map(
       massIdDocument.externalEvents
-        .filter((event) => isActorEvent(event))
+        .filter(
+          eventLabelIsAnyOf([
+            MethodologyDocumentEventLabel.HAULER,
+            MethodologyDocumentEventLabel.PROCESSOR,
+            MethodologyDocumentEventLabel.RECYCLER,
+            MethodologyDocumentEventLabel.WASTE_GENERATOR,
+          ]),
+        )
         .map((event) => [
           event.participant.id,
           assert<NonEmptyString>(event.label),


### PR DESCRIPTION
### Summary

_Summarize the suggested changes with this PR._

### Details

_Add more context to describe the changes and screenshots if appropriate._

### Related links

_Insert links related to this change, such as Notion pages, ClickUp tasks, or any other relevant sources._

---

- [ ] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved event filtering logic for participant homologation checks to better match specific event labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->