### PR TITLE
refactor/load parent document

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/composting-cycle-timeframe/composting-cycle-timeframe.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
   stubBoldMassIdDocument,
   stubBoldMassIdDropOffEvent,
@@ -26,7 +26,7 @@ const { DROP_OFF, RECYCLED } = DocumentEventName;
 describe('CompostingCycleTimeframeProcessor', () => {
   const ruleDataProcessor = new CompostingCycleTimeframeProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(
     compostingCycleTimeframeTestCases.map((testCase) => {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/document-manifest/document-manifest.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -15,7 +15,7 @@ import {
 jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 
 describe('DocumentManifestProcessor', () => {
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each([...exceptionTestCases, ...documentManifestTestCases])(
     'should return $resultStatus when $scenario',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/driver-identification/driver-identification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -17,7 +17,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('DriverIdentificationProcessor', () => {
   const ruleDataProcessor = new DriverIdentificationProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(driverIdentificationTestCases)(
     'should return $resultStatus when $scenario',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/drop-off-at-recycling-facility/drop-off-at-recycling-facility.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -14,7 +14,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('DropOffAtRecyclingFacilityProcessor', () => {
   const ruleDataProcessor = new DropOffAtRecyclingFacilityProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(dropOffAtRecyclingFacilityTestCases)(
     'should return $resultStatus when $scenario',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/hauler-identification/hauler-identification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -13,7 +13,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 
 describe('HaulerIdentificationProcessor', () => {
   const ruleDataProcessor = new HaulerIdentificationProcessor();
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(haulerIdentificationTestCases)(
     `should return $resultStatus when $scenario`,

--- a/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/local-waste-classification/local-waste-classification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -14,7 +14,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('LocalWasteClassificationProcessor', () => {
   const ruleDataProcessor = new LocalWasteClassificationProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(localWasteClassificationTestCases)(
     'should return $resultStatus when $scenario',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/mass-definition/mass-definition.processor.spec.ts
@@ -1,6 +1,6 @@
 import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { MassIdOrganicSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleInput,
@@ -18,7 +18,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('MassDefinitionProcessor', () => {
   const ruleDataProcessor = new MassDefinitionProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   describe('isValidSubtype', () => {
     it('should return false when subtype is undefined', () => {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/processor-identification/processor-identification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -14,7 +14,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('ProcessorIdentificationProcessor', () => {
   const ruleDataProcessor = new ProcessorIdentificationProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(processorIdentificationTestCases)(
     `should return $resultStatus when $scenario`,

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-boundary/project-boundary.processor.spec.ts
@@ -1,5 +1,5 @@
 import { calculateDistance } from '@carrot-fndn/shared/helpers';
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
   BoldStubsBuilder,
   stubBoldMassIdDropOffEvent,
@@ -29,7 +29,7 @@ jest.mock('@carrot-fndn/shared/helpers', () => ({
 describe('ProjectBoundaryProcessor', () => {
   const ruleDataProcessor = new ProjectBoundaryProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
   const calculateDistanceMock = jest.mocked(calculateDistance);
 
   beforeEach(() => {

--- a/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/project-period/project-period.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
   stubBoldMassIdDocument,
   stubBoldMassIdRecycledEvent,
@@ -28,7 +28,7 @@ const { RECYCLED } = DocumentEventName;
 
 describe('ProjectPeriodProcessor', () => {
   const ruleDataProcessor = new TestProjectPeriodProcessor();
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(projectPeriodTestCases)(
     'should return $resultStatus when $scenario',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/recycler-identification/recycler-identification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -14,7 +14,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('RecyclerIdentificationProcessor', () => {
   const ruleDataProcessor = new RecyclerIdentificationProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(recyclerIdentificationTestCases)(
     `should return $resultStatus when $scenario`,

--- a/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/uniqueness-check/uniqueness-check.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -27,7 +27,7 @@ jest.mock('./uniqueness-check.helpers', () => ({
 
 describe('UniquenessCheckProcessor Rule', () => {
   const ruleDataProcessor = new UniquenessCheckProcessor();
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   describe('UniquenessCheckProcessor', () => {
     it.each(uniquenessCheckTestCases)(

--- a/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/vehicle-identification/vehicle-identification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -14,7 +14,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('VehicleIdentificationProcessor', () => {
   const ruleDataProcessor = new VehicleIdentificationProcessor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(vehicleIdentificationTestCases)(
     'should return $resultStatus when $scenario',

--- a/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/src/waste-origin-identification/waste-origin-identification.processor.spec.ts
@@ -1,4 +1,4 @@
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
@@ -13,7 +13,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 
 describe('WasteOriginIdentificationProcessor', () => {
   const ruleDataProcessor = new WasteOriginIdentificationProcessor();
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(wasteOriginIdentificationTestCases)(
     `should return $resultStatus when $scenario`,

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
@@ -9,16 +9,16 @@ import { faker } from '@faker-js/faker';
 import { createMock } from '@golevelup/ts-jest';
 import { random } from 'typia';
 
-import { loadParentDocument } from './document.helpers';
+import { loadDocument } from './document.helpers';
 
 const loaderService = createMock<DocumentLoaderService>();
 
 describe('Document Helpers', () => {
-  describe('loadParentDocument', () => {
+  describe('loadDocument', () => {
     it('should return undefined if no key is provided', async () => {
       const key = undefined;
 
-      const result = await loadParentDocument(loaderService, key);
+      const result = await loadDocument(loaderService, key);
 
       expect(result).toBe(undefined);
     });
@@ -26,7 +26,7 @@ describe('Document Helpers', () => {
     it('should return undefined if the provided key is an empty string', async () => {
       const key = '';
 
-      const result = await loadParentDocument(loaderService, key);
+      const result = await loadDocument(loaderService, key);
 
       expect(result).toBe(undefined);
     });
@@ -40,7 +40,7 @@ describe('Document Helpers', () => {
           random<DocumentEntity>() as DocumentEntity<Document>,
         );
 
-      const result = await loadParentDocument(loaderService, key);
+      const result = await loadDocument(loaderService, key);
 
       expect(result).toBe(undefined);
     });
@@ -53,7 +53,7 @@ describe('Document Helpers', () => {
         .spyOn(loaderService, 'load')
         .mockResolvedValueOnce(stubDocumentEntity({ document }));
 
-      const result = await loadParentDocument(loaderService, key);
+      const result = await loadDocument(loaderService, key);
 
       expect(result).toEqual(document);
     });
@@ -67,7 +67,7 @@ describe('Document Helpers', () => {
           new Error('Not found document for Parent Document Key'),
         );
 
-      const result = await loadParentDocument(loaderService, key);
+      const result = await loadDocument(loaderService, key);
 
       expect(result).toBe(undefined);
     });

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
@@ -6,12 +6,12 @@ import { isNonEmptyString, logger } from '@carrot-fndn/shared/helpers';
 
 import { validateDocument } from './document-helpers.typia';
 
-export const loadParentDocument = async (
+export const loadDocument = async (
   loaderService: DocumentLoaderService,
   key: Maybe<string>,
 ): Promise<Document | undefined> => {
   if (!isNonEmptyString(key)) {
-    logger.info(`[loadParentDocument] Invalid key provided: ${key}`);
+    logger.info(`[loadDocument] Invalid key provided: ${key}`);
 
     return undefined;
   }
@@ -24,7 +24,7 @@ export const loadParentDocument = async (
     if (!validation.success) {
       logger.warn(
         { validationErrors: validation.errors },
-        `[loadParentDocument] Invalid parent document ${key}`,
+        `[loadDocument] Invalid document ${key}`,
       );
 
       return undefined;
@@ -32,10 +32,7 @@ export const loadParentDocument = async (
 
     return validation.data;
   } catch (error) {
-    logger.warn(
-      { error },
-      `[loadParentDocument] Failed to load document: ${key}`,
-    );
+    logger.warn({ error }, `[loadDocument] Failed to load document: ${key}`);
 
     return undefined;
   }

--- a/libs/shared/methodologies/bold/io-helpers/src/testing.helpers.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/testing.helpers.ts
@@ -22,10 +22,8 @@ export const spyOnDocumentQueryServiceLoad = (
   });
 };
 
-export const spyOnLoadParentDocument = (
-  result: Awaited<ReturnType<(typeof documentHelpers)['loadParentDocument']>>,
+export const spyOnLoadDocument = (
+  result: Awaited<ReturnType<(typeof documentHelpers)['loadDocument']>>,
 ) => {
-  jest
-    .spyOn(documentHelpers, 'loadParentDocument')
-    .mockResolvedValueOnce(result);
+  jest.spyOn(documentHelpers, 'loadDocument').mockResolvedValueOnce(result);
 };

--- a/libs/shared/methodologies/bold/processors/src/parent-document-rule-processor.spec.ts
+++ b/libs/shared/methodologies/bold/processors/src/parent-document-rule-processor.spec.ts
@@ -2,7 +2,7 @@ import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
 
 import { isNil } from '@carrot-fndn/shared/helpers';
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
   type RuleInput,
   RuleOutputStatus,
@@ -14,7 +14,7 @@ import { ParentDocumentRuleProcessor } from './parent-document-rule-processor';
 jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 
 describe('ParentDocumentRuleProcessor', () => {
-  const mockedloadParentDocument = jest.mocked(loadParentDocument);
+  const mockedloadDocument = jest.mocked(loadDocument);
 
   class TestParentDocumentRuleProcessor extends ParentDocumentRuleProcessor<
     []
@@ -56,7 +56,7 @@ describe('ParentDocumentRuleProcessor', () => {
       const ruleInput = random<RuleInput>();
       const document = random<Document>();
 
-      mockedloadParentDocument.mockResolvedValueOnce(document);
+      mockedloadDocument.mockResolvedValueOnce(document);
 
       const result = await processor['loadDocument'](ruleInput);
 

--- a/libs/shared/methodologies/bold/processors/src/parent-document-rule-processor.ts
+++ b/libs/shared/methodologies/bold/processors/src/parent-document-rule-processor.ts
@@ -2,7 +2,7 @@ import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 import type { RuleInput } from '@carrot-fndn/shared/rule/types';
 
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { RuleStandardDataProcessor } from '@carrot-fndn/shared/rule/standard-data-processor';
 
 export abstract class ParentDocumentRuleProcessor<
@@ -11,7 +11,7 @@ export abstract class ParentDocumentRuleProcessor<
   protected override async loadDocument(
     ruleInput: RuleInput,
   ): Promise<Document | undefined> {
-    return loadParentDocument(
+    return loadDocument(
       this.context.documentLoaderService,
       toDocumentKey({
         documentId: ruleInput.parentDocumentId,

--- a/tools/create-rule.js
+++ b/tools/create-rule.js
@@ -153,7 +153,7 @@ export class ${pascalCase}ProcessorErrors extends BaseProcessorErrors {
     name: `${fileName}.processor.spec.ts`,
     content: `import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 
-import { loadParentDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
   type RuleInput,
   type RuleOutput,
@@ -169,7 +169,7 @@ jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 describe('${pascalCase}Processor', () => {
   const ruleDataProcessor = new ${pascalCase}Processor();
 
-  const documentLoaderService = jest.mocked(loadParentDocument);
+  const documentLoaderService = jest.mocked(loadDocument);
 
   it.each(${camelCase}TestCases)(
     'should return $resultStatus when $scenario',


### PR DESCRIPTION
- **refactor(shared): rename loadParentDocument to loadDocument for better semantics**
- **refactor(shared): update testing helpers to use renamed loadDocument function**
- **refactor(shared): update ParentDocumentRuleProcessor to use loadDocument**
- **refactor(rule): update all mass-id rule processor tests with loadDocument**
- **refactor(script): update rule creation template to use loadDocument**

### Summary

Rename `loadParentDocument` to `loadDocument` for better semantics and update all its references across the codebase.

### Details

This PR makes a semantically clearer naming change from `loadParentDocument` to simply `loadDocument` as the function is used to load documents in general, not just parent documents. The changes include:

- Renamed the core function in io-helpers module
- Updated all method calls across spec files and rule processors
- Updated the testing helpers to reflect the new name
- Updated the rule creation templates to use the new function name

These changes improve code readability and maintain consistency throughout the codebase without changing any functionality.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the document loading function and related test utilities from "loadParentDocument" to "loadDocument" across the application and test files.
  - Updated all references, imports, mocks, and log messages to use the new function name for consistency.
- **Tests**
  - Adjusted test setups to mock and use "loadDocument" instead of "loadParentDocument", with no changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->