### PR TITLE
fix: remove unnecessary environment and handle aws credentials in deploy

### DIFF
--- a/.github/actions/prepare-to-run-nx/action.yaml
+++ b/.github/actions/prepare-to-run-nx/action.yaml
@@ -4,12 +4,6 @@ description: Runs all required steps to prepare runner to run a Nx target
 permissions: write-all # required for AWS credentials
 
 inputs:
-  environment:
-    description: The environment to run the Nx target in
-    required: true
-  aws_account_id_production:
-    description: AWS Account ID for production environment
-    required: true
   aws_account_id_development:
     description: AWS Account ID for development environment
     required: true
@@ -20,24 +14,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set AWS Account ID
-      id: set-aws-account
-      shell: bash
+    - name: Configure AWS Credentials
       env:
         AWS_REGION: us-east-1
-      run: |
-        if [[ "${{ inputs.environment }}" == "production" ]]; then
-            echo "AWS_ACCOUNT_ID=${{ inputs.aws_account_id_production }}" >> $GITHUB_ENV
-          else
-            echo "AWS_ACCOUNT_ID=${{ inputs.aws_account_id_development }}" >> $GITHUB_ENV
-          fi
-        echo "AWS_REGION=$AWS_REGION" >> $GITHUB_ENV
-        echo "NX_KEY=${{ inputs.nx_key }}" >> $GITHUB_ENV
-
-    - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
-        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/GitHubActions-methodology-rules
+        role-to-assume: arn:aws:iam::${{ inputs.aws_account_id_development }}:role/GitHubActions-methodology-rules
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Derive appropriate SHAs for base and head for `nx affected` commands

--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -30,8 +30,6 @@ jobs:
           fetch-depth: 0 # required for Nx affected
       - uses: ./.github/actions/prepare-to-run-nx
         with:
-          environment: development
-          aws_account_id_production: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
           aws_account_id_development: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
           nx_key: ${{ secrets.NX_KEY }}
 
@@ -53,8 +51,6 @@ jobs:
           fetch-depth: 0 # required for Nx affected
       - uses: ./.github/actions/prepare-to-run-nx
         with:
-          environment: development
-          aws_account_id_production: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
           aws_account_id_development: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
           nx_key: ${{ secrets.NX_KEY }}
 
@@ -77,8 +73,6 @@ jobs:
 
       - uses: ./.github/actions/prepare-to-run-nx
         with:
-          environment: development
-          aws_account_id_production: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
           aws_account_id_development: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
           nx_key: ${{ secrets.NX_KEY }}
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,10 +37,23 @@ jobs:
 
       - uses: ./.github/actions/prepare-to-run-nx
         with:
-          environment: ${{ matrix.environment }}
-          aws_account_id_production: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
           aws_account_id_development: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
           nx_key: ${{ secrets.NX_KEY }}
+
+      - name: Set AWS Account ID
+        id: set-aws-account
+        run: |
+          if [[ "${{ matrix.environment }}" == "production" ]]; then
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}" >> $GITHUB_ENV
+          else
+            echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}" >> $GITHUB_ENV
+          fi
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/GitHubActions-methodology-rules
+          aws-region: ${{ env.AWS_REGION }}
 
       - run: pnpm upload-lambdas-and-metadata ${{ matrix.environment }}
 


### PR DESCRIPTION
### Summary

Refactor AWS account selection and credentials configuration in GitHub Actions for Nx workflows.

### Details

- **Removed** the `environment` and `aws_account_id_production` inputs from the `.github/actions/prepare-to-run-nx/action.yaml` composite action.
- The action now only requires the development AWS account ID, simplifying its interface.
- The logic for selecting the correct AWS account (production or development) and configuring AWS credentials has been **moved out of the composite action** and into the workflow files themselves.
- In `.github/workflows/deploy.yaml`, a new step sets the `AWS_ACCOUNT_ID` environment variable based on the matrix environment, and credentials are configured accordingly.
- This change ensures that production credentials are only set when actually deploying to production, improving clarity and reducing the risk of misconfiguration.
- All affected workflows (`backend-check.yaml`, `deploy.yaml`) have been updated to match the new action interface and credential setup flow.
- 
---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified workflow and action inputs by removing unnecessary environment and production account parameters.
  - Centralized AWS account selection and credentials configuration within the deployment workflow for improved clarity and maintainability.
  - Streamlined backend check and deployment processes to consistently use development account inputs where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->