### PR TITLE
docs(rule): add github cli instructions and labels to pr rules

### DIFF
--- a/.cursor/rules/pull-request-rules.mdc
+++ b/.cursor/rules/pull-request-rules.mdc
@@ -87,6 +87,44 @@ Always check the declaration checkbox when creating PR descriptions, confirming:
 - Best practices were followed
 - Code quality has improved
 
+## Creating Pull Requests
+
+### Using GitHub CLI
+
+After creating the PR description in a file named `pr_description.md`, use the GitHub CLI to create the pull request with the following command:
+
+```bash
+gh pr create \
+  -a @me \                           # Assign PR to yourself
+  -r @carrot-foundation/developers \ # Request review from the developers team
+  --label feature \                  # Add appropriate labels
+  -F pr_description.md \             # Use the generated PR description file
+  -R carrot-foundation/methodology-rules \ # Specify the target repository
+  --head $(git branch --show-current) \    # Specify the current branch to push
+  -t "Your PR title here"            # Specify the PR title (use the commit message)
+```
+
+Note:
+- The `-R` flag specifies the target repository in the format `owner/repo`
+- The `--head` flag with `$(git branch --show-current)` automatically uses your current branch name, making the command non-interactive
+- The `-t` flag should use your commit message as the PR title for consistency
+
+### Steps for AI Agent
+
+1. Create the PR description following the template and guidelines above
+2. Save the PR description to a temporary file named `pr_description.md`
+3. Execute the gh CLI command to create the PR
+4. Clean up the temporary description file after PR creation
+
+### Labels
+
+Use appropriate labels based on the PR type:
+- `feature` for new features
+- `bug` for bug fixes
+- `chore` for maintenance tasks
+- `docs` for documentation updates
+- `refactoring` for refactoring changes
+
 ## Special Cases
 
 ### Breaking Changes
@@ -143,4 +181,4 @@ When updating documentation:
    - Ensure all sections are filled
    - Check for typos and formatting issues
 
-- [Conventional Commits](mdc:https:/www.conventionalcommits.org)
+- @Conventional Commits


### PR DESCRIPTION
# Summary

Updates the pull request rules documentation with GitHub CLI instructions and label guidelines to improve the PR creation process.

# Details

The changes include:

1. **GitHub CLI Instructions**:

   - Added detailed command example for creating PRs using GitHub CLI
   - Included explanation of command flags and their purposes
   - Added notes about repository format and branch name handling

2. **AI Agent Steps**:

   - Added clear steps for AI agents to follow when creating PRs
   - Included file handling instructions for PR descriptions

3. **Label Guidelines**:

   - Added a new section about PR labels
   - Defined appropriate labels for different PR types (feature, bug, chore, docs, refactoring)

4. **Documentation Updates**:
   - Fixed conventional commits link format
   - Improved overall documentation structure

# Declaration

- [x] I have tested these changes and they work as expected
- [x] I have not broken any existing services
- [x] I have followed our best practices
- [x] My code quality is better than it was before


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions for creating pull requests using the GitHub CLI, including sample commands and explanations of key flags.
  - Provided a step-by-step workflow for automating PR creation.
  - Defined standard labels for categorizing pull request types.
  - Made a minor correction to a reference for Conventional Commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->