### PR TITLE
refactor(shared): unify methodology document creation in mass-id rule processor tests

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.lambda.e2e.spec.ts
@@ -41,7 +41,7 @@ describe('AvoidedEmissionsProcessor E2E', () => {
           },
         })
         .createMassIdAuditDocument()
-        .createMethodologyDocuments()
+        .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.spec.ts
@@ -37,7 +37,7 @@ describe('AvoidedEmissionsProcessor', () => {
             },
           })
           .createMassIdAuditDocument()
-          .createMethodologyDocuments()
+          .createMethodologyDocument()
           .createParticipantHomologationDocuments(homologationDocuments)
           .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.test-cases.ts
@@ -68,7 +68,7 @@ const {
 } = new BoldStubsBuilder()
   .createMassIdDocument()
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.lambda.e2e.spec.ts
@@ -35,10 +35,10 @@ describe('GeolocationPrecisionProcessor E2E', () => {
         massIdAuditDocument,
         massIdDocument,
         participantsHomologationDocuments,
-      } = new BoldStubsBuilder({ actorParticipants })
+      } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
         .createMassIdDocument(massIdDocumentParameters)
         .createMassIdAuditDocument()
-        .createMethodologyDocuments()
+        .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.spec.ts
@@ -29,10 +29,10 @@ describe('GeolocationPrecisionProcessor', () => {
         massIdAuditDocument,
         massIdDocument,
         participantsHomologationDocuments,
-      } = new BoldStubsBuilder({ actorParticipants })
+      } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
         .createMassIdDocument(massIdDocumentParameters)
         .createMassIdAuditDocument()
-        .createMethodologyDocuments()
+        .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.test-cases.ts
@@ -1,9 +1,7 @@
-import type { MethodologyParticipant } from '@carrot-fndn/shared/types';
-
 import { calculateDistance } from '@carrot-fndn/shared/helpers';
 import {
-  ACTOR_PARTICIPANTS,
   BoldStubsBuilder,
+  MASS_ID_ACTOR_PARTICIPANTS,
   type StubBoldDocumentParameters,
   generateNearbyCoordinates,
   stubAddress,
@@ -18,6 +16,7 @@ import {
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import { type MethodologyParticipant } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
 import { GeolocationPrecisionProcessorErrors } from './geolocation-precision.errors';
@@ -29,13 +28,16 @@ const { CAPTURED_GPS_LATITUDE, CAPTURED_GPS_LONGITUDE } =
   DocumentEventAttributeName;
 
 const actorParticipants = new Map(
-  ACTOR_PARTICIPANTS.map((subtype) => [
+  MASS_ID_ACTOR_PARTICIPANTS.map((subtype) => [
     subtype,
     stubParticipant({ id: faker.string.uuid(), type: subtype }),
   ]),
 );
 const actorsCoordinates = new Map(
-  ACTOR_PARTICIPANTS.map((subtype) => [subtype, generateNearbyCoordinates()]),
+  MASS_ID_ACTOR_PARTICIPANTS.map((subtype) => [
+    subtype,
+    generateNearbyCoordinates(),
+  ]),
 );
 
 const recyclerParticipant = actorParticipants.get(
@@ -330,7 +332,7 @@ const {
     },
   })
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.spec.ts
@@ -1,7 +1,7 @@
 import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { MassIdSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
+import { MassIdOrganicSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleInput,
   type RuleOutput,
@@ -27,14 +27,14 @@ describe('MassDefinitionProcessor', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when subtype is in MassIdSubtype enum', () => {
-      const validSubtype = stubEnumValue(MassIdSubtype);
+    it('should return true when subtype is in MassIdOrganicSubtype enum', () => {
+      const validSubtype = stubEnumValue(MassIdOrganicSubtype);
       const result = ruleDataProcessor['isValidSubtype'](validSubtype);
 
       expect(result).toBe(true);
     });
 
-    it('should return false when subtype is not in MassIdSubtype enum', () => {
+    it('should return false when subtype is not in MassIdOrganicSubtype enum', () => {
       const result = ruleDataProcessor['isValidSubtype'](
         'THIS_IS_DEFINITELY_NOT_IN_MASS_SUBTYPE_ENUM',
       );

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.ts
@@ -6,14 +6,14 @@ import {
   type Document,
   DocumentCategory,
   DocumentType,
-  MassIdSubtype,
+  MassIdOrganicSubtype,
   MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { MassDefinitionProcessorErrors } from './mass-definition.errors';
 
-const ALLOWED_SUBTYPES: string[] = Object.values(MassIdSubtype);
+const ALLOWED_SUBTYPES: string[] = Object.values(MassIdOrganicSubtype);
 
 const { MASS_ID } = DocumentCategory;
 const { KG } = MeasurementUnit;
@@ -26,8 +26,8 @@ export const RESULT_COMMENTS = {
     `The document category must be "${MASS_ID}", but "${category}" was provided.`,
   INVALID_MEASUREMENT_UNIT: (measurementUnit: string): string =>
     `The measurement unit must be "${KG}", but "${measurementUnit}" was provided.`,
-  INVALID_SUBTYPE: (subtype: string): string =>
-    `The subtype "${subtype}" is not among the allowed values.`,
+  INVALID_SUBTYPE: (subtype: unknown): string =>
+    `The subtype "${String(subtype)}" is not among the allowed values.`,
   INVALID_TYPE: (type: string): string =>
     `The document type must be "${ORGANIC}", but "${type}" was provided.`,
   INVALID_VALUE: (value: number): string =>
@@ -102,7 +102,7 @@ export class MassDefinitionProcessor extends ParentDocumentRuleProcessor<Documen
         isValid: document.currentValue > 0,
       },
       {
-        errorMessage: this.RESULT_COMMENT.INVALID_SUBTYPE(document.subtype!),
+        errorMessage: this.RESULT_COMMENT.INVALID_SUBTYPE(document.subtype),
         isValid: this.isValidSubtype(document.subtype),
       },
     ];

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.lambda.e2e.spec.ts
@@ -35,10 +35,10 @@ describe('MassSortingProcessor E2E', () => {
         massIdAuditDocument,
         massIdDocument,
         participantsHomologationDocuments,
-      } = new BoldStubsBuilder({ actorParticipants })
+      } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
         .createMassIdDocument({ externalEventsMap: massIdEvents })
         .createMassIdAuditDocument()
-        .createMethodologyDocuments()
+        .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.spec.ts
@@ -30,12 +30,12 @@ describe('MassSortingProcessor', () => {
           massIdAuditDocument,
           massIdDocument,
           participantsHomologationDocuments,
-        } = new BoldStubsBuilder({ actorParticipants })
+        } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
           .createMassIdDocument({
             externalEventsMap: massIdEvents,
           })
           .createMassIdAuditDocument()
-          .createMethodologyDocuments()
+          .createMethodologyDocument()
           .createParticipantHomologationDocuments(homologationDocuments)
           .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.test-cases.ts
@@ -1,6 +1,6 @@
 import {
-  ACTOR_PARTICIPANTS,
   BoldStubsBuilder,
+  MASS_ID_ACTOR_PARTICIPANTS,
   stubBoldEmissionAndCompostingMetricsEvent,
   stubBoldMassIdDropOffEvent,
   stubBoldMassIdSortingEvent,
@@ -37,7 +37,7 @@ const calculatedSortingValue = valueBeforeSorting * sortingFactor;
 const wrongSortingValue = calculatedSortingValue + 0.15;
 
 const actorParticipants = new Map(
-  ACTOR_PARTICIPANTS.map((subtype) => [
+  MASS_ID_ACTOR_PARTICIPANTS.map((subtype) => [
     subtype,
     stubParticipant({ id: faker.string.uuid(), type: subtype }),
   ]),
@@ -159,7 +159,7 @@ const {
     },
   })
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 
@@ -174,7 +174,7 @@ const invalidSortingValue = new BoldStubsBuilder()
     },
   })
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.test-cases.ts
@@ -22,14 +22,14 @@ const processorError = new ParticipantHomologationsProcessorErrors();
 const massIdAuditWithHomologations = new BoldStubsBuilder()
   .createMassIdDocument()
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 
 const massIdWithExpiredHomologation = new BoldStubsBuilder()
   .createMassIdDocument()
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments(
     new Map([
       [

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.lambda.e2e.spec.ts
@@ -39,7 +39,7 @@ describe('WeighingProcessor E2E', () => {
           externalEventsMap: massIdDocumentEvents,
         })
         .createMassIdAuditDocument()
-        .createMethodologyDocuments()
+        .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.spec.ts
@@ -34,7 +34,7 @@ describe('WeighingProcessor', () => {
             externalEventsMap: massIdDocumentEvents,
           })
           .createMassIdAuditDocument()
-          .createMethodologyDocuments()
+          .createMethodologyDocument()
           .createParticipantHomologationDocuments(homologationDocuments)
           .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
@@ -686,7 +686,7 @@ const {
 } = new BoldStubsBuilder()
   .createMassIdDocument()
   .createMassIdAuditDocument()
-  .createMethodologyDocuments()
+  .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -11,7 +11,7 @@ import {
   DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
   DocumentType,
-  MassIdSubtype,
+  MassIdOrganicSubtype,
   MeasurementUnit,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -337,6 +337,7 @@ export const stubBoldMassIdDocument = ({
   return {
     ...stubDocument(
       {
+        subtype: stubEnumValue(MassIdOrganicSubtype),
         ...partialDocument,
         category: MASS_ID,
         currentValue: isNil(partialDocument?.currentValue)
@@ -347,7 +348,6 @@ export const stubBoldMassIdDocument = ({
           ...(partialDocument?.externalEvents ?? []),
         ],
         measurementUnit: MeasurementUnit.KG,
-        subtype: stubEnumValue(MassIdSubtype),
         type: DocumentType.ORGANIC,
       },
       false,

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-methodology-definition.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-methodology-definition.stubs.ts
@@ -1,0 +1,36 @@
+import { isNil } from '@carrot-fndn/shared/helpers';
+import {
+  type Document,
+  DocumentCategory,
+  DocumentType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import { stubDocument } from '../stubs';
+import { mergeEventsMaps } from './bold.builder.helpers';
+import { type StubBoldDocumentParameters } from './bold.stubs.types';
+
+const { METHODOLOGY } = DocumentCategory;
+
+export const stubBoldMethodologyDefinitionDocument = ({
+  externalEventsMap,
+  partialDocument,
+}: StubBoldDocumentParameters = {}): Document => {
+  const mergedEventsMap = isNil(externalEventsMap)
+    ? new Map()
+    : mergeEventsMaps(new Map(), externalEventsMap);
+
+  return {
+    ...stubDocument(
+      {
+        ...partialDocument,
+        category: METHODOLOGY,
+        externalEvents: [
+          ...mergedEventsMap.values(),
+          ...(partialDocument?.externalEvents ?? []),
+        ],
+        type: DocumentType.DEFINITION,
+      },
+      false,
+    ),
+  };
+};

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -54,11 +54,11 @@ export interface BoldStubsBuilderResult {
   creditDocuments: Document[];
   creditDocumentsStubs: Document[];
   massIdActorParticipants: Map<string, MethodologyParticipant>;
+  massIdActorParticipantsAddresses: Map<string, MethodologyAddress>;
   massIdAuditDocument: Document;
   massIdAuditId: string;
   massIdDocument: Document;
   massIdDocumentId: string;
-  massIdactorParticipantsAddresses: Map<string, MethodologyAddress>;
   methodologyActorParticipants: Map<string, MethodologyParticipant>;
   methodologyDocument: Document | undefined;
   participantsHomologationDocuments: Map<string, Document>;
@@ -398,11 +398,11 @@ export class BoldStubsBuilder {
       creditDocuments: this.creditDocuments,
       creditDocumentsStubs: this.creditDocumentsStubs,
       massIdActorParticipants: this.massIdActorParticipants,
+      massIdActorParticipantsAddresses: this.massIdActorParticipantsAddresses,
       massIdAuditDocument: this.massIdAuditDocument,
       massIdAuditId: this.massIdAuditDocumentId,
       massIdDocument: this.massIdDocument,
       massIdDocumentId: this.massIdDocumentId,
-      massIdactorParticipantsAddresses: this.massIdActorParticipantsAddresses,
       methodologyActorParticipants: this.methodologyActorParticipants,
       methodologyDocument: this.methodologyDocument,
       participantsHomologationDocuments: this.participantsHomologationDocuments,

--- a/libs/shared/methodologies/bold/testing/src/builders/index.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/index.ts
@@ -4,3 +4,4 @@ export * from './bold-mass-id-audit.stubs';
 export * from './bold-participant-homologation.stubs';
 export * from './bold.builder.helpers';
 export * from './bold.stubs.types';
+export * from './bold-methodology-definition.stubs';

--- a/libs/shared/methodologies/bold/types/src/document.types.ts
+++ b/libs/shared/methodologies/bold/types/src/document.types.ts
@@ -5,12 +5,12 @@ import type {
   DocumentCategory,
   DocumentSubtype,
   DocumentType,
-  MassIdSubtype,
+  MassIdOrganicSubtype,
 } from './enum.types';
 
 export interface Document extends MethodologyDocument {
   category: DocumentCategory | string;
   externalEvents?: DocumentEvent[] | undefined;
-  subtype?: DocumentSubtype | MassIdSubtype | string | undefined;
+  subtype?: DocumentSubtype | MassIdOrganicSubtype | string | undefined;
   type?: DocumentType | string | undefined;
 }

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -1,4 +1,7 @@
-import { MethodologyDocumentEventName } from '@carrot-fndn/shared/types';
+import {
+  MethodologyActorType,
+  MethodologyDocumentEventName,
+} from '@carrot-fndn/shared/types';
 
 export enum DocumentCategory {
   MASS_ID = 'MassID',
@@ -20,48 +23,51 @@ export enum DocumentType {
   RECYCLED_ID = 'RecycledID',
 }
 
-export enum MassIdSubtype {
+export enum MassIdOrganicSubtype {
   DOMESTIC_SLUDGE = 'Domestic Sludge',
   EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = 'EFB similar to Garden, Yard and Park Waste',
   FOOD_FOOD_WASTE_AND_BEVERAGES = 'Food, Food Waste and Beverages',
   GARDEN_YARD_AND_PARK_WASTE = 'Garden, Yard and Park Waste',
-  GLASS_PLASTIC_METAL_OTHER_INERT_WASTE = 'Glass, Plastic, Metal, Other Inert Waste',
   INDUSTRIAL_SLUDGE = 'Industrial Sludge',
-  OTHERS = 'Others',
   PULP_PAPER_AND_CARDBOARD = 'Pulp, Paper and Cardboard',
-  TEXTILES = 'Textiles',
   TOBACCO = 'Tobacco',
   WOOD_AND_WOOD_PRODUCTS = 'Wood and Wood Products',
 }
 
 export enum DocumentSubtype {
-  DOMESTIC_SLUDGE = MassIdSubtype.DOMESTIC_SLUDGE,
-  EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = MassIdSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE,
-  FOOD_FOOD_WASTE_AND_BEVERAGES = MassIdSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-  GARDEN_YARD_AND_PARK_WASTE = MassIdSubtype.GARDEN_YARD_AND_PARK_WASTE,
-  GLASS_PLASTIC_METAL_OTHER_INERT_WASTE = MassIdSubtype.GLASS_PLASTIC_METAL_OTHER_INERT_WASTE,
+  DOMESTIC_SLUDGE = MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+  EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = MassIdOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE,
+  FOOD_FOOD_WASTE_AND_BEVERAGES = MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+  GARDEN_YARD_AND_PARK_WASTE = MassIdOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE,
   GROUP = 'Group',
-  HAULER = 'Hauler',
-  INDUSTRIAL_SLUDGE = MassIdSubtype.INDUSTRIAL_SLUDGE,
-  OTHERS = MassIdSubtype.OTHERS,
+  HAULER = MethodologyActorType.HAULER,
+  INDUSTRIAL_SLUDGE = MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+  INTEGRATOR = MethodologyActorType.INTEGRATOR,
   PROCESS = 'Process',
-  PROCESSOR = 'Processor',
-  PULP_PAPER_AND_CARDBOARD = MassIdSubtype.PULP_PAPER_AND_CARDBOARD,
-  RECYCLER = 'Recycler',
+  PROCESSOR = MethodologyActorType.PROCESSOR,
+  PULP_PAPER_AND_CARDBOARD = MassIdOrganicSubtype.PULP_PAPER_AND_CARDBOARD,
+  RECYCLER = MethodologyActorType.RECYCLER,
   SOURCE = 'Source',
   TCC = 'TCC',
-  TEXTILES = MassIdSubtype.TEXTILES,
-  TOBACCO = MassIdSubtype.TOBACCO,
+  TOBACCO = MassIdOrganicSubtype.TOBACCO,
   TRC = 'TRC',
-  WASTE_GENERATOR = 'Waste Generator',
-  WOOD_AND_WOOD_PRODUCTS = MassIdSubtype.WOOD_AND_WOOD_PRODUCTS,
+  WASTE_GENERATOR = MethodologyActorType.WASTE_GENERATOR,
+  WOOD_AND_WOOD_PRODUCTS = MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
 }
 
 export enum MassIdDocumentActorType {
-  HAULER = DocumentSubtype.HAULER,
-  PROCESSOR = DocumentSubtype.PROCESSOR,
-  RECYCLER = DocumentSubtype.RECYCLER,
-  WASTE_GENERATOR = DocumentSubtype.WASTE_GENERATOR,
+  HAULER = MethodologyActorType.HAULER,
+  INTEGRATOR = MethodologyActorType.INTEGRATOR,
+  PROCESSOR = MethodologyActorType.PROCESSOR,
+  RECYCLER = MethodologyActorType.RECYCLER,
+  WASTE_GENERATOR = MethodologyActorType.WASTE_GENERATOR,
+}
+
+export enum MethodologyDocumentActorType {
+  APPOINTED_NGO = MethodologyActorType.APPOINTED_NGO,
+  METHODOLOGY_AUTHOR = MethodologyActorType.METHODOLOGY_AUTHOR,
+  METHODOLOGY_DEVELOPER = MethodologyActorType.METHODOLOGY_DEVELOPER,
+  NETWORK = MethodologyActorType.NETWORK,
 }
 
 export enum MeasurementUnit {

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -8,11 +8,34 @@ export enum MethodologyParticipantType {
   ACTOR = 'ACTOR',
 }
 
-export enum MethodologyDocumentEventLabel {
+export enum MethodologyActorType {
+  APPOINTED_NGO = 'Appointed NGO',
+  AUDITOR = 'Auditor',
   HAULER = 'Hauler',
+  INTEGRATOR = 'Integrator',
+  METHODOLOGY_AUTHOR = 'Methodology Author',
+  METHODOLOGY_DEVELOPER = 'Methodology Developer',
+  NETWORK = 'Network',
   PROCESSOR = 'Processor',
   RECYCLER = 'Recycler',
+  REMAINDER = 'Remainder',
+  SOURCE = 'Source',
   WASTE_GENERATOR = 'Waste Generator',
+}
+
+export enum MethodologyDocumentEventLabel {
+  APPOINTED_NGO = MethodologyActorType.APPOINTED_NGO,
+  AUDITOR = MethodologyActorType.AUDITOR,
+  HAULER = MethodologyActorType.HAULER,
+  INTEGRATOR = MethodologyActorType.INTEGRATOR,
+  METHODOLOGY_AUTHOR = MethodologyActorType.METHODOLOGY_AUTHOR,
+  METHODOLOGY_DEVELOPER = MethodologyActorType.METHODOLOGY_DEVELOPER,
+  NETWORK = MethodologyActorType.NETWORK,
+  PROCESSOR = MethodologyActorType.PROCESSOR,
+  RECYCLER = MethodologyActorType.RECYCLER,
+  REMAINDER = MethodologyActorType.REMAINDER,
+  SOURCE = MethodologyActorType.SOURCE,
+  WASTE_GENERATOR = MethodologyActorType.WASTE_GENERATOR,
 }
 
 export enum MethodologyApprovedExceptionType {
@@ -38,7 +61,7 @@ export enum MethodologyDocumentEventName {
   RULES_METADATA = 'RULES METADATA',
   SORTING = 'Sorting',
   TRANSPORT_MANIFEST = 'Transport Manifest',
-  WASTE_GENERATOR = 'Waste Generator',
+  WASTE_GENERATOR = MethodologyActorType.WASTE_GENERATOR,
   WEIGHING = 'Weighing',
 }
 


### PR DESCRIPTION
### Summary

This change refactors the handling of actor participants and methodology document stubs in the BOLD methodology codebase. The `BoldStubsBuilder` class is updated to distinguish between mass ID and methodology actor participants, introducing new constants and methods for each group. The method for creating methodology documents is renamed from `.createMethodologyDocuments()` to `.createMethodologyDocument()`, with all related test setups and stub creation logic updated accordingly. Enum types are revised to clarify actor roles and document subtypes, and a new stub builder for methodology definition documents is added. Test files and supporting types are updated to align with these structural changes.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**