### PR TITLE
fix(shared): add required text property to Slack payload in send-slack-message action

### DIFF
--- a/.github/actions/send-slack-message/action.yaml
+++ b/.github/actions/send-slack-message/action.yaml
@@ -20,7 +20,7 @@ runs:
       with:
         payload: |
           {
+            "text": "${{ inputs.message }}",
             "author": "${{ github.actor }}",
-            "run_url": "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            "message": "${{ inputs.message }}"
+            "run_url": "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }


### PR DESCRIPTION
### Summary

Fixes the Slack message action by adding the required `text` property to the payload, resolving the `no_text` error from Slack's webhook API.

### Details

- Added `text` property to the payload in `.github/actions/send-slack-message/action.yaml`.
- Ensures Slack messages are delivered as expected when the action is triggered.

### Related links

- [Slack API docs: Incoming Webhooks](https://api.slack.com/messaging/webhooks)
- [GitHub Actions run](https://github.com/carrot-foundation/methodology-rules/actions/runs/${{ github.run_id }})

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Slack notification formatting to improve message delivery in Slack channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->