### PR TITLE
refactor(rule): replace MassSubtype with MassIdSubtype and update related tests

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.spec.ts
@@ -1,7 +1,7 @@
 import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { MassSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
+import { MassIdSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleInput,
   type RuleOutput,
@@ -27,14 +27,14 @@ describe('MassDefinitionProcessor', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when subtype is in MassSubtype enum', () => {
-      const validSubtype = stubEnumValue(MassSubtype);
+    it('should return true when subtype is in MassIdSubtype enum', () => {
+      const validSubtype = stubEnumValue(MassIdSubtype);
       const result = ruleDataProcessor['isValidSubtype'](validSubtype);
 
       expect(result).toBe(true);
     });
 
-    it('should return false when subtype is not in MassSubtype enum', () => {
+    it('should return false when subtype is not in MassIdSubtype enum', () => {
       const result = ruleDataProcessor['isValidSubtype'](
         'THIS_IS_DEFINITELY_NOT_IN_MASS_SUBTYPE_ENUM',
       );

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts
@@ -6,14 +6,14 @@ import {
   type Document,
   DocumentCategory,
   DocumentType,
-  MassSubtype,
+  MassIdSubtype,
   MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { MassDefinitionProcessorErrors } from './mass-definition.errors';
 
-const ALLOWED_SUBTYPES: string[] = Object.values(MassSubtype);
+const ALLOWED_SUBTYPES: string[] = Object.values(MassIdSubtype);
 
 const { MASS_ID } = DocumentCategory;
 const { KG } = MeasurementUnit;

--- a/libs/shared/methodologies/bold/matchers/src/document.matchers.spec.ts
+++ b/libs/shared/methodologies/bold/matchers/src/document.matchers.spec.ts
@@ -23,7 +23,7 @@ describe('Document Matchers', () => {
     it('should return true if document has the same values passed in match', () => {
       const documentMatch: DocumentMatch = {
         category: DocumentCategory.MASS_ID,
-        subtype: DocumentSubtype.AGRO_INDUSTRIAL,
+        subtype: DocumentSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         type: DocumentType.ORGANIC,
       };
       const documentReference = stubDocumentReference(documentMatch);
@@ -38,7 +38,7 @@ describe('Document Matchers', () => {
     it('should return false if document has at least one value different from those passed in match', () => {
       const documentMatch: DocumentMatch = {
         category: DocumentCategory.MASS_ID,
-        subtype: DocumentSubtype.AGRO_INDUSTRIAL,
+        subtype: DocumentSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         type: DocumentType.ORGANIC,
       };
       const documentReference = stubDocumentReference(documentMatch);

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -11,7 +11,7 @@ import {
   DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
   DocumentType,
-  MassSubtype,
+  MassIdSubtype,
   MeasurementUnit,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -347,7 +347,7 @@ export const stubBoldMassIdDocument = ({
           ...(partialDocument?.externalEvents ?? []),
         ],
         measurementUnit: MeasurementUnit.KG,
-        subtype: stubEnumValue(MassSubtype),
+        subtype: stubEnumValue(MassIdSubtype),
         type: DocumentType.ORGANIC,
       },
       false,

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -41,7 +41,8 @@ const { ACTOR, DROP_OFF, LINK, OUTPUT, PICK_UP, RELATED } = DocumentEventName;
 const { MASS_ID, METHODOLOGY } = DocumentCategory;
 const { CREDIT, DEFINITION, MASS_ID_AUDIT, ORGANIC, PARTICIPANT_HOMOLOGATION } =
   DocumentType;
-const { FOOD_WASTE, GROUP, PROCESS, TCC, TRC } = DocumentSubtype;
+const { FOOD_FOOD_WASTE_AND_BEVERAGES, GROUP, PROCESS, TCC, TRC } =
+  DocumentSubtype;
 
 export interface BoldStubsBuilderOptions {
   actorParticipants?: Map<string, MethodologyParticipant>;
@@ -242,7 +243,7 @@ export class BoldStubsBuilder {
     return {
       category: MASS_ID,
       documentId: this.massIdDocumentId,
-      subtype: FOOD_WASTE,
+      subtype: FOOD_FOOD_WASTE_AND_BEVERAGES,
       type: ORGANIC,
     };
   }

--- a/libs/shared/methodologies/bold/types/src/document.types.ts
+++ b/libs/shared/methodologies/bold/types/src/document.types.ts
@@ -5,12 +5,12 @@ import type {
   DocumentCategory,
   DocumentSubtype,
   DocumentType,
-  MassSubtype,
+  MassIdSubtype,
 } from './enum.types';
 
 export interface Document extends MethodologyDocument {
   category: DocumentCategory | string;
   externalEvents?: DocumentEvent[] | undefined;
-  subtype?: DocumentSubtype | MassSubtype | string | undefined;
+  subtype?: DocumentSubtype | MassIdSubtype | string | undefined;
   type?: DocumentType | string | undefined;
 }

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -20,27 +20,41 @@ export enum DocumentType {
   RECYCLED_ID = 'RecycledID',
 }
 
-export enum DocumentSubtype {
-  AGRO_INDUSTRIAL = 'Agro-industrial',
-  ANIMAL_MANURE = 'Animal Manure',
-  ANIMAL_WASTE_MANAGEMENT = 'Animal Waste Management',
+export enum MassIdSubtype {
   DOMESTIC_SLUDGE = 'Domestic Sludge',
-  FOOD_WASTE = 'Food Waste',
-  GARDEN_AND_PARK_WASTE = 'Garden and Park Waste',
+  EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = 'EFB similar to Garden, Yard and Park Waste',
+  FOOD_FOOD_WASTE_AND_BEVERAGES = 'Food, Food Waste and Beverages',
+  GARDEN_YARD_AND_PARK_WASTE = 'Garden, Yard and Park Waste',
+  GLASS_PLASTIC_METAL_OTHER_INERT_WASTE = 'Glass, Plastic, Metal, Other Inert Waste',
+  INDUSTRIAL_SLUDGE = 'Industrial Sludge',
+  OTHERS = 'Others',
+  PULP_PAPER_AND_CARDBOARD = 'Pulp, Paper and Cardboard',
+  TEXTILES = 'Textiles',
+  TOBACCO = 'Tobacco',
+  WOOD_AND_WOOD_PRODUCTS = 'Wood and Wood Products',
+}
+
+export enum DocumentSubtype {
+  DOMESTIC_SLUDGE = MassIdSubtype.DOMESTIC_SLUDGE,
+  EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = MassIdSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE,
+  FOOD_FOOD_WASTE_AND_BEVERAGES = MassIdSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+  GARDEN_YARD_AND_PARK_WASTE = MassIdSubtype.GARDEN_YARD_AND_PARK_WASTE,
+  GLASS_PLASTIC_METAL_OTHER_INERT_WASTE = MassIdSubtype.GLASS_PLASTIC_METAL_OTHER_INERT_WASTE,
   GROUP = 'Group',
   HAULER = 'Hauler',
-  INDUSTRIAL_FOOD_WASTE = 'Industrial Food-Waste',
-  INDUSTRIAL_SLUDGE = 'Industrial Sludge',
-  OTHER_NON_DANGEROUS_ORGANICS = 'Other Non-Dangerous Organics',
+  INDUSTRIAL_SLUDGE = MassIdSubtype.INDUSTRIAL_SLUDGE,
+  OTHERS = MassIdSubtype.OTHERS,
   PROCESS = 'Process',
   PROCESSOR = 'Processor',
+  PULP_PAPER_AND_CARDBOARD = MassIdSubtype.PULP_PAPER_AND_CARDBOARD,
   RECYCLER = 'Recycler',
   SOURCE = 'Source',
   TCC = 'TCC',
+  TEXTILES = MassIdSubtype.TEXTILES,
+  TOBACCO = MassIdSubtype.TOBACCO,
   TRC = 'TRC',
   WASTE_GENERATOR = 'Waste Generator',
-  WOOD = 'Wood',
-  WOOD_AND_WOOD_PRODUCTS = 'Wood and Wood Products',
+  WOOD_AND_WOOD_PRODUCTS = MassIdSubtype.WOOD_AND_WOOD_PRODUCTS,
 }
 
 export enum MassIdDocumentActorType {
@@ -48,20 +62,6 @@ export enum MassIdDocumentActorType {
   PROCESSOR = DocumentSubtype.PROCESSOR,
   RECYCLER = DocumentSubtype.RECYCLER,
   WASTE_GENERATOR = DocumentSubtype.WASTE_GENERATOR,
-}
-
-export enum MassSubtype {
-  AGRO_INDUSTRIAL = DocumentSubtype.AGRO_INDUSTRIAL,
-  ANIMAL_MANURE = DocumentSubtype.ANIMAL_MANURE,
-  ANIMAL_WASTE_MANAGEMENT = DocumentSubtype.ANIMAL_WASTE_MANAGEMENT,
-  DOMESTIC_SLUDGE = DocumentSubtype.DOMESTIC_SLUDGE,
-  FOOD_WASTE = DocumentSubtype.FOOD_WASTE,
-  GARDEN_AND_PARK_WASTE = DocumentSubtype.GARDEN_AND_PARK_WASTE,
-  INDUSTRIAL_FOOD_WASTE = DocumentSubtype.INDUSTRIAL_FOOD_WASTE,
-  INDUSTRIAL_SLUDGE = DocumentSubtype.INDUSTRIAL_SLUDGE,
-  OTHER_NON_DANGEROUS_ORGANICS = DocumentSubtype.OTHER_NON_DANGEROUS_ORGANICS,
-  WOOD = DocumentSubtype.WOOD,
-  WOOD_AND_WOOD_PRODUCTS = DocumentSubtype.WOOD_AND_WOOD_PRODUCTS,
 }
 
 export enum MeasurementUnit {


### PR DESCRIPTION
### Summary

- **New Features**
  - Introduced a new enum for waste subtypes, expanding available options for mass identification.

- **Refactor**
  - Updated various components and tests to use the new waste subtype enum, ensuring consistency across the application.
  - Consolidated and streamlined waste subtype definitions for improved clarity and maintainability.

- **Bug Fixes**
  - Corrected subtype references in tests and builders to align with the new subtype structure.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**