### PR TITLE
fix(rule): enhance certificate uniqueness check handler with recycled ID and methodology slug

### DIFF
--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/certificate-uniqueness-check/src/lambda.ts
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/certificate-uniqueness-check/src/lambda.ts
@@ -1,1 +1,8 @@
-export { certificateUniquenessCheckLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/certificate-uniqueness-check';
+import { RECYCLED_ID } from '@carrot-fndn/shared/methodologies/bold/matchers';
+import { certificateUniquenessCheckLambda } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/certificate-uniqueness-check';
+import { BoldMethodologySlug } from '@carrot-fndn/shared/methodologies/bold/types';
+
+export const handler = certificateUniquenessCheckLambda(
+  RECYCLED_ID,
+  BoldMethodologySlug.RECYCLING,
+);


### PR DESCRIPTION
### Summary

Call the `certificateUniquenessCheck` lambda with the correct parameters.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the configuration of the certificate uniqueness check process to improve clarity and maintainability. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->