### PR TITLE
chore: add USD suffix on credit price

### DIFF
--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -22,6 +22,7 @@ import {
   formatDecimalPlaces,
   formatPercentage,
   getAggregateParticipantKey,
+  parseUnitPriceNumberPartOrReturnUndefined,
 } from './rewards-distribution.helpers';
 
 describe('Rewards Distribution Helpers', () => {
@@ -481,6 +482,68 @@ describe('Rewards Distribution Helpers', () => {
 
       expect(actors.get(participantType1)?.actorType).toEqual(actorType1);
       expect(actors.get(participantType2)?.actorType).toEqual(actorType2);
+    });
+  });
+
+  describe('parseUnitPriceNumberPartOrReturnUndefined', () => {
+    it('should parse a valid unit price string with USD', () => {
+      expect(parseUnitPriceNumberPartOrReturnUndefined('0.15333 USD')).toBe(
+        0.153_33,
+      );
+      expect(parseUnitPriceNumberPartOrReturnUndefined('1 USD')).toBe(1);
+      expect(parseUnitPriceNumberPartOrReturnUndefined('123.456789 USD')).toBe(
+        123.456_789,
+      );
+    });
+
+    it('should return undefined for missing USD', () => {
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('0.15333'),
+      ).toBeUndefined();
+      expect(parseUnitPriceNumberPartOrReturnUndefined('1')).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('123.456789'),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined for empty or non-string input', () => {
+      expect(parseUnitPriceNumberPartOrReturnUndefined('')).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined(undefined),
+      ).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined(null as any),
+      ).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined(123 as any),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined for zero or negative values', () => {
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('0 USD'),
+      ).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('-1 USD'),
+      ).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('-0.1 USD'),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined for malformed strings', () => {
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('USD 0.15333'),
+      ).toBeUndefined();
+      expect(parseUnitPriceNumberPartOrReturnUndefined('USD')).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('0.15333 usd'),
+      ).toBeUndefined();
+      expect(
+        parseUnitPriceNumberPartOrReturnUndefined('USD 1'),
+      ).toBeUndefined();
+      expect(parseUnitPriceNumberPartOrReturnUndefined('1USD')).toBeUndefined();
+      expect(parseUnitPriceNumberPartOrReturnUndefined('USD1')).toBeUndefined();
     });
   });
 });

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -1,7 +1,14 @@
-import { sumBigNumbers } from '@carrot-fndn/shared/helpers';
+import {
+  assertNonEmptyString,
+  sumBigNumbers,
+} from '@carrot-fndn/shared/helpers';
 import { RewardsDistributionActorType } from '@carrot-fndn/shared/methodologies/bold/types';
-import { type NonEmptyString } from '@carrot-fndn/shared/types';
+import {
+  type NonEmptyString,
+  NonZeroPositive,
+} from '@carrot-fndn/shared/types';
 import BigNumber from 'bignumber.js';
+import { is } from 'typia';
 
 import type {
   ActorsByType,
@@ -11,6 +18,10 @@ import type {
   RewardsDistribution,
   RuleSubject,
 } from './rewards-distribution.types';
+
+import { MethodologyDocumentEventAttributeValue } from './../../../../../../shared/types/src/methodology/methodology-document-event.types';
+
+const DOLLAR_REGEX = /^(\d+(?:\.\d{1,6})?)\sUSD$/;
 
 export const formatPercentage = (percentage: BigNumber): BigNumber =>
   percentage.dividedBy(100);
@@ -222,4 +233,28 @@ export const calculateRewardsDistribution = (
       percentage: remainder.percentage.toString(),
     },
   };
+};
+
+export const parseUnitPriceNumberPartOrReturnUndefined = (
+  unitPrice: MethodologyDocumentEventAttributeValue | undefined,
+): NonZeroPositive | undefined => {
+  if (!is<NonEmptyString>(unitPrice)) {
+    return undefined;
+  }
+
+  const match = unitPrice.match(DOLLAR_REGEX);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const unitPriceNumberPart = assertNonEmptyString(match[1]);
+
+  const rawUnitPrice = Number(unitPriceNumberPart);
+
+  if (!is<NonZeroPositive>(rawUnitPrice)) {
+    return undefined;
+  }
+
+  return rawUnitPrice;
 };

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -37,7 +37,7 @@ describe('RewardsDistributionProcessor', () => {
         expectedActorsResult,
         expectedCertificateTotalValue,
         massIdCertificateDocuments,
-        unitPrice,
+        unitPriceNumberPart,
       }) => {
         spyOnLoadDocument(creditOrderDocument);
         spyOnDocumentQueryServiceLoad(
@@ -86,7 +86,7 @@ describe('RewardsDistributionProcessor', () => {
         expect(
           Math.abs(totalAmount.minus(totalCreditPrice).toNumber()) < 0.000_005,
         ).toBeTruthy();
-        expect(creditUnitPrice).toBe(String(unitPrice));
+        expect(creditUnitPrice).toBe(String(unitPriceNumberPart));
         expect(massIdCertificateTotalValue).toBe(
           String(expectedCertificateTotalValue),
         );

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -55,7 +55,8 @@ type TestCase = {
   massIdCertificateDocuments: CertificateDocument[];
   resultStatus: RuleOutputStatus;
   scenario: string;
-  unitPrice: number;
+  unitPrice: string;
+  unitPriceNumberPart: string;
 };
 
 const { CREDIT_ORDER, RECYCLED_ID } = DocumentType;
@@ -74,7 +75,8 @@ const {
   WASTE_GENERATOR,
 } = RewardsDistributionActorType;
 
-const UNIT_PRICE_VALUE = 0.153_33;
+const UNIT_PRICE_NUMBER_PART = '0.15333';
+const UNIT_PRICE_VALUE = `${UNIT_PRICE_NUMBER_PART} USD`;
 
 const DEFAULT_REWARDS = {
   [APPOINTED_NGO]: '0',
@@ -545,6 +547,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     resultStatus: RuleOutputStatus.APPROVED,
     scenario: 'single certificate with equal distribution',
     unitPrice: UNIT_PRICE_VALUE,
+    unitPriceNumberPart: UNIT_PRICE_NUMBER_PART,
   },
   {
     creditOrderDocument: documents.multiHauler.creditOrderDocument,
@@ -555,6 +558,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     resultStatus: RuleOutputStatus.APPROVED,
     scenario: 'single certificate with multiple HAULER participants',
     unitPrice: UNIT_PRICE_VALUE,
+    unitPriceNumberPart: UNIT_PRICE_NUMBER_PART,
   },
   {
     creditOrderDocument: documents.multipleCertificates.creditOrderDocument,
@@ -565,6 +569,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     resultStatus: RuleOutputStatus.APPROVED,
     scenario: 'multiple certificates with the same participants',
     unitPrice: UNIT_PRICE_VALUE,
+    unitPriceNumberPart: UNIT_PRICE_NUMBER_PART,
   },
 ];
 

--- a/libs/shared/helpers/src/assert.typia.spec.ts
+++ b/libs/shared/helpers/src/assert.typia.spec.ts
@@ -1,0 +1,23 @@
+import { TypeGuardError } from 'typia';
+
+import { assertNonEmptyString } from './assert.typia';
+
+describe('assertNonEmptyString', () => {
+  it('should return the string if it is non-empty', () => {
+    expect(assertNonEmptyString('hello')).toBe('hello');
+    expect(assertNonEmptyString('a')).toBe('a');
+    expect(assertNonEmptyString('  space  ')).toBe('  space  ');
+  });
+
+  it('should throw TypeGuardError for empty string', () => {
+    expect(() => assertNonEmptyString('')).toThrow(TypeGuardError);
+  });
+
+  it('should throw TypeGuardError for non-string values', () => {
+    const invalidValues = [null, undefined, 123, {}, [], true, false];
+
+    for (const value of invalidValues) {
+      expect(() => assertNonEmptyString(value)).toThrow(TypeGuardError);
+    }
+  });
+});

--- a/libs/shared/helpers/src/assert.typia.ts
+++ b/libs/shared/helpers/src/assert.typia.ts
@@ -1,0 +1,4 @@
+import { NonEmptyString } from '@carrot-fndn/shared/types';
+import { createAssert } from 'typia';
+
+export const assertNonEmptyString = createAssert<NonEmptyString>();

--- a/libs/shared/helpers/src/index.ts
+++ b/libs/shared/helpers/src/index.ts
@@ -1,4 +1,5 @@
 export * from './array.helpers';
+export * from './assert.typia';
 export * from './calculate-distance-between-coordinates';
 export * from './common.helpers';
 export * from './document.helpers';


### PR DESCRIPTION
### Summary

Parse credit price with USD suffix, as this is how it is stored in the document.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a utility to parse and validate unit prices from strings formatted with a "USD" suffix, ensuring only positive, non-zero values are accepted.
	- Added a type assertion helper to enforce non-empty string validation at runtime.

- **Bug Fixes**
	- Corrected a method name to use proper casing for improved clarity and consistency.

- **Tests**
	- Expanded test coverage for unit price parsing and non-empty string assertions.
	- Updated and extended test cases to reflect new unit price string formats and validation logic.

- **Chores**
	- Updated type definitions and exports to support new helpers and test structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->