### PR TITLE
refactor(rule): remove parseUnitPriceNumberPartOrReturnUndefined function and update related tests

### DIFF
--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -22,7 +22,6 @@ import {
   formatDecimalPlaces,
   formatPercentage,
   getAggregateParticipantKey,
-  parseUnitPriceNumberPartOrReturnUndefined,
 } from './rewards-distribution.helpers';
 
 describe('Rewards Distribution Helpers', () => {
@@ -482,68 +481,6 @@ describe('Rewards Distribution Helpers', () => {
 
       expect(actors.get(participantType1)?.actorType).toEqual(actorType1);
       expect(actors.get(participantType2)?.actorType).toEqual(actorType2);
-    });
-  });
-
-  describe('parseUnitPriceNumberPartOrReturnUndefined', () => {
-    it('should parse a valid unit price string with USD', () => {
-      expect(parseUnitPriceNumberPartOrReturnUndefined('0.15333 USD')).toBe(
-        0.153_33,
-      );
-      expect(parseUnitPriceNumberPartOrReturnUndefined('1 USD')).toBe(1);
-      expect(parseUnitPriceNumberPartOrReturnUndefined('123.456789 USD')).toBe(
-        123.456_789,
-      );
-    });
-
-    it('should return undefined for missing USD', () => {
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('0.15333'),
-      ).toBeUndefined();
-      expect(parseUnitPriceNumberPartOrReturnUndefined('1')).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('123.456789'),
-      ).toBeUndefined();
-    });
-
-    it('should return undefined for empty or non-string input', () => {
-      expect(parseUnitPriceNumberPartOrReturnUndefined('')).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined(undefined),
-      ).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined(null as never),
-      ).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined(123 as never),
-      ).toBeUndefined();
-    });
-
-    it('should return undefined for zero or negative values', () => {
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('0 USD'),
-      ).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('-1 USD'),
-      ).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('-0.1 USD'),
-      ).toBeUndefined();
-    });
-
-    it('should return undefined for malformed strings', () => {
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('USD 0.15333'),
-      ).toBeUndefined();
-      expect(parseUnitPriceNumberPartOrReturnUndefined('USD')).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('0.15333 usd'),
-      ).toBeUndefined();
-      expect(
-        parseUnitPriceNumberPartOrReturnUndefined('USD 1'),
-      ).toBeUndefined();
-      expect(parseUnitPriceNumberPartOrReturnUndefined('1USD')).toBeUndefined();
-      expect(parseUnitPriceNumberPartOrReturnUndefined('USD1')).toBeUndefined();
     });
   });
 });

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -234,27 +234,3 @@ export const calculateRewardsDistribution = (
     },
   };
 };
-
-export const parseUnitPriceNumberPartOrReturnUndefined = (
-  unitPrice: MethodologyDocumentEventAttributeValue | undefined,
-): NonZeroPositive | undefined => {
-  if (!is<NonEmptyString>(unitPrice)) {
-    return undefined;
-  }
-
-  const match = unitPrice.match(DOLLAR_REGEX);
-
-  if (!match) {
-    return undefined;
-  }
-
-  const unitPriceNumberPart = assertNonEmptyString(match[1]);
-
-  const rawUnitPrice = Number(unitPriceNumberPart);
-
-  if (!is<NonZeroPositive>(rawUnitPrice)) {
-    return undefined;
-  }
-
-  return rawUnitPrice;
-};

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -1,16 +1,8 @@
-import type {
-  MethodologyDocumentEventAttributeValue,
-  NonEmptyString,
-  NonZeroPositive,
-} from '@carrot-fndn/shared/types';
+import type { NonEmptyString } from '@carrot-fndn/shared/types';
 
-import {
-  assertNonEmptyString,
-  sumBigNumbers,
-} from '@carrot-fndn/shared/helpers';
+import { sumBigNumbers } from '@carrot-fndn/shared/helpers';
 import { RewardsDistributionActorType } from '@carrot-fndn/shared/methodologies/bold/types';
 import BigNumber from 'bignumber.js';
-import { is } from 'typia';
 
 import type {
   ActorsByType,
@@ -20,8 +12,6 @@ import type {
   RewardsDistribution,
   RuleSubject,
 } from './rewards-distribution.types';
-
-const DOLLAR_REGEX = /^(\d+(?:\.\d{1,6})?)\sUSD$/;
 
 export const formatPercentage = (percentage: BigNumber): BigNumber =>
   percentage.dividedBy(100);

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -37,7 +37,7 @@ describe('RewardsDistributionProcessor', () => {
         expectedActorsResult,
         expectedCertificateTotalValue,
         massIdCertificateDocuments,
-        unitPriceNumberPart,
+        unitPrice,
       }) => {
         spyOnLoadDocument(creditOrderDocument);
         spyOnDocumentQueryServiceLoad(
@@ -86,7 +86,7 @@ describe('RewardsDistributionProcessor', () => {
         expect(
           Math.abs(totalAmount.minus(totalCreditPrice).toNumber()) < 0.000_005,
         ).toBeTruthy();
-        expect(creditUnitPrice).toBe(String(unitPriceNumberPart));
+        expect(creditUnitPrice).toBe(String(unitPrice));
         expect(massIdCertificateTotalValue).toBe(
           String(expectedCertificateTotalValue),
         );

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.ts
@@ -3,6 +3,7 @@ import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loade
 import {
   isNil,
   isNonEmptyArray,
+  isNonZeroPositive,
   toDocumentKey,
 } from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
@@ -34,10 +35,7 @@ import type {
 } from './rewards-distribution.types';
 
 import { RewardsDistributionProcessorErrors } from './rewards-distribution.errors';
-import {
-  calculateRewardsDistribution,
-  parseUnitPriceNumberPartOrReturnUndefined,
-} from './rewards-distribution.helpers';
+import { calculateRewardsDistribution } from './rewards-distribution.helpers';
 
 const { CREDIT_UNIT_PRICE, RULE_RESULT_DETAILS } = DocumentEventAttributeName;
 
@@ -90,16 +88,13 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
 
     const unitPrice = getEventAttributeValue(creditsEvent, CREDIT_UNIT_PRICE);
 
-    const unitPriceNumberPart =
-      parseUnitPriceNumberPartOrReturnUndefined(unitPrice);
-
-    if (isNil(unitPriceNumberPart)) {
+    if (!isNonZeroPositive(unitPrice)) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.INVALID_CREDIT_UNIT_PRICE,
       );
     }
 
-    return unitPriceNumberPart;
+    return unitPrice;
   }
 
   getRewardsDistributionRuleValue(

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -74,7 +74,7 @@ const {
   WASTE_GENERATOR,
 } = RewardsDistributionActorType;
 
-const UNIT_PRICE_VALUE = 0.15333;
+const UNIT_PRICE_VALUE = 0.153_33;
 
 const DEFAULT_REWARDS = {
   [APPOINTED_NGO]: '0',

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -55,8 +55,7 @@ type TestCase = {
   massIdCertificateDocuments: CertificateDocument[];
   resultStatus: RuleOutputStatus;
   scenario: string;
-  unitPrice: string;
-  unitPriceNumberPart: string;
+  unitPrice: number;
 };
 
 const { CREDIT_ORDER, RECYCLED_ID } = DocumentType;
@@ -75,8 +74,7 @@ const {
   WASTE_GENERATOR,
 } = RewardsDistributionActorType;
 
-const UNIT_PRICE_NUMBER_PART = '0.15333';
-const UNIT_PRICE_VALUE = `${UNIT_PRICE_NUMBER_PART} USD`;
+const UNIT_PRICE_VALUE = 0.15333;
 
 const DEFAULT_REWARDS = {
   [APPOINTED_NGO]: '0',
@@ -547,7 +545,6 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     resultStatus: RuleOutputStatus.APPROVED,
     scenario: 'single certificate with equal distribution',
     unitPrice: UNIT_PRICE_VALUE,
-    unitPriceNumberPart: UNIT_PRICE_NUMBER_PART,
   },
   {
     creditOrderDocument: documents.multiHauler.creditOrderDocument,
@@ -558,7 +555,6 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     resultStatus: RuleOutputStatus.APPROVED,
     scenario: 'single certificate with multiple HAULER participants',
     unitPrice: UNIT_PRICE_VALUE,
-    unitPriceNumberPart: UNIT_PRICE_NUMBER_PART,
   },
   {
     creditOrderDocument: documents.multipleCertificates.creditOrderDocument,
@@ -569,7 +565,6 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     resultStatus: RuleOutputStatus.APPROVED,
     scenario: 'multiple certificates with the same participants',
     unitPrice: UNIT_PRICE_VALUE,
-    unitPriceNumberPart: UNIT_PRICE_NUMBER_PART,
   },
 ];
 


### PR DESCRIPTION
### Summary

Refactor rewards distribution helpers and processor to remove obsolete unit price parsing logic and use direct numeric validation.

### Details

- Removed the `parseUnitPriceNumberPartOrReturnUndefined` helper and all its usages from the rewards distribution helpers and processor.
- Updated the processor to use `isNonZeroPositive` directly for validating the credit unit price.
- Cleaned up related tests and test cases to reflect the new logic and data types (unit price is now a number, not a string with currency).
- Ensured all references and expectations in tests use the updated approach.
- No changes to external behavior; this is an internal refactor for clarity and maintainability.

---

- [x] **I, the PR author, declare that this PR works as expected and does not break any service. I also declare that I gave my best to apply all of the best practices and that I'm leaving the code better than I found it.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified unit price handling by removing parsing logic and related helper functions.
  - Updated validation to use numeric values directly for unit price.
  - Adjusted test cases and type definitions to reflect the use of numeric unit prices.
- **Tests**
  - Removed test suite for the deprecated unit price parsing helper.
  - Updated test parameter names and values to align with the new numeric unit price approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->