### PR TITLE
fix: remove field Vehicle Type from weighing rule

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.constants.ts
@@ -18,7 +18,6 @@ const {
   SCALE_TYPE,
   TARE,
   VEHICLE_LICENSE_PLATE,
-  VEHICLE_TYPE,
   WEIGHING_CAPTURE_METHOD,
 } = DocumentEventAttributeName;
 const { TRUCK } = DocumentEventVehicleType;
@@ -39,7 +38,7 @@ export const APPROVED_RESULT_COMMENTS = {
 
 export const INVALID_RESULT_COMMENTS = {
   CONTAINER_CAPACITY_FORMAT: `The "${CONTAINER_CAPACITY}" format must be one of the supported formats: ${supportedFormats}.`,
-  CONTAINER_QUANTITY: `The "${CONTAINER_QUANTITY}" must not be declared when the "${VEHICLE_TYPE}" is "${TRUCK}".`,
+  CONTAINER_QUANTITY: `The "${CONTAINER_QUANTITY}" must not be declared when the "${CONTAINER_TYPE}" is "${TRUCK}".`,
   GROSS_WEIGHT_FORMAT: `The "${GROSS_WEIGHT}" format must be one of the supported formats: ${supportedFormats}.`,
   NET_WEIGHT_CALCULATION: ({
     calculatedNetWeight,
@@ -84,7 +83,7 @@ export const INVALID_RESULT_COMMENTS = {
 
 export const WRONG_FORMAT_RESULT_COMMENTS = {
   CONTAINER_CAPACITY: `The "${CONTAINER_CAPACITY}" must be greater than 0.`,
-  CONTAINER_QUANTITY: `The "${CONTAINER_QUANTITY}" must be greater than 0 unless the "${VEHICLE_TYPE}" is "${TRUCK}".`,
+  CONTAINER_QUANTITY: `The "${CONTAINER_QUANTITY}" must be greater than 0 unless the "${CONTAINER_TYPE}" is "${TRUCK}".`,
   CONTAINER_TYPE: `The "${CONTAINER_TYPE}" must be provided.`,
   DESCRIPTION: `The "${WEIGHING}" event must have a "${DESCRIPTION}", but none was provided.`,
   EVENT_VALUE: (eventValue: unknown) =>

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.helpers.ts
@@ -18,7 +18,6 @@ import {
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
-  DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -39,7 +38,6 @@ import { isApprovedExceptionAttributeValue } from './weighing.typia';
 
 const { HOMOLOGATION_RESULT, MONITORING_SYSTEMS_AND_EQUIPMENT, WEIGHING } =
   DocumentEventName;
-const { TRUCK } = DocumentEventVehicleType;
 const {
   APPROVED_EXCEPTIONS,
   CONTAINER_CAPACITY,
@@ -50,7 +48,6 @@ const {
   SCALE_TYPE,
   TARE,
   VEHICLE_LICENSE_PLATE,
-  VEHICLE_TYPE,
   WEIGHING_CAPTURE_METHOD,
 } = DocumentEventAttributeName;
 
@@ -66,7 +63,6 @@ export interface WeighingValues {
   scaleType: MethodologyDocumentEventAttributeValue | undefined;
   tare: MethodologyDocumentEventAttribute | undefined;
   vehicleLicensePlateAttribute: MethodologyDocumentEventAttribute | undefined;
-  vehicleType: MethodologyDocumentEventAttributeValue | undefined;
   weighingCaptureMethod: string | undefined;
 }
 
@@ -148,7 +144,6 @@ export const getValuesRelatedToWeighing = (
     weighingEvent,
     VEHICLE_LICENSE_PLATE,
   ),
-  vehicleType: getEventAttributeValue(weighingEvent, VEHICLE_TYPE),
   weighingCaptureMethod: getEventAttributeValue(
     weighingEvent,
     WEIGHING_CAPTURE_METHOD,
@@ -189,7 +184,7 @@ const validators: Record<string, Validator> = {
 
   containerQuantity: (values) => {
     const errors: string[] = [];
-    const isTruck = values.vehicleType === TRUCK;
+    const isTruck = values.containerType === DocumentEventContainerType.TRUCK;
 
     if (isTruck && isNonZeroPositiveInt(values.containerQuantity)) {
       errors.push(INVALID_RESULT_COMMENTS.CONTAINER_QUANTITY);

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
@@ -12,7 +12,6 @@ import {
   DocumentEventContainerType,
   DocumentEventName,
   DocumentEventScaleType,
-  DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -44,11 +43,9 @@ const {
   SCALE_TYPE,
   TARE,
   VEHICLE_LICENSE_PLATE,
-  VEHICLE_TYPE,
   WEIGHING_CAPTURE_METHOD,
 } = DocumentEventAttributeName;
 const { RECYCLER } = MassIdDocumentActorType;
-const { CAR, TRUCK } = DocumentEventVehicleType;
 const { KILOGRAM } = MethodologyDocumentEventAttributeFormat;
 
 const scaleType = random<DocumentEventScaleType>();
@@ -107,6 +104,22 @@ const validWeighingAttributes: MetadataAttributeParameter[] = [
   [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
   [SCALE_TYPE, scaleType],
   [CONTAINER_QUANTITY, 1],
+  {
+    format: KILOGRAM,
+    name: GROSS_WEIGHT,
+    value: 100,
+  },
+  {
+    format: KILOGRAM,
+    name: TARE,
+    value: 1,
+  },
+];
+
+const validWeighingAttributesWithoutQuantity: MetadataAttributeParameter[] = [
+  [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
+  [SCALE_TYPE, scaleType],
+  [CONTAINER_QUANTITY, undefined],
   {
     format: KILOGRAM,
     name: GROSS_WEIGHT,
@@ -183,7 +196,7 @@ export const weighingTestCases = [
     massIdDocumentEvents: {
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          [VEHICLE_TYPE, CAR],
+          [CONTAINER_TYPE, DocumentEventContainerType.BAG],
           ...validWeighingAttributes,
           [CONTAINER_QUANTITY, undefined],
         ],
@@ -194,7 +207,7 @@ export const weighingTestCases = [
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_QUANTITY,
     resultStatus: RuleOutputStatus.REJECTED,
-    scenario: `the ${CONTAINER_QUANTITY} attribute is missing and the ${VEHICLE_TYPE} is ${TRUCK}`,
+    scenario: `the ${CONTAINER_QUANTITY} attribute is missing and the ${CONTAINER_TYPE} is ${DocumentEventContainerType.BAG}`,
   },
   {
     homologationDocuments: new Map([
@@ -209,7 +222,10 @@ export const weighingTestCases = [
     ]),
     massIdDocumentEvents: {
       [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [[VEHICLE_TYPE, CAR], ...validWeighingAttributes],
+        metadataAttributes: [
+          [CONTAINER_TYPE, DocumentEventContainerType.BAG],
+          ...validWeighingAttributes,
+        ],
         partialDocumentEvent: {
           value: eventValue,
         },
@@ -225,7 +241,7 @@ export const weighingTestCases = [
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
           [CONTAINER_QUANTITY, 1],
-          [VEHICLE_TYPE, TRUCK],
+          [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
           ...validWeighingAttributes,
         ],
         partialDocumentEvent: {
@@ -235,7 +251,7 @@ export const weighingTestCases = [
     },
     resultComment: INVALID_RESULT_COMMENTS.CONTAINER_QUANTITY,
     resultStatus: RuleOutputStatus.REJECTED,
-    scenario: `the ${CONTAINER_QUANTITY} attribute is defined, but the ${VEHICLE_TYPE} is ${TRUCK}`,
+    scenario: `the ${CONTAINER_QUANTITY} attribute is defined, but the ${CONTAINER_TYPE} is ${DocumentEventContainerType.TRUCK}`,
   },
   {
     homologationDocuments: stubBaseHomologationDocuments(),
@@ -430,7 +446,7 @@ export const weighingTestCases = [
     massIdDocumentEvents: {
       [`${WEIGHING}-2`]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],
@@ -440,7 +456,7 @@ export const weighingTestCases = [
       }),
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],
@@ -462,7 +478,7 @@ export const weighingTestCases = [
     massIdDocumentEvents: {
       [`${WEIGHING}-2`]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
           [CONTAINER_CAPACITY, undefined],
@@ -474,7 +490,7 @@ export const weighingTestCases = [
       }),
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
           [CONTAINER_CAPACITY, undefined],
@@ -498,7 +514,7 @@ export const weighingTestCases = [
     massIdDocumentEvents: {
       [`${WEIGHING}-2`]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],
@@ -509,7 +525,7 @@ export const weighingTestCases = [
       }),
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],
@@ -530,7 +546,7 @@ export const weighingTestCases = [
     massIdDocumentEvents: {
       [`${WEIGHING}-2`]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],
@@ -541,7 +557,7 @@ export const weighingTestCases = [
       }),
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, twoStepScaleType],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
           {
@@ -571,7 +587,7 @@ export const weighingTestCases = [
     massIdDocumentEvents: {
       [`${WEIGHING}-2`]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, DocumentEventScaleType.CONVEYOR_BELT_SCALE],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],
@@ -582,7 +598,7 @@ export const weighingTestCases = [
       }),
       [WEIGHING]: stubBoldMassIdWeighingEvent({
         metadataAttributes: [
-          ...validWeighingAttributes,
+          ...validWeighingAttributesWithoutQuantity,
           [SCALE_TYPE, DocumentEventScaleType.CONVEYOR_BELT_SCALE],
           [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
         ],

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -161,7 +161,14 @@ const defaultWeighingAttributes: MetadataAttributeParameter[] = [
   [WEIGHING_CAPTURE_METHOD, random<DocumentEventWeighingCaptureMethod>()],
   [SCALE_TYPE, random<DocumentEventScaleType>()],
   [SCALE_HOMOLOGATION, random<MethodologyDocumentEventAttributeReference>()],
-  [CONTAINER_TYPE, random<DocumentEventContainerType>()],
+  [
+    CONTAINER_TYPE,
+    faker.helpers.arrayElement(
+      Object.values(DocumentEventContainerType).filter(
+        (type) => type !== DocumentEventContainerType.TRUCK,
+      ),
+    ),
+  ],
   [CONTAINER_QUANTITY, faker.number.int({ min: 1 })],
   {
     format: KILOGRAM,


### PR DESCRIPTION
### Summary

Remove field Vehicle Type from weighing rule

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated validation and test logic to use container type instead of vehicle type for weighing events, ensuring more accurate handling of truck-related scenarios.
	- Improved error messages to reference container type rather than vehicle type.
	- Test cases now explicitly handle scenarios with missing container quantity and align with container types.

- **Chores**
	- Adjusted test data generation to exclude trucks from randomly assigned container types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->