### PR TITLE
chore/update bold builder

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.lambda.e2e.spec.ts
@@ -35,12 +35,12 @@ describe('AvoidedEmissionsProcessor E2E', () => {
         massIdDocument,
         participantsHomologationDocuments,
       } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           partialDocument: {
             currentValue: massIdDocumentValue as number,
           },
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.processor.spec.ts
@@ -31,12 +31,12 @@ describe('AvoidedEmissionsProcessor', () => {
           massIdDocument,
           participantsHomologationDocuments,
         } = new BoldStubsBuilder()
-          .createMassIdDocument({
+          .createMassIdDocuments({
             partialDocument: {
               currentValue: massIdDocumentValue as number,
             },
           })
-          .createMassIdAuditDocument()
+          .createMassIdAuditDocuments()
           .createMethodologyDocument()
           .createParticipantHomologationDocuments(homologationDocuments)
           .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/avoided-emissions/avoided-emissions.test-cases.ts
@@ -66,8 +66,8 @@ const {
   massIdDocument,
   participantsHomologationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocument()
-  .createMassIdAuditDocument()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.lambda.e2e.spec.ts
@@ -53,10 +53,10 @@ describe('CompostingCycleTimeframeProcessor E2E', () => {
       }
 
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: externalEvents,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/credit-absence/credit-absence.processor.spec.ts
@@ -16,10 +16,9 @@ describe('CreditAbsenceProcessor', () => {
   it.each(creditAbsenceTestCases)(
     'should return $resultStatus when $scenario',
     async ({ documents, massIdAuditDocument, resultComment, resultStatus }) => {
-      spyOnDocumentQueryServiceLoad(stubDocument(), [
-        ...documents,
-        massIdAuditDocument,
-      ]);
+      const allDocuments = [...documents, massIdAuditDocument];
+
+      spyOnDocumentQueryServiceLoad(stubDocument(), allDocuments);
 
       const ruleInput = {
         ...random<Required<RuleInput>>(),

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.lambda.e2e.spec.ts
@@ -24,10 +24,10 @@ describe('DocumentManifestLambda E2E', () => {
       const lambda = documentManifestLambda(documentManifestType);
 
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.spec.ts
@@ -27,7 +27,7 @@ describe('DocumentManifestProcessor', () => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.lambda.e2e.spec.ts
@@ -22,12 +22,12 @@ describe('DriverIdentificationLambda E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ pickUpEvent, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: {
             [PICK_UP]: pickUpEvent,
           },
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.spec.ts
@@ -25,7 +25,7 @@ describe('DriverIdentificationProcessor', () => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: {
             [PICK_UP]: pickUpEvent,
           },

--- a/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('DropOffAtRecyclingFacilityLambda E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.spec.ts
@@ -20,7 +20,7 @@ describe('DropOffAtRecyclingFacilityProcessor', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.lambda.e2e.spec.ts
@@ -36,8 +36,8 @@ describe('GeolocationPrecisionProcessor E2E', () => {
         massIdDocument,
         participantsHomologationDocuments,
       } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-        .createMassIdDocument(massIdDocumentParameters)
-        .createMassIdAuditDocument()
+        .createMassIdDocuments(massIdDocumentParameters)
+        .createMassIdAuditDocuments()
         .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.processor.spec.ts
@@ -30,8 +30,8 @@ describe('GeolocationPrecisionProcessor', () => {
         massIdDocument,
         participantsHomologationDocuments,
       } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-        .createMassIdDocument(massIdDocumentParameters)
-        .createMassIdAuditDocument()
+        .createMassIdDocuments(massIdDocumentParameters)
+        .createMassIdAuditDocuments()
         .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/geolocation-precision/geolocation-precision.test-cases.ts
@@ -325,13 +325,13 @@ const {
   massIdDocument,
   participantsHomologationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocument({
+  .createMassIdDocuments({
     externalEventsMap: {
       [DROP_OFF]: undefined,
       [PICK_UP]: undefined,
     },
   })
-  .createMassIdAuditDocument()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.lambda.e2e.spec.ts
@@ -23,10 +23,10 @@ describe('HaulerIdentificationProcessor E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const massId = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('LocalWasteClassificationLambda E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.spec.ts
@@ -22,7 +22,7 @@ describe('LocalWasteClassificationProcessor', () => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.lambda.e2e.spec.ts
@@ -16,8 +16,8 @@ describe('MassDefinitionLambda E2E', () => {
   const documentKeyPrefix = faker.string.uuid();
 
   const massId = new BoldStubsBuilder()
-    .createMassIdDocument()
-    .createMassIdAuditDocument()
+    .createMassIdDocuments()
+    .createMassIdAuditDocuments()
     .build();
 
   it.each(massDefinitionTestCases)(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.test-cases.ts
@@ -5,8 +5,8 @@ import { MassDefinitionProcessorErrors } from './mass-definition.errors';
 import { RESULT_COMMENTS } from './mass-definition.processor';
 
 const massIdStubs = new BoldStubsBuilder()
-  .createMassIdDocument()
-  .createMassIdAuditDocument()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
   .build();
 const processorErrors = new MassDefinitionProcessorErrors();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.lambda.e2e.spec.ts
@@ -36,8 +36,8 @@ describe('MassSortingProcessor E2E', () => {
         massIdDocument,
         participantsHomologationDocuments,
       } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-        .createMassIdDocument({ externalEventsMap: massIdEvents })
-        .createMassIdAuditDocument()
+        .createMassIdDocuments({ externalEventsMap: massIdEvents })
+        .createMassIdAuditDocuments()
         .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.processor.spec.ts
@@ -31,10 +31,10 @@ describe('MassSortingProcessor', () => {
           massIdDocument,
           participantsHomologationDocuments,
         } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-          .createMassIdDocument({
+          .createMassIdDocuments({
             externalEventsMap: massIdEvents,
           })
-          .createMassIdAuditDocument()
+          .createMassIdAuditDocuments()
           .createMethodologyDocument()
           .createParticipantHomologationDocuments(homologationDocuments)
           .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-sorting/mass-sorting.test-cases.ts
@@ -149,7 +149,7 @@ const {
   massIdDocument,
   participantsHomologationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocument({
+  .createMassIdDocuments({
     externalEventsMap: {
       [DROP_OFF]: stubBoldMassIdDropOffEvent({
         partialDocumentEvent: {
@@ -158,13 +158,13 @@ const {
       }),
     },
   })
-  .createMassIdAuditDocument()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 
 const invalidSortingValue = new BoldStubsBuilder()
-  .createMassIdDocument({
+  .createMassIdDocuments({
     externalEventsMap: {
       [SORTING]: stubBoldMassIdSortingEvent({
         partialDocumentEvent: {
@@ -173,7 +173,7 @@ const invalidSortingValue = new BoldStubsBuilder()
       }),
     },
   })
-  .createMassIdAuditDocument()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/participant-homologations/participant-homologations.test-cases.ts
@@ -20,15 +20,15 @@ const { EFFECTIVE_DATE, EXPIRATION_DATE } = DocumentEventAttributeName;
 const processorError = new ParticipantHomologationsProcessorErrors();
 
 const massIdAuditWithHomologations = new BoldStubsBuilder()
-  .createMassIdDocument()
-  .createMassIdAuditDocument()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();
 
 const massIdWithExpiredHomologation = new BoldStubsBuilder()
-  .createMassIdDocument()
-  .createMassIdAuditDocument()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments(
     new Map([

--- a/libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('ProcessorIdentificationProcessor E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('ProjectBoundaryLambda E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultContent, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.spec.ts
@@ -42,7 +42,7 @@ describe('ProjectBoundaryProcessor', () => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
         .build();
@@ -85,7 +85,7 @@ describe('ProjectBoundaryProcessor', () => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: {
             [DocumentEventName.DROP_OFF]: stubBoldMassIdDropOffEvent(),
             [DocumentEventName.PICK_UP]: stubBoldMassIdPickUpEvent(),

--- a/libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('RecyclerActorProcessor E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.e2e.spec.ts
@@ -61,7 +61,7 @@ describe('Uniqueness Check Helpers E2E', () => {
     auditApiService = new AuditApiService();
 
     const { massIdDocument } = new BoldStubsBuilder()
-      .createMassIdDocument({
+      .createMassIdDocuments({
         externalEventsMap: {
           [`${ACTOR}-${RECYCLER}`]: eventsData.recyclerEvent,
           [`${ACTOR}-${WASTE_GENERATOR}`]: eventsData.wasteGeneratorEvent,
@@ -81,7 +81,7 @@ describe('Uniqueness Check Helpers E2E', () => {
   describe('fetchSimilarMassIdDocuments', () => {
     it('should return an empty array when no similar documents are found', async () => {
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument()
+        .createMassIdDocuments()
         .build();
 
       const result = await fetchSimilarMassIdDocuments({

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.helpers.spec.ts
@@ -33,7 +33,7 @@ describe('uniqueness-check.helpers', () => {
   describe('mapMassIdV2Query', () => {
     it('should create a valid query object with proper structure', () => {
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument()
+        .createMassIdDocuments()
         .build();
 
       const eventsData: helpers.EventsData = {
@@ -58,7 +58,7 @@ describe('uniqueness-check.helpers', () => {
   describe('createOldFormatQuery', () => {
     it('should create a valid query object with proper structure', () => {
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument()
+        .createMassIdDocuments()
         .build();
 
       const eventsData: helpers.EventsData = {
@@ -81,7 +81,7 @@ describe('uniqueness-check.helpers', () => {
   describe('fetchSimilarMassIdDocuments', () => {
     it('should call API with both new and old format queries and combine results', async () => {
       const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument()
+        .createMassIdDocuments()
         .build();
 
       const newFormatDuplicates = [

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.lambda.e2e.spec.ts
@@ -42,8 +42,8 @@ describe('UniquenessCheckLambda E2E', () => {
         resultStatus,
       }) => {
         const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-          .createMassIdDocument()
-          .createMassIdAuditDocument()
+          .createMassIdDocuments()
+          .createMassIdAuditDocuments()
           .build();
 
         mockCheckDuplicateDocuments

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.spec.ts
@@ -41,7 +41,7 @@ describe('UniquenessCheckProcessor Rule', () => {
         const ruleInput = random<Required<RuleInput>>();
 
         const { massIdDocument } = new BoldStubsBuilder()
-          .createMassIdDocument()
+          .createMassIdDocuments()
           .build();
 
         mockCheckDuplicateDocuments

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.test-cases.ts
@@ -63,8 +63,8 @@ export const uniquenessCheckTestCases = [
 const processorErrors = new UniquenessCheckProcessorErrors();
 
 const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-  .createMassIdDocument()
-  .createMassIdAuditDocument()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
   .build();
 
 export const uniquenessCheckErrorTestCases = [

--- a/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('VehicleIdentificationLambda E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.lambda.e2e.spec.ts
@@ -19,10 +19,10 @@ describe('WasteOriginIdentificationProcessor E2E', () => {
     'should validate waste origin identification - $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.lambda.e2e.spec.ts
@@ -35,10 +35,10 @@ describe('WeighingProcessor E2E', () => {
         massIdDocument,
         participantsHomologationDocuments,
       } = new BoldStubsBuilder()
-        .createMassIdDocument({
+        .createMassIdDocuments({
           externalEventsMap: massIdDocumentEvents,
         })
-        .createMassIdAuditDocument()
+        .createMassIdAuditDocuments()
         .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.processor.spec.ts
@@ -30,10 +30,10 @@ describe('WeighingProcessor', () => {
           massIdDocument,
           participantsHomologationDocuments,
         } = new BoldStubsBuilder()
-          .createMassIdDocument({
+          .createMassIdDocuments({
             externalEventsMap: massIdDocumentEvents,
           })
-          .createMassIdAuditDocument()
+          .createMassIdAuditDocuments()
           .createMethodologyDocument()
           .createParticipantHomologationDocuments(homologationDocuments)
           .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/weighing/weighing.test-cases.ts
@@ -700,8 +700,8 @@ const {
   massIdDocument,
   participantsHomologationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocument()
-  .createMassIdAuditDocument()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
   .createMethodologyDocument()
   .createParticipantHomologationDocuments()
   .build();

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-certificate.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-certificate.stubs.ts
@@ -4,7 +4,7 @@ import {
   DocumentCategory,
   type DocumentEvent,
   DocumentEventName,
-  DocumentSubtype,
+  DocumentType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { random } from 'typia';
 
@@ -53,7 +53,7 @@ export const stubBoldCertificateDocument = ({
   return {
     ...stubDocument(
       {
-        type: random<DocumentSubtype.TCC | DocumentSubtype.TRC>(),
+        type: random<DocumentType.GAS_ID | DocumentType.RECYCLED_ID>(),
         ...partialDocument,
         category: DocumentCategory.METHODOLOGY,
         externalEvents: [

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-certificate.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-certificate.stubs.ts
@@ -1,0 +1,67 @@
+import { isNil } from '@carrot-fndn/shared/helpers';
+import {
+  type Document,
+  DocumentCategory,
+  type DocumentEvent,
+  DocumentEventName,
+  DocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { random } from 'typia';
+
+import {
+  stubDocument,
+  stubDocumentEventWithMetadataAttributes,
+} from '../stubs';
+import {
+  type MetadataAttributeParameter,
+  mergeEventsMaps,
+  mergeMetadataAttributes,
+} from './bold.builder.helpers';
+import {
+  type StubBoldDocumentEventParameters,
+  type StubBoldDocumentParameters,
+} from './bold.stubs.types';
+
+const { RULES_METADATA } = DocumentEventName;
+
+const defaultRulesMetadataAttributes: MetadataAttributeParameter[] = [];
+
+export const stubBoldCertificateRulesMetadataEvent = ({
+  metadataAttributes,
+  partialDocumentEvent,
+}: StubBoldDocumentEventParameters = {}): DocumentEvent =>
+  stubDocumentEventWithMetadataAttributes(
+    {
+      ...partialDocumentEvent,
+      name: RULES_METADATA,
+    },
+    mergeMetadataAttributes(defaultRulesMetadataAttributes, metadataAttributes),
+  );
+
+const boldCertificateExternalEventsMap = new Map([
+  [RULES_METADATA, stubBoldCertificateRulesMetadataEvent()],
+]);
+
+export const stubBoldCertificateDocument = ({
+  externalEventsMap,
+  partialDocument,
+}: StubBoldDocumentParameters = {}): Document => {
+  const mergedEventsMap = isNil(externalEventsMap)
+    ? boldCertificateExternalEventsMap
+    : mergeEventsMaps(boldCertificateExternalEventsMap, externalEventsMap);
+
+  return {
+    ...stubDocument(
+      {
+        type: random<DocumentSubtype.TCC | DocumentSubtype.TRC>(),
+        ...partialDocument,
+        category: DocumentCategory.METHODOLOGY,
+        externalEvents: [
+          ...mergedEventsMap.values(),
+          ...(partialDocument?.externalEvents ?? []),
+        ],
+      },
+      false,
+    ),
+  };
+};

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-credits.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-credits.stubs.ts
@@ -1,0 +1,34 @@
+import { isNil } from '@carrot-fndn/shared/helpers';
+import {
+  type Document,
+  DocumentCategory,
+  DocumentType,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import { stubDocument } from '../stubs';
+import { mergeEventsMaps } from './bold.builder.helpers';
+import { type StubBoldDocumentParameters } from './bold.stubs.types';
+
+export const stubBoldCreditsDocument = ({
+  externalEventsMap,
+  partialDocument,
+}: StubBoldDocumentParameters = {}): Document => {
+  const mergedEventsMap = isNil(externalEventsMap)
+    ? new Map()
+    : mergeEventsMaps(new Map(), externalEventsMap);
+
+  return {
+    ...stubDocument(
+      {
+        ...partialDocument,
+        category: DocumentCategory.METHODOLOGY,
+        externalEvents: [
+          ...mergedEventsMap.values(),
+          ...(partialDocument?.externalEvents ?? []),
+        ],
+        type: DocumentType.CREDIT,
+      },
+      false,
+    ),
+  };
+};

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -556,7 +556,7 @@ export class BoldStubsBuilder {
   }: StubBoldDocumentParameters & { count?: number } = {}): BoldStubsBuilder {
     if (count !== undefined) {
       this.count = count;
-      // Create new arrays instead of modifying readonly properties
+
       const newMassIdDocumentIds = Array.from({ length: this.count }, () =>
         faker.string.uuid(),
       );
@@ -564,7 +564,6 @@ export class BoldStubsBuilder {
         faker.string.uuid(),
       );
 
-      // Assign to class properties
       this.massIdDocumentIds = newMassIdDocumentIds;
       this.massIdAuditDocumentIds = newMassIdAuditDocumentIds;
 
@@ -647,7 +646,6 @@ export class BoldStubsBuilder {
       },
     });
 
-    // Add link to methodology for all audit documents
     this.massIdAuditDocuments = this.massIdAuditDocuments.map((auditDocument) =>
       this.addExternalEventToDocument(
         auditDocument,

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -10,7 +10,6 @@ import {
   MassIdDocumentActorType,
   MethodologyDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { stubArray } from '@carrot-fndn/shared/testing';
 import {
   type Geolocation,
   type MethodologyAddress,
@@ -23,11 +22,12 @@ import type { StubBoldDocumentParameters } from './bold.stubs.types';
 import {
   generateNearbyCoordinates,
   stubAddress,
-  stubCreditDocument,
   stubDocumentEvent,
   stubParticipant,
   stubParticipantHomologationGroupDocument,
 } from '../stubs';
+import { stubBoldCertificateDocument } from './bold-certificate.stubs';
+import { stubBoldCreditsDocument } from './bold-credits.stubs';
 import {
   stubBoldMassIdDocument,
   stubBoldMassIdDropOffEvent,
@@ -45,20 +45,24 @@ const { FOOD_FOOD_WASTE_AND_BEVERAGES, GROUP, PROCESS, TCC, TRC } =
   DocumentSubtype;
 
 export interface BoldStubsBuilderOptions {
+  count?: number;
   massIdActorParticipants?: Map<string, MethodologyParticipant>;
-  massIdAuditDocumentId?: string;
-  massIdDocumentId?: string;
+  massIdAuditDocumentIds?: string[];
+  massIdDocumentIds?: string[];
 }
 
 export interface BoldStubsBuilderResult {
-  creditDocuments: Document[];
-  creditDocumentsStubs: Document[];
+  certificateDocument: Document;
+  certificateDocuments: Document[];
+  creditsDocument: Document;
   massIdActorParticipants: Map<string, MethodologyParticipant>;
   massIdActorParticipantsAddresses: Map<string, MethodologyAddress>;
   massIdAuditDocument: Document;
-  massIdAuditId: string;
+  massIdAuditDocuments: Document[];
+  massIdAuditIds: string[];
   massIdDocument: Document;
-  massIdDocumentId: string;
+  massIdDocumentIds: string[];
+  massIdDocuments: Document[];
   methodologyActorParticipants: Map<string, MethodologyParticipant>;
   methodologyDocument: Document | undefined;
   participantsHomologationDocuments: Map<string, Document>;
@@ -85,13 +89,17 @@ export class BoldStubsBuilder {
     { base: Geolocation; nearby: Geolocation }
   >;
 
-  private creditDocuments: Document[] = [];
+  private certificateDocumentReferences: DocumentReference[] = [];
 
-  private creditDocumentsStubs: Document[] = [];
+  private certificateDocuments: Document[] = [];
 
-  private creditReferences: DocumentReference[] = [];
+  private count: number;
 
-  private readonly massAuditReference: DocumentReference;
+  private creditsDocument: Document;
+
+  private creditsReference: DocumentReference;
+
+  private massAuditReferences: DocumentReference[] = [];
 
   private readonly massIdActorParticipants: Map<string, MethodologyParticipant>;
 
@@ -100,15 +108,15 @@ export class BoldStubsBuilder {
     MethodologyAddress
   >;
 
-  private massIdAuditDocument: Document;
+  private massIdAuditDocumentIds: string[];
 
-  private readonly massIdAuditDocumentId: string;
+  private massIdAuditDocuments: Document[] = [];
 
-  private massIdDocument: Document;
+  private massIdDocumentIds: string[];
 
-  private readonly massIdDocumentId: string;
+  private massIdDocuments: Document[] = [];
 
-  private readonly massIdReference: DocumentReference;
+  private massIdReferences: DocumentReference[] = [];
 
   private readonly methodologyActorParticipants: Map<
     string,
@@ -129,9 +137,15 @@ export class BoldStubsBuilder {
     new Map();
 
   constructor(options: BoldStubsBuilderOptions = {}) {
-    this.massIdDocumentId = options.massIdDocumentId ?? faker.string.uuid();
-    this.massIdAuditDocumentId =
-      options.massIdAuditDocumentId ?? faker.string.uuid();
+    this.count = options.count ?? 1;
+
+    this.massIdDocumentIds =
+      options.massIdDocumentIds ??
+      Array.from({ length: this.count }, () => faker.string.uuid());
+
+    this.massIdAuditDocumentIds =
+      options.massIdAuditDocumentIds ??
+      Array.from({ length: this.count }, () => faker.string.uuid());
 
     this.massIdActorParticipants = this.initializeMassIdActorParticipants(
       options.massIdActorParticipants,
@@ -142,21 +156,23 @@ export class BoldStubsBuilder {
     this.actorsCoordinates = this.initializeActorsCoordinates();
     this.massIdActorParticipantsAddresses = this.initializeActorAddresses();
 
-    this.massIdReference = this.createMassIdReference();
-    this.massAuditReference = this.createMassAuditReference();
+    this.massIdReferences = this.createMassIdReferences();
+    this.certificateDocumentReferences =
+      this.createCertificateDocumentReferences();
+    this.massAuditReferences = this.createMassAuditReferences();
   }
 
-  private addCreditReferencesToMassIdDocument(): Document {
+  private addCreditReferenceToMassIdDocument(
+    massIdDocument: Document,
+  ): Document {
     return {
-      ...this.massIdDocument,
+      ...massIdDocument,
       externalEvents: [
-        ...(this.massIdDocument.externalEvents ?? []),
-        ...this.creditReferences.map((reference) =>
-          stubDocumentEvent({
-            name: RELATED,
-            relatedDocument: reference,
-          }),
-        ),
+        ...(massIdDocument.externalEvents ?? []),
+        stubDocumentEvent({
+          name: RELATED,
+          relatedDocument: this.creditsReference,
+        }),
       ],
     };
   }
@@ -171,31 +187,29 @@ export class BoldStubsBuilder {
     };
   }
 
-  private createCreditDocuments(references: DocumentReference[]): Document[] {
-    return references.map((reference) =>
-      stubCreditDocument({
-        id: reference.documentId,
-        subtype: reference.subtype,
-      }),
-    );
+  private createCertificateDocumentReferences(
+    certificateType: typeof TCC | typeof TRC = TCC,
+  ): DocumentReference[] {
+    return Array.from({ length: this.count }, () => ({
+      category: METHODOLOGY,
+      documentId: faker.string.uuid(),
+      type: certificateType,
+    }));
   }
 
-  private createCreditReferences(
-    count: number,
-    creditType: typeof TCC | typeof TRC,
-  ): DocumentReference[] {
-    return stubArray(
-      () => ({
-        category: METHODOLOGY,
-        documentId: faker.string.uuid(),
-        subtype: creditType,
-        type: CREDIT,
-      }),
-      { max: count },
-    );
+  private createCreditsDocumentReference(
+    subtype: typeof TCC | typeof TRC,
+  ): DocumentReference {
+    return {
+      category: METHODOLOGY,
+      documentId: faker.string.uuid(),
+      subtype,
+      type: CREDIT,
+    };
   }
 
   private createDefaultMassIdEventsMap(
+    index: number,
     actorEvents: Record<string, DocumentEvent>,
   ): Map<string, DocumentEvent> {
     return new Map([
@@ -216,7 +230,7 @@ export class BoldStubsBuilder {
         OUTPUT,
         stubDocumentEvent({
           name: OUTPUT,
-          relatedDocument: this.massAuditReference,
+          relatedDocument: this.massAuditReferences[index],
         }),
       ],
       [
@@ -236,13 +250,13 @@ export class BoldStubsBuilder {
     ]);
   }
 
-  private createMassAuditReference(): DocumentReference {
-    return {
+  private createMassAuditReferences(): DocumentReference[] {
+    return this.massIdAuditDocumentIds.map((documentId) => ({
       category: METHODOLOGY,
-      documentId: this.massIdAuditDocumentId,
+      documentId,
       subtype: PROCESS,
       type: MASS_ID_AUDIT,
-    };
+    }));
   }
 
   private createMassIdActorEvents(): Record<string, DocumentEvent> {
@@ -259,13 +273,13 @@ export class BoldStubsBuilder {
     );
   }
 
-  private createMassIdReference(): DocumentReference {
-    return {
+  private createMassIdReferences(): DocumentReference[] {
+    return this.massIdDocumentIds.map((documentId) => ({
       category: MASS_ID,
-      documentId: this.massIdDocumentId,
+      documentId,
       subtype: FOOD_FOOD_WASTE_AND_BEVERAGES,
       type: ORGANIC,
-    };
+    }));
   }
 
   private createMethodologyActorEvents(): Record<string, DocumentEvent> {
@@ -365,18 +379,37 @@ export class BoldStubsBuilder {
     ]);
   }
 
-  private validateMassIdDocumentExists(): void {
-    if (isNil(this.massIdDocument)) {
+  private validateAllDocumentsExist(): void {
+    if (
+      this.massIdDocuments.length === 0 ||
+      this.massIdAuditDocuments.length === 0
+    ) {
       throw new Error(
-        'MassID document must be created first. Call createMassIdDocument() before this method.',
+        'MassID documents must be created first. Call createMassIdDocuments() and createMassIdAuditDocuments() before this method.',
+      );
+    }
+  }
+
+  private validateCertificateDocumentsExist(): void {
+    if (this.certificateDocuments.length === 0) {
+      throw new Error(
+        'MassID Certificate documents must be created first. Call createCertificateDocuments() before this method.',
+      );
+    }
+  }
+
+  private validateMassIdAuditDocumentsExist(): void {
+    if (this.massIdAuditDocuments.length === 0) {
+      throw new Error(
+        'MassID Audit documents must be created first. Call createMassIdAuditDocuments() before this method.',
       );
     }
   }
 
   private validateMassIdDocumentsExist(): void {
-    if (isNil(this.massIdDocument) || isNil(this.massIdAuditDocument)) {
+    if (this.massIdDocuments.length === 0) {
       throw new Error(
-        'MassID documents must be created first. Call createMassIdDocument() and createMassIdAuditDocument() before this method.',
+        'MassID documents must be created first. Call createMassIdDocuments() before this method.',
       );
     }
   }
@@ -395,62 +428,170 @@ export class BoldStubsBuilder {
 
   build(): BoldStubsBuilderResult {
     return {
-      creditDocuments: this.creditDocuments,
-      creditDocumentsStubs: this.creditDocumentsStubs,
+      get certificateDocument() {
+        if (this.certificateDocuments.length === 0) {
+          throw new Error(
+            'No certificate documents created. Call createCertificateDocuments() before building.',
+          );
+        }
+
+        return this.certificateDocuments[0]!;
+      },
+      certificateDocuments: this.certificateDocuments,
+      creditsDocument: this.creditsDocument,
       massIdActorParticipants: this.massIdActorParticipants,
       massIdActorParticipantsAddresses: this.massIdActorParticipantsAddresses,
-      massIdAuditDocument: this.massIdAuditDocument,
-      massIdAuditId: this.massIdAuditDocumentId,
-      massIdDocument: this.massIdDocument,
-      massIdDocumentId: this.massIdDocumentId,
+      get massIdAuditDocument() {
+        if (this.massIdAuditDocuments.length === 0) {
+          throw new Error(
+            'No massId audit documents created. Call createMassIdAuditDocuments() before building.',
+          );
+        }
+
+        return this.massIdAuditDocuments[0]!;
+      },
+      massIdAuditDocuments: this.massIdAuditDocuments,
+      massIdAuditIds: this.massIdAuditDocumentIds,
+      get massIdDocument() {
+        if (this.massIdDocuments.length === 0) {
+          throw new Error(
+            'No massId documents created. Call createMassIdDocuments() before building.',
+          );
+        }
+
+        return this.massIdDocuments[0]!;
+      },
+      massIdDocumentIds: this.massIdDocumentIds,
+      massIdDocuments: this.massIdDocuments,
       methodologyActorParticipants: this.methodologyActorParticipants,
       methodologyDocument: this.methodologyDocument,
       participantsHomologationDocuments: this.participantsHomologationDocuments,
     };
   }
 
-  createMassIdAuditDocument({
+  createCertificateDocuments({
     externalEventsMap,
     partialDocument,
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
-    this.validateMassIdDocumentExists();
+    this.validateMassIdDocumentsExist();
+    this.validateMassIdAuditDocumentsExist();
 
-    this.massIdAuditDocument = stubBoldMassIdAuditDocument({
-      externalEventsMap: {
-        [LINK]: stubDocumentEvent({
-          name: LINK,
-          referencedDocument: this.massIdReference,
-          relatedDocument: undefined,
+    this.certificateDocuments = this.massIdAuditDocuments.map(
+      (auditDocument, index) =>
+        stubBoldCertificateDocument({
+          externalEventsMap,
+          partialDocument: {
+            currentValue: auditDocument.currentValue,
+            ...partialDocument,
+            id: this.certificateDocumentReferences[index]!.documentId,
+            parentDocumentId: auditDocument.id,
+          },
         }),
-        ...externalEventsMap,
-      },
-      partialDocument: {
-        ...partialDocument,
-        currentValue: this.massIdDocument.currentValue,
-        id: this.massAuditReference.documentId,
-        parentDocumentId: this.massIdDocument.id,
-      },
-    });
+    );
 
     return this;
   }
 
-  createMassIdDocument({
+  createCreditsDocument(
+    creditsSubtype?: typeof TCC | typeof TRC,
+  ): BoldStubsBuilder {
+    this.validateMassIdDocumentsExist();
+    this.validateMassIdAuditDocumentsExist();
+    this.validateCertificateDocumentsExist();
+
+    this.creditsReference = this.createCreditsDocumentReference(
+      creditsSubtype ?? TRC,
+    );
+    this.creditsDocument = stubBoldCreditsDocument({
+      partialDocument: {
+        id: this.creditsReference.documentId,
+        subtype: creditsSubtype ?? this.creditsReference.subtype,
+      },
+    });
+
+    this.massIdDocuments = this.massIdDocuments.map((document) =>
+      this.addCreditReferenceToMassIdDocument(document),
+    );
+
+    return this;
+  }
+
+  createMassIdAuditDocuments({
     externalEventsMap,
     partialDocument,
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
-    const actorEvents = this.createMassIdActorEvents();
-    const defaultEventsMap = this.createDefaultMassIdEventsMap(actorEvents);
-    const mergedEventsMap = isNil(externalEventsMap)
-      ? defaultEventsMap
-      : this.mergeEventsMaps(defaultEventsMap, externalEventsMap);
+    this.validateMassIdDocumentsExist();
 
-    this.massIdDocument = stubBoldMassIdDocument({
-      externalEventsMap: mergedEventsMap,
-      partialDocument: {
-        ...partialDocument,
-        id: this.massIdReference.documentId,
-      },
+    this.massIdAuditDocuments = this.massIdDocuments.map(
+      (massIdDocument, index) =>
+        stubBoldMassIdAuditDocument({
+          externalEventsMap: {
+            [LINK]: stubDocumentEvent({
+              name: LINK,
+              referencedDocument: this.massIdReferences[index],
+              relatedDocument: undefined,
+            }),
+            [RELATED]: stubDocumentEvent({
+              name: RELATED,
+              relatedDocument: this.certificateDocumentReferences[index],
+            }),
+            ...externalEventsMap,
+          },
+          partialDocument: {
+            ...partialDocument,
+            currentValue: massIdDocument.currentValue,
+            id: this.massAuditReferences[index]!.documentId,
+            parentDocumentId: massIdDocument.id,
+          },
+        }),
+    );
+
+    return this;
+  }
+
+  createMassIdDocuments({
+    count,
+    externalEventsMap,
+    partialDocument,
+  }: StubBoldDocumentParameters & { count?: number } = {}): BoldStubsBuilder {
+    if (count !== undefined) {
+      this.count = count;
+      // Create new arrays instead of modifying readonly properties
+      const newMassIdDocumentIds = Array.from({ length: this.count }, () =>
+        faker.string.uuid(),
+      );
+      const newMassIdAuditDocumentIds = Array.from({ length: this.count }, () =>
+        faker.string.uuid(),
+      );
+
+      // Assign to class properties
+      this.massIdDocumentIds = newMassIdDocumentIds;
+      this.massIdAuditDocumentIds = newMassIdAuditDocumentIds;
+
+      this.massIdReferences = this.createMassIdReferences();
+      this.certificateDocumentReferences =
+        this.createCertificateDocumentReferences();
+      this.massAuditReferences = this.createMassAuditReferences();
+    }
+
+    const actorEvents = this.createMassIdActorEvents();
+
+    this.massIdDocuments = this.massIdDocumentIds.map((_, index) => {
+      const defaultEventsMap = this.createDefaultMassIdEventsMap(
+        index,
+        actorEvents,
+      );
+      const mergedEventsMap = isNil(externalEventsMap)
+        ? defaultEventsMap
+        : this.mergeEventsMaps(defaultEventsMap, externalEventsMap);
+
+      return stubBoldMassIdDocument({
+        externalEventsMap: mergedEventsMap,
+        partialDocument: {
+          ...partialDocument,
+          id: this.massIdReferences[index]!.documentId,
+        },
+      });
     });
 
     return this;
@@ -460,7 +601,7 @@ export class BoldStubsBuilder {
     externalEventsMap,
     partialDocument,
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
-    this.validateMassIdDocumentsExist();
+    this.validateAllDocumentsExist();
 
     const actorEvents = this.createMethodologyActorEvents();
 
@@ -470,7 +611,7 @@ export class BoldStubsBuilder {
         OUTPUT,
         stubDocumentEvent({
           name: OUTPUT,
-          relatedDocument: this.participantHomologationGroupReference,
+          relatedDocument: this.participantHomologationGroupReference!,
         }),
       ],
     ]);
@@ -506,13 +647,16 @@ export class BoldStubsBuilder {
       },
     });
 
-    this.massIdAuditDocument = this.addExternalEventToDocument(
-      this.massIdAuditDocument,
-      stubDocumentEvent({
-        name: LINK,
-        referencedDocument: this.methodologyReference,
-        relatedDocument: undefined,
-      }),
+    // Add link to methodology for all audit documents
+    this.massIdAuditDocuments = this.massIdAuditDocuments.map((auditDocument) =>
+      this.addExternalEventToDocument(
+        auditDocument,
+        stubDocumentEvent({
+          name: LINK,
+          referencedDocument: this.methodologyReference,
+          relatedDocument: undefined,
+        }),
+      ),
     );
 
     return this;
@@ -570,42 +714,23 @@ export class BoldStubsBuilder {
           }),
         );
 
-      this.massIdAuditDocument = this.addExternalEventToDocument(
-        this.massIdAuditDocument,
-        stubDocumentEvent({
-          address: primaryAddress,
-          name: LINK,
-          participant: primaryParticipant,
-          referencedDocument: reference,
-          relatedDocument: undefined,
-        }),
+      this.massIdAuditDocuments = this.massIdAuditDocuments.map(
+        (auditDocument) =>
+          this.addExternalEventToDocument(
+            auditDocument,
+            stubDocumentEvent({
+              address: primaryAddress,
+              name: LINK,
+              participant: primaryParticipant,
+              referencedDocument: reference,
+              relatedDocument: undefined,
+            }),
+          ),
       );
 
       this.participantsHomologationReferences.set(subtype, reference);
       this.participantsHomologationDocuments.set(subtype, documentStub);
     }
-
-    return this;
-  }
-
-  withCredits({
-    count = 1,
-    creditType = TRC,
-  }: {
-    count?: number;
-    creditType?: typeof TCC | typeof TRC;
-  } = {}): BoldStubsBuilder {
-    this.validateMassIdDocumentExists();
-
-    const creditCount = Math.max(1, count);
-
-    this.creditReferences = this.createCreditReferences(
-      creditCount,
-      creditType,
-    );
-    this.creditDocuments = this.createCreditDocuments(this.creditReferences);
-
-    this.massIdDocument = this.addCreditReferencesToMassIdDocument();
 
     return this;
   }

--- a/libs/shared/methodologies/bold/testing/src/builders/index.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/index.ts
@@ -5,3 +5,4 @@ export * from './bold-participant-homologation.stubs';
 export * from './bold.builder.helpers';
 export * from './bold.stubs.types';
 export * from './bold-methodology-definition.stubs';
+export * from './bold-credits.stubs';


### PR DESCRIPTION
- **feat: add stubs for bold certificate and credits documents in the builder**
- **refactor: unify massIdDocument and massIdAuditDocument creation in stubs builder**

### Summary

- **New Features**
  - Introduced new utilities for creating test data related to certificates and credits, enabling more comprehensive testing scenarios.

- **Refactor**
  - Updated test data builders to support creation of multiple MassID, audit, and certificate documents, replacing previous single-document methods.
  - Revised test setup across multiple test suites to utilize the new pluralized document creation methods for improved consistency and flexibility.
  - Enhanced test cases for credit absence to use explicit document stubs and clearer relationships, including modeling of cancelled credit documents.

- **Chores**
  - Streamlined and clarified test data setup for improved maintainability and future test coverage.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new stub builders for certificate and credit documents to enhance test data coverage.

- **Refactor**
  - Updated test data builder to handle multiple MassID, audit, and certificate documents, improving test flexibility.
  - Modified test cases and setups across modules to use pluralized document creation methods and refined document relationships.
  - Improved clarity in test data construction, including explicit modeling of cancelled credits and associated events.

- **Chores**
  - Expanded test data builder exports to support wider usage in testing contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->