### PR TITLE
feat: remove referencedDocument and add bidirectional to DocumentRelation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 local/
 rules-metadata.json
 temp-rules-metadata.json
+
+# Windsurf
+.windsurf

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -24,7 +24,7 @@ import {
   MethodologyDocumentActorType,
   RewardsDistributionActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyActorType } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
@@ -342,7 +342,7 @@ const createTestDocuments = () => {
       ...(standardDocuments.creditOrderDocument.externalEvents ?? []),
       stubDocumentEvent({
         name: RELATED,
-        relatedDocument: mapDocumentReference(
+        relatedDocument: mapDocumentRelation(
           secondDocuments.massIdCertificateDocuments[0]!,
         ),
       }),

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.ts
@@ -15,7 +15,7 @@ import {
   MassIdOrganicSubtype,
   RewardsDistributionActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -63,13 +63,13 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     let methodologyDocument: Document | undefined;
 
     await documentQuery.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
-      if (MASS_ID.matches(documentReference)) {
+      if (MASS_ID.matches(documentRelation)) {
         massIdDocument = document;
       }
 
-      if (METHODOLOGY_DEFINITION.matches(documentReference)) {
+      if (METHODOLOGY_DEFINITION.matches(documentRelation)) {
         methodologyDocument = document;
       }
     });

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
@@ -27,7 +27,7 @@ import {
   DocumentEventName,
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -187,13 +187,13 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
     let massIdDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
-      if (PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference)) {
+      if (PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation)) {
         homologationDocuments.push(document);
       }
 
-      if (MASS_ID.matches(documentReference)) {
+      if (MASS_ID.matches(documentRelation)) {
         massIdDocument = document;
       }
     });

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -28,7 +28,7 @@ import {
   DocumentEventName,
   DocumentSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -139,16 +139,16 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
     let massIdDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
       if (
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference) &&
-        documentReference.subtype === DocumentSubtype.RECYCLER
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation) &&
+        documentRelation.subtype === DocumentSubtype.RECYCLER
       ) {
         recyclerHomologationDocument = document;
       }
 
-      if (MASS_ID.matches(documentReference)) {
+      if (MASS_ID.matches(documentRelation)) {
         massIdDocument = document;
       }
     });

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
@@ -17,7 +17,7 @@ import {
   type Document,
   DocumentCategory,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -147,19 +147,19 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
     const relatedMassIdAuditDocuments: Document[] = [];
 
     await documentQuery?.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
-      if (CREDIT_ORDER_MATCH.matches(documentReference)) {
+      if (CREDIT_ORDER_MATCH.matches(documentRelation)) {
         creditDocuments.push(document);
       }
 
-      if (this.massIdCertificateMatcher.matches(documentReference)) {
+      if (this.massIdCertificateMatcher.matches(documentRelation)) {
         massIdCertificateDocuments.push(document);
       }
 
       if (
-        MASS_ID_AUDIT.matches(documentReference) &&
-        documentReference.documentId !== ruleInput.documentId
+        MASS_ID_AUDIT.matches(documentRelation) &&
+        documentRelation.documentId !== ruleInput.documentId
       ) {
         relatedMassIdAuditDocuments.push(document);
       }

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
@@ -11,7 +11,7 @@ import {
   DocumentEventName,
   DocumentType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentStatus } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
@@ -65,8 +65,7 @@ const massIdWithTwoAuditDocuments: Document = {
     ...(simpleMassIdStubs.massIdDocument.externalEvents ?? []),
     stubDocumentEvent({
       name: RELATED,
-      referencedDocument: undefined,
-      relatedDocument: mapDocumentReference(duplicatedMassIdAuditDocument),
+      relatedDocument: mapDocumentRelation(duplicatedMassIdAuditDocument),
     }),
   ],
 };
@@ -92,8 +91,7 @@ const massIdWithAuditDocumentsForDifferentMethodologies: Document = {
     ...(simpleMassIdStubs.massIdDocument.externalEvents ?? []),
     stubDocumentEvent({
       name: RELATED,
-      referencedDocument: undefined,
-      relatedDocument: mapDocumentReference(massIdAuditForOtherMethodology),
+      relatedDocument: mapDocumentRelation(massIdAuditForOtherMethodology),
     }),
   ],
 };

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-homologations-requirements/src/participant-homologations-requirements.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-homologations-requirements/src/participant-homologations-requirements.processor.ts
@@ -18,7 +18,7 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/matchers';
 import { eventLabelIsAnyOf } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -118,13 +118,13 @@ export class ParticipantHomologationsRequirementsProcessor extends RuleDataProce
     let massIdDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
-      if (MASS_ID.matches(documentReference)) {
+      if (MASS_ID.matches(documentRelation)) {
         massIdDocument = document;
       }
 
-      if (PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference)) {
+      if (PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation)) {
         homologationDocuments.set(document.primaryParticipant.id, document);
       }
     });

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -25,7 +25,7 @@ import {
   DocumentSubtype,
   MassIdOrganicSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -197,23 +197,23 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     let wasteGeneratorHomologationDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
       if (
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference) &&
-        documentReference.subtype === DocumentSubtype.RECYCLER
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation) &&
+        documentRelation.subtype === DocumentSubtype.RECYCLER
       ) {
         recyclerHomologationDocument = document;
       }
 
       if (
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference) &&
-        documentReference.subtype === DocumentSubtype.WASTE_GENERATOR
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation) &&
+        documentRelation.subtype === DocumentSubtype.WASTE_GENERATOR
       ) {
         wasteGeneratorHomologationDocument = document;
       }
 
-      if (MASS_ID.matches(documentReference)) {
+      if (MASS_ID.matches(documentRelation)) {
         massIdDocument = document;
       }
     });

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.constants.ts
@@ -95,7 +95,7 @@ export const WRONG_FORMAT_RESULT_COMMENTS = {
 } as const;
 
 export const NOT_FOUND_RESULT_COMMENTS = {
-  HOMOLOGATION_EVENT: `The referenced "${SCALE_HOMOLOGATION}" event was not found.`,
+  HOMOLOGATION_EVENT: `The related "${SCALE_HOMOLOGATION}" event was not found.`,
   MORE_THAN_TWO_WEIGHING_EVENTS: `More than two "${WEIGHING}" events were found, which is not supported.`,
   NO_WEIGHING_EVENTS: `No "${WEIGHING}" events were found in the document.`,
 } as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -17,7 +17,7 @@ import {
   DocumentEventWeighingCaptureMethod,
   DocumentSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { mapDocumentReference } from '@carrot-fndn/shared/methodologies/bold/utils';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
@@ -169,16 +169,16 @@ export class WeighingProcessor extends RuleDataProcessor {
     let massIdDocument: Document | undefined;
 
     await documentQuery.iterator().each(({ document }) => {
-      const documentReference = mapDocumentReference(document);
+      const documentRelation = mapDocumentRelation(document);
 
       if (
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference) &&
-        documentReference.subtype === DocumentSubtype.RECYCLER
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation) &&
+        documentRelation.subtype === DocumentSubtype.RECYCLER
       ) {
         recyclerHomologationDocument = document;
       }
 
-      if (MASS_ID.matches(documentReference)) {
+      if (MASS_ID.matches(documentRelation)) {
         massIdDocument = document;
       }
     });

--- a/libs/shared/methodologies/bold/io-helpers/src/document-query.service.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document-query.service.spec.ts
@@ -6,7 +6,7 @@ import {
 import {
   stubDocument,
   stubDocumentEvent,
-  stubDocumentReference,
+  stubDocumentRelation,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type Document,
@@ -348,13 +348,12 @@ describe('DocumenQueryService', () => {
     });
 
     it('should return array with relatedDocuments', async () => {
-      const { category, subtype, type } = stubDocumentReference();
+      const { category, subtype, type } = stubDocumentRelation();
       const relatedDocument = stubDocument();
       const document = stubDocument();
 
       document.externalEvents = [
         stubDocumentEvent({
-          referencedDocument: undefined,
           relatedDocument: { category, subtype, type },
         }),
       ];
@@ -392,15 +391,14 @@ describe('DocumenQueryService', () => {
       expect(result).toEqual([relatedDocument]);
     });
 
-    it('should return referencedDocuments in the relatedDocuments array', async () => {
-      const { category, subtype, type } = stubDocumentReference();
-      const referencedDocument = stubDocument();
+    it('should return relatedDocuments with bidirectional false in array', async () => {
+      const { category, subtype, type } = stubDocumentRelation();
+      const relatedDocument = stubDocument();
       const document = stubDocument();
 
       document.externalEvents = [
         stubDocumentEvent({
-          referencedDocument: { category, subtype, type },
-          relatedDocument: undefined,
+          relatedDocument: { bidirectional: false, category, subtype, type },
         }),
       ];
 
@@ -412,7 +410,7 @@ describe('DocumenQueryService', () => {
         .spyOn(provideDocumentLoaderService, 'load')
         .mockResolvedValueOnce(stubDocumentEntity({ document }))
         .mockResolvedValueOnce(
-          stubDocumentEntity({ document: referencedDocument }),
+          stubDocumentEntity({ document: relatedDocument }),
         );
 
       const loaderDocuments = await loadDocuments.load({
@@ -426,7 +424,7 @@ describe('DocumenQueryService', () => {
         .map(({ document: documentLoad }) => documentLoad);
 
       expect(provideDocumentLoaderService.load).toHaveBeenCalledTimes(2);
-      expect(result).toEqual([referencedDocument]);
+      expect(result).toEqual([relatedDocument]);
     });
 
     it('should return empty array when relatedDocuments criteria is array empty', async () => {
@@ -579,7 +577,6 @@ describe('DocumenQueryService', () => {
     it('should return undefined', () => {
       const eventRelationship = loadDocuments['getEventRelationship'](
         stubDocumentEvent({
-          referencedDocument: undefined,
           relatedDocument: undefined,
         }),
       );

--- a/libs/shared/methodologies/bold/io-helpers/src/document-query.service.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document-query.service.ts
@@ -1,7 +1,7 @@
 import type {
   Document,
   DocumentEvent,
-  DocumentReference,
+  DocumentRelation,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { DocumentLoaderService } from '@carrot-fndn/shared/document/loader';
@@ -23,7 +23,7 @@ import type {
 
 import { BaseDocumentQueryService } from './abstract-document-query.service';
 import {
-  isDocumentReference,
+  isDocumentRelation,
   isObject,
   isRelatedDocumentCriteria,
   validateDocument,
@@ -99,7 +99,7 @@ export class DocumentQueryService extends BaseDocumentQueryService<
           const relationship = this.getEventRelationship(event);
 
           if (
-            isDocumentReference(relationship) &&
+            isDocumentRelation(relationship) &&
             matcher.matches(relationship)
           ) {
             documentKeys.push(
@@ -168,15 +168,10 @@ export class DocumentQueryService extends BaseDocumentQueryService<
   }
 
   private getEventRelationship({
-    referencedDocument,
     relatedDocument,
-  }: DocumentEvent): DocumentReference | undefined {
-    if (isDocumentReference(relatedDocument)) {
+  }: DocumentEvent): DocumentRelation | undefined {
+    if (isDocumentRelation(relatedDocument)) {
       return relatedDocument;
-    }
-
-    if (isDocumentReference(referencedDocument)) {
-      return referencedDocument;
     }
 
     return undefined;

--- a/libs/shared/methodologies/bold/io-helpers/src/document-query.service.typia.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document-query.service.typia.ts
@@ -1,11 +1,11 @@
 import type {
   Document,
-  DocumentReference,
+  DocumentRelation,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { createIs, createValidate } from 'typia';
 
-export const isDocumentReference = createIs<DocumentReference>();
+export const isDocumentRelation = createIs<DocumentRelation>();
 export const validateDocument = createValidate<Document>();
 export const isObject = createIs<object>();
 export const isRelatedDocumentCriteria = createIs<{

--- a/libs/shared/methodologies/bold/matchers/src/document.matchers.spec.ts
+++ b/libs/shared/methodologies/bold/matchers/src/document.matchers.spec.ts
@@ -1,4 +1,4 @@
-import { stubDocumentReference } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentCategory,
   DocumentSubtype,
@@ -25,11 +25,11 @@ describe('Document Matchers', () => {
         subtype: DocumentSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         type: DocumentType.ORGANIC,
       };
-      const documentReference = stubDocumentReference(documentMatch);
+      const documentRelation = stubDocumentRelation(documentMatch);
 
       const documentMatcher = new DocumentMatcher(documentMatch);
 
-      const matchesResult = documentMatcher.matches(documentReference);
+      const matchesResult = documentMatcher.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
@@ -40,14 +40,14 @@ describe('Document Matchers', () => {
         subtype: DocumentSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         type: DocumentType.ORGANIC,
       };
-      const documentReference = stubDocumentReference(documentMatch);
+      const documentRelation = stubDocumentRelation(documentMatch);
 
       const documentMatcher = new DocumentMatcher({
         ...documentMatch,
         type: DocumentType.MASS_ID_AUDIT,
       });
 
-      const matchesResult = documentMatcher.matches(documentReference);
+      const matchesResult = documentMatcher.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -55,21 +55,21 @@ describe('Document Matchers', () => {
 
   describe('MASS_ID', () => {
     it('should return true if the document category is Mass ID', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
       });
 
-      const matchesResult = MASS_ID.matches(documentReference);
+      const matchesResult = MASS_ID.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Mass ID', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
       });
 
-      const matchesResult = MASS_ID.matches(documentReference);
+      const matchesResult = MASS_ID.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -77,34 +77,34 @@ describe('Document Matchers', () => {
 
   describe('MASS_ID_AUDIT', () => {
     it('should return true if the document category is Methodology and type is Mass ID Audit', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.MASS_ID_AUDIT,
       });
 
-      const matchesResult = MASS_ID_AUDIT.matches(documentReference);
+      const matchesResult = MASS_ID_AUDIT.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Methodology', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
         type: DocumentType.MASS_ID_AUDIT,
       });
 
-      const matchesResult = MASS_ID_AUDIT.matches(documentReference);
+      const matchesResult = MASS_ID_AUDIT.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
 
     it('should return false if the document type is not Mass ID Audit', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.ORGANIC,
       });
 
-      const matchesResult = MASS_ID_AUDIT.matches(documentReference);
+      const matchesResult = MASS_ID_AUDIT.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -112,34 +112,34 @@ describe('Document Matchers', () => {
 
   describe('RECYCLED_ID', () => {
     it('should return true if the document category is Methodology and type is Recycled ID', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.RECYCLED_ID,
       });
 
-      const matchesResult = RECYCLED_ID.matches(documentReference);
+      const matchesResult = RECYCLED_ID.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Methodology', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
         type: DocumentType.RECYCLED_ID,
       });
 
-      const matchesResult = RECYCLED_ID.matches(documentReference);
+      const matchesResult = RECYCLED_ID.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
 
     it('should return false if the document type is not Recycled ID', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.ORGANIC,
       });
 
-      const matchesResult = RECYCLED_ID.matches(documentReference);
+      const matchesResult = RECYCLED_ID.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -147,34 +147,34 @@ describe('Document Matchers', () => {
 
   describe('METHODOLOGY_DEFINITION', () => {
     it('should return true if the document category is Methodology and type is Definition', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.DEFINITION,
       });
 
-      const matchesResult = METHODOLOGY_DEFINITION.matches(documentReference);
+      const matchesResult = METHODOLOGY_DEFINITION.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Methodology', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
         type: DocumentType.DEFINITION,
       });
 
-      const matchesResult = METHODOLOGY_DEFINITION.matches(documentReference);
+      const matchesResult = METHODOLOGY_DEFINITION.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
 
     it('should return false if the document type is not Definition', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.ORGANIC,
       });
 
-      const matchesResult = METHODOLOGY_DEFINITION.matches(documentReference);
+      const matchesResult = METHODOLOGY_DEFINITION.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -182,40 +182,40 @@ describe('Document Matchers', () => {
 
   describe('PARTICIPANT_HOMOLOGATION_GROUP', () => {
     it('should return true if document matches category, type and subtype', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         subtype: DocumentSubtype.GROUP,
         type: DocumentType.PARTICIPANT_HOMOLOGATION,
       });
 
       const matchesResult =
-        PARTICIPANT_HOMOLOGATION_GROUP.matches(documentReference);
+        PARTICIPANT_HOMOLOGATION_GROUP.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Methodology', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
         subtype: DocumentSubtype.GROUP,
         type: DocumentType.PARTICIPANT_HOMOLOGATION,
       });
 
       const matchesResult =
-        PARTICIPANT_HOMOLOGATION_GROUP.matches(documentReference);
+        PARTICIPANT_HOMOLOGATION_GROUP.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
 
     it('should return false if the document subtype is not Group', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         subtype: DocumentSubtype.TCC,
         type: DocumentType.PARTICIPANT_HOMOLOGATION,
       });
 
       const matchesResult =
-        PARTICIPANT_HOMOLOGATION_GROUP.matches(documentReference);
+        PARTICIPANT_HOMOLOGATION_GROUP.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -223,37 +223,37 @@ describe('Document Matchers', () => {
 
   describe('PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH', () => {
     it('should return true if document matches category and type', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.PARTICIPANT_HOMOLOGATION,
       });
 
       const matchesResult =
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference);
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Methodology', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
         type: DocumentType.PARTICIPANT_HOMOLOGATION,
       });
 
       const matchesResult =
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference);
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
 
     it('should return false if the document type is not Participant Homologation', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.ORGANIC,
       });
 
       const matchesResult =
-        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentReference);
+        PARTICIPANT_HOMOLOGATION_PARTIAL_MATCH.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });
@@ -261,23 +261,23 @@ describe('Document Matchers', () => {
 
   describe('CREDIT_ORDER_MATCH', () => {
     it('should return true if document matches category and type', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.CREDIT_ORDER,
       });
 
-      const matchesResult = CREDIT_ORDER_MATCH.matches(documentReference);
+      const matchesResult = CREDIT_ORDER_MATCH.matches(documentRelation);
 
       expect(matchesResult).toBe(true);
     });
 
     it('should return false if the document category is not Methodology', () => {
-      const documentReference = stubDocumentReference({
+      const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
         type: DocumentType.CREDIT_ORDER,
       });
 
-      const matchesResult = CREDIT_ORDER_MATCH.matches(documentReference);
+      const matchesResult = CREDIT_ORDER_MATCH.matches(documentRelation);
 
       expect(matchesResult).toBe(false);
     });

--- a/libs/shared/methodologies/bold/matchers/src/document.matchers.ts
+++ b/libs/shared/methodologies/bold/matchers/src/document.matchers.ts
@@ -2,7 +2,7 @@ import { pick } from '@carrot-fndn/shared/helpers';
 import {
   type Document,
   DocumentCategory,
-  type DocumentReference,
+  type DocumentRelation,
   DocumentSubtype,
   DocumentType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -20,7 +20,7 @@ export class DocumentMatcher {
     this.match = match;
   }
 
-  matches(document: Omit<DocumentReference, 'id'>): boolean {
+  matches(document: Omit<DocumentRelation, 'id'>): boolean {
     const matchKeys = Object.keys(this.match) as Array<keyof DocumentMatch>;
 
     const objectToMatch = pick(document, ...matchKeys);

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -7,7 +7,7 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
-  type DocumentReference,
+  type DocumentRelation,
   DocumentSubtype,
   DocumentType,
   MassIdDocumentActorType,
@@ -122,7 +122,7 @@ export class BoldStubsBuilder {
 
   private count: number;
 
-  private creditOrderReference?: DocumentReference;
+  private creditOrderRelation?: DocumentRelation;
 
   private readonly massIdActorParticipants: Map<string, MethodologyParticipant>;
 
@@ -133,15 +133,15 @@ export class BoldStubsBuilder {
 
   private massIdAuditDocumentIds: string[];
 
-  private massIdAuditReferences: DocumentReference[] = [];
+  private massIdAuditRelations: DocumentRelation[] = [];
 
   private massIdCertificateDocumentIds: string[];
 
-  private massIdCertificateDocumentReferences: DocumentReference[] = [];
+  private massIdCertificateDocumentRelations: DocumentRelation[] = [];
 
   private massIdDocumentIds: string[];
 
-  private massIdReferences: DocumentReference[] = [];
+  private massIdRelations: DocumentRelation[] = [];
 
   private readonly methodologyActorParticipants: Map<
     string,
@@ -150,15 +150,15 @@ export class BoldStubsBuilder {
 
   private methodologyDocument?: Document;
 
-  private methodologyReference?: DocumentReference;
+  private methodologyRelation?: DocumentRelation;
 
   private participantHomologationGroupDocument?: Document;
 
-  private participantHomologationGroupReference?: DocumentReference;
+  private participantHomologationGroupRelation?: DocumentRelation;
 
   private participantsHomologationDocuments: Map<string, Document> = new Map();
 
-  private participantsHomologationReferences: Map<string, DocumentReference> =
+  private participantsHomologationRelations: Map<string, DocumentRelation> =
     new Map();
 
   constructor(options: BoldStubsBuilderOptions = {}) {
@@ -189,21 +189,20 @@ export class BoldStubsBuilder {
     this.actorsCoordinates = this.initializeActorsCoordinates();
     this.massIdActorParticipantsAddresses = this.initializeActorAddresses();
 
-    this.massIdReferences = this.createMassIdReferences();
-    this.massIdCertificateDocumentReferences =
-      this.createMassIdCertificateDocumentReferences();
-    this.massIdAuditReferences = this.createMassIdAuditReferences();
+    this.massIdRelations = this.createMassIdRelations();
+    this.massIdCertificateDocumentRelations =
+      this.createMassIdCertificateDocumentRelations();
+    this.massIdAuditRelations = this.createMassIdAuditRelations();
   }
 
-  addMassIdCertificateDocumentReferencesToMassIdAuditDocuments(): void {
+  addMassIdCertificateDocumentRelationsToMassIdAuditDocuments(): void {
     this._massIdAuditDocuments = this._massIdAuditDocuments.map(
       (document, index) =>
         this.addExternalEventToDocument(
           document,
           stubDocumentEvent({
             name: RELATED,
-            referencedDocument: undefined,
-            relatedDocument: this.massIdCertificateDocumentReferences[index],
+            relatedDocument: this.massIdCertificateDocumentRelations[index],
           }),
         ),
     );
@@ -272,22 +271,21 @@ export class BoldStubsBuilder {
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
     this.validateCertificateDocumentsExist();
 
-    this.creditOrderReference = this.createCreditOrderDocumentReference();
+    this.creditOrderRelation = this.createCreditOrderDocumentRelation();
     const creditOrderDocument = stubBoldCreditOrderDocument({
       externalEventsMap,
       partialDocument: {
         ...partialDocument,
-        id: this.creditOrderReference.documentId,
+        id: this.creditOrderRelation.documentId,
       },
     });
 
     this._creditOrderDocument = creditOrderDocument;
 
-    this.addCertificatesReferencesToCreditOrderDocument();
+    this.addCertificatesReflationsToCreditOrderDocument();
 
     this._massIdCertificateDocuments = this._massIdCertificateDocuments.map(
-      (document) =>
-        this.addCreditReferenceToMassIdCertificateDocument(document),
+      (document) => this.addCreditRelationToMassIdCertificateDocument(document),
     );
 
     return this;
@@ -307,14 +305,12 @@ export class BoldStubsBuilder {
           externalEventsMap: {
             [LINK]: stubDocumentEvent({
               name: LINK,
-              referencedDocument: this.massIdReferences[index],
-              relatedDocument: undefined,
+              relatedDocument: this.massIdRelations[index],
             }),
             [methodologyEventName]: stubDocumentEventWithMetadataAttributes(
               {
                 name: methodologyEventName,
-                referencedDocument: undefined,
-                relatedDocument: this.methodologyReference,
+                relatedDocument: this.methodologyRelation,
               },
               [[METHODOLOGY_SLUG, BoldMethodologySlug.RECYCLING]],
             ),
@@ -323,13 +319,13 @@ export class BoldStubsBuilder {
           partialDocument: {
             ...partialDocument,
             currentValue: massIdDocument.currentValue,
-            id: this.massIdAuditReferences[index]!.documentId,
+            id: this.massIdAuditRelations[index]!.documentId,
             parentDocumentId: massIdDocument.id,
           },
         }),
     );
 
-    this.addMassIdAuditReferencesToMassIdDocuments();
+    this.addMassIdAuditRelationsToMassIdDocuments();
 
     return this;
   }
@@ -340,8 +336,8 @@ export class BoldStubsBuilder {
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
     this.validateMassIdAuditDocumentsExist();
 
-    this.massIdCertificateDocumentReferences =
-      this.createMassIdCertificateDocumentReferences();
+    this.massIdCertificateDocumentRelations =
+      this.createMassIdCertificateDocumentRelations();
 
     this._massIdCertificateDocuments = this._massIdAuditDocuments.map(
       (auditDocument, index) => {
@@ -356,17 +352,17 @@ export class BoldStubsBuilder {
           externalEventsMap: mergedEventsMap,
           partialDocument: {
             currentValue: auditDocument.currentValue,
-            type: this.massIdCertificateDocumentReferences[index]!.type,
+            type: this.massIdCertificateDocumentRelations[index]!.type,
             ...partialDocument,
-            id: this.massIdCertificateDocumentReferences[index]!.documentId,
+            id: this.massIdCertificateDocumentRelations[index]!.documentId,
             parentDocumentId: auditDocument.id,
           },
         });
       },
     );
 
-    this.addMassIdCertificateDocumentReferencesToMassIdDocuments();
-    this.addMassIdCertificateDocumentReferencesToMassIdAuditDocuments();
+    this.addMassIdCertificateDocumentRelationsToMassIdDocuments();
+    this.addMassIdCertificateDocumentRelationsToMassIdAuditDocuments();
 
     return this;
   }
@@ -396,10 +392,10 @@ export class BoldStubsBuilder {
       this.massIdAuditDocumentIds = newMassIdAuditDocumentIds;
       this.massIdCertificateDocumentIds = newMassIdCertificateDocumentIds;
 
-      this.massIdReferences = this.createMassIdReferences();
-      this.massIdAuditReferences = this.createMassIdAuditReferences();
-      this.massIdCertificateDocumentReferences =
-        this.createMassIdCertificateDocumentReferences();
+      this.massIdRelations = this.createMassIdRelations();
+      this.massIdAuditRelations = this.createMassIdAuditRelations();
+      this.massIdCertificateDocumentRelations =
+        this.createMassIdCertificateDocumentRelations();
     }
 
     const actorEvents = this.createMassIdActorEvents();
@@ -417,7 +413,7 @@ export class BoldStubsBuilder {
         externalEventsMap: mergedEventsMap,
         partialDocument: {
           ...partialDocument,
-          id: this.massIdReferences[index]!.documentId,
+          id: this.massIdRelations[index]!.documentId,
         },
       });
     });
@@ -439,8 +435,7 @@ export class BoldStubsBuilder {
         OUTPUT,
         stubDocumentEvent({
           name: OUTPUT,
-          referencedDocument: undefined,
-          relatedDocument: this.participantHomologationGroupReference!,
+          relatedDocument: this.participantHomologationGroupRelation!,
         }),
       ],
     ]);
@@ -449,13 +444,14 @@ export class BoldStubsBuilder {
       ? defaultEventsMap
       : this.mergeEventsMaps(defaultEventsMap, externalEventsMap);
 
-    this.methodologyReference = {
+    this.methodologyRelation = {
+      bidirectional: false,
       category: METHODOLOGY,
       documentId: faker.string.uuid(),
       type: DEFINITION,
     };
 
-    this.participantHomologationGroupReference = {
+    this.participantHomologationGroupRelation = {
       category: METHODOLOGY,
       documentId: faker.string.uuid(),
       subtype: GROUP,
@@ -464,15 +460,15 @@ export class BoldStubsBuilder {
 
     this.participantHomologationGroupDocument =
       stubParticipantHomologationGroupDocument({
-        id: this.participantHomologationGroupReference.documentId,
-        parentDocumentId: this.methodologyReference.documentId,
+        id: this.participantHomologationGroupRelation.documentId,
+        parentDocumentId: this.methodologyRelation.documentId,
       });
 
     this.methodologyDocument = stubBoldMethodologyDefinitionDocument({
       externalEventsMap: mergedEventsMap,
       partialDocument: {
         ...partialDocument,
-        id: this.methodologyReference.documentId,
+        id: this.methodologyRelation.documentId,
       },
     });
 
@@ -482,8 +478,7 @@ export class BoldStubsBuilder {
           auditDocument,
           stubDocumentEvent({
             name: LINK,
-            referencedDocument: this.methodologyReference,
-            relatedDocument: undefined,
+            relatedDocument: this.methodologyRelation,
           }),
         ),
     );
@@ -497,7 +492,7 @@ export class BoldStubsBuilder {
     this.validateMethodologyDocumentsExist();
 
     for (const subtype of MASS_ID_ACTOR_PARTICIPANTS) {
-      const reference = this.createParticipantHomologationReference(subtype);
+      const relation = this.createParticipantHomologationRelation(subtype);
       const primaryAddress =
         this.massIdActorParticipantsAddresses.get(subtype)!;
       const primaryParticipant = this.massIdActorParticipants.get(subtype)!;
@@ -523,9 +518,9 @@ export class BoldStubsBuilder {
       const documentStub = stubBoldHomologationDocument({
         externalEventsMap: mergedEventsMap,
         partialDocument: {
-          id: reference.documentId,
+          id: relation.documentId,
           parentDocumentId:
-            this.participantHomologationGroupReference!.documentId,
+            this.participantHomologationGroupRelation!.documentId,
           primaryAddress,
           primaryParticipant,
           subtype,
@@ -539,8 +534,7 @@ export class BoldStubsBuilder {
             address: primaryAddress,
             name: OUTPUT,
             participant: primaryParticipant,
-            referencedDocument: undefined,
-            relatedDocument: reference,
+            relatedDocument: relation,
           }),
         );
 
@@ -552,36 +546,34 @@ export class BoldStubsBuilder {
               address: primaryAddress,
               name: LINK,
               participant: primaryParticipant,
-              referencedDocument: reference,
-              relatedDocument: undefined,
+              relatedDocument: { ...relation, bidirectional: false },
             }),
           ),
       );
 
-      this.participantsHomologationReferences.set(subtype, reference);
+      this.participantsHomologationRelations.set(subtype, relation);
       this.participantsHomologationDocuments.set(subtype, documentStub);
     }
 
     return this;
   }
 
-  private addCertificatesReferencesToCreditOrderDocument(): void {
+  private addCertificatesReflationsToCreditOrderDocument(): void {
     this._creditOrderDocument = {
       ...this._creditOrderDocument!,
       externalEvents: [
         ...(this._creditOrderDocument?.externalEvents ?? []),
-        ...this.massIdCertificateDocumentReferences.map((reference) =>
+        ...this.massIdCertificateDocumentRelations.map((relation) =>
           stubDocumentEvent({
             name: RELATED,
-            referencedDocument: undefined,
-            relatedDocument: reference,
+            relatedDocument: relation,
           }),
         ),
       ],
     };
   }
 
-  private addCreditReferenceToMassIdCertificateDocument(
+  private addCreditRelationToMassIdCertificateDocument(
     massIdCertificateDocument: Document,
   ): Document {
     return {
@@ -590,8 +582,7 @@ export class BoldStubsBuilder {
         ...(massIdCertificateDocument.externalEvents ?? []),
         stubDocumentEvent({
           name: RELATED,
-          referencedDocument: undefined,
-          relatedDocument: this.creditOrderReference,
+          relatedDocument: this.creditOrderRelation,
         }),
       ],
     };
@@ -607,33 +598,31 @@ export class BoldStubsBuilder {
     };
   }
 
-  private addMassIdAuditReferencesToMassIdDocuments(): void {
+  private addMassIdAuditRelationsToMassIdDocuments(): void {
     this._massIdDocuments = this._massIdDocuments.map((document, index) =>
       this.addExternalEventToDocument(
         document,
         stubDocumentEvent({
           name: LINK,
-          referencedDocument: undefined,
-          relatedDocument: this.massIdAuditReferences[index],
+          relatedDocument: this.massIdAuditRelations[index],
         }),
       ),
     );
   }
 
-  private addMassIdCertificateDocumentReferencesToMassIdDocuments(): void {
+  private addMassIdCertificateDocumentRelationsToMassIdDocuments(): void {
     this._massIdDocuments = this._massIdDocuments.map((document, index) =>
       this.addExternalEventToDocument(
         document,
         stubDocumentEvent({
           name: RELATED,
-          referencedDocument: undefined,
-          relatedDocument: this.massIdCertificateDocumentReferences[index],
+          relatedDocument: this.massIdCertificateDocumentRelations[index],
         }),
       ),
     );
   }
 
-  private createCreditOrderDocumentReference(): DocumentReference {
+  private createCreditOrderDocumentRelation(): DocumentRelation {
     return {
       category: METHODOLOGY,
       documentId: faker.string.uuid(),
@@ -651,24 +640,21 @@ export class BoldStubsBuilder {
         MASS_ID,
         stubDocumentEvent({
           name: MASS_ID,
-          referencedDocument: undefined,
-          relatedDocument: this.massIdReferences[index]!,
+          relatedDocument: this.massIdRelations[index]!,
         }),
       ],
       [
         MASS_ID_AUDIT,
         stubDocumentEvent({
           name: MASS_ID_AUDIT,
-          referencedDocument: undefined,
-          relatedDocument: this.massIdAuditReferences[index]!,
+          relatedDocument: this.massIdAuditRelations[index]!,
         }),
       ],
       [
         methodologyEventName,
         stubDocumentEvent({
           name: methodologyEventName,
-          referencedDocument: undefined,
-          relatedDocument: this.methodologyReference,
+          relatedDocument: this.methodologyRelation,
         }),
       ],
     ]);
@@ -696,8 +682,7 @@ export class BoldStubsBuilder {
         OUTPUT,
         stubDocumentEvent({
           name: OUTPUT,
-          referencedDocument: undefined,
-          relatedDocument: this.massIdAuditReferences[index],
+          relatedDocument: this.massIdAuditRelations[index],
         }),
       ],
       [
@@ -731,7 +716,7 @@ export class BoldStubsBuilder {
     );
   }
 
-  private createMassIdAuditReferences(): DocumentReference[] {
+  private createMassIdAuditRelations(): DocumentRelation[] {
     return this.massIdAuditDocumentIds.map((documentId) => ({
       category: METHODOLOGY,
       documentId,
@@ -740,7 +725,7 @@ export class BoldStubsBuilder {
     }));
   }
 
-  private createMassIdCertificateDocumentReferences(): DocumentReference[] {
+  private createMassIdCertificateDocumentRelations(): DocumentRelation[] {
     return this.massIdCertificateDocumentIds.map((documentId) => ({
       category: METHODOLOGY,
       documentId,
@@ -748,8 +733,9 @@ export class BoldStubsBuilder {
     }));
   }
 
-  private createMassIdReferences(): DocumentReference[] {
+  private createMassIdRelations(): DocumentRelation[] {
     return this.massIdDocumentIds.map((documentId) => ({
+      bidirectional: false,
       category: MASS_ID,
       documentId,
       subtype: FOOD_FOOD_WASTE_AND_BEVERAGES,
@@ -773,9 +759,9 @@ export class BoldStubsBuilder {
     );
   }
 
-  private createParticipantHomologationReference(
+  private createParticipantHomologationRelation(
     subtype: string,
-  ): DocumentReference {
+  ): DocumentRelation {
     return {
       category: METHODOLOGY,
       documentId: faker.string.uuid(),
@@ -894,8 +880,8 @@ export class BoldStubsBuilder {
 
   private validateMethodologyDocumentsExist(): void {
     if (
-      isNil(this.methodologyReference) ||
-      isNil(this.participantHomologationGroupReference) ||
+      isNil(this.methodologyRelation) ||
+      isNil(this.participantHomologationGroupRelation) ||
       isNil(this.participantHomologationGroupDocument)
     ) {
       throw new Error(

--- a/libs/shared/methodologies/bold/testing/src/stubs/document-event.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/stubs/document-event.stubs.ts
@@ -5,7 +5,7 @@ import {
   type DocumentEventAttribute,
   DocumentEventAttributeName,
   DocumentEventName,
-  type DocumentReference,
+  type DocumentRelation,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type AnyObject,
@@ -32,22 +32,13 @@ export const stubDocumentEvent = (
   address: stubAddress(partialEvent.address),
   author: stubAuthor(partialEvent.author),
   participant: stubParticipant(partialEvent.participant),
-  referencedDocument: isPropertyOverridenWithUndefined(
-    partialEvent,
-    'referencedDocument',
-  )
-    ? undefined
-    : {
-        ...random<DocumentReference>(),
-        ...partialEvent.referencedDocument,
-      },
   relatedDocument: isPropertyOverridenWithUndefined(
     partialEvent,
     'relatedDocument',
   )
     ? undefined
     : {
-        ...random<DocumentReference>(),
+        ...random<DocumentRelation>(),
         ...partialEvent.relatedDocument,
       },
 });

--- a/libs/shared/methodologies/bold/testing/src/stubs/document.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/stubs/document.stubs.ts
@@ -4,7 +4,7 @@ import {
   type Document,
   DocumentCategory,
   type DocumentEvent,
-  type DocumentReference,
+  type DocumentRelation,
   DocumentSubtype,
   DocumentType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -38,10 +38,10 @@ export const stubDocument = (
   };
 };
 
-export const stubDocumentReference = (
-  partial?: Partial<DocumentReference>,
-): DocumentReference => ({
-  ...random<Required<DocumentReference>>(),
+export const stubDocumentRelation = (
+  partial?: Partial<DocumentRelation>,
+): DocumentRelation => ({
+  ...random<Required<DocumentRelation>>(),
   ...partial,
 });
 

--- a/libs/shared/methodologies/bold/types/src/document-event.types.ts
+++ b/libs/shared/methodologies/bold/types/src/document-event.types.ts
@@ -2,7 +2,7 @@ import type {
   MethodologyDocumentEvent,
   MethodologyDocumentEventAttribute,
   MethodologyDocumentEventMetadata,
-  MethodologyDocumentReference,
+  MethodologyDocumentRelation,
 } from '@carrot-fndn/shared/types';
 
 import type {
@@ -16,8 +16,7 @@ import type {
 export interface DocumentEvent extends MethodologyDocumentEvent {
   metadata?: DocumentEventMetadata | undefined;
   name: DocumentEventName | string;
-  referencedDocument?: DocumentReference | undefined;
-  relatedDocument?: DocumentReference | undefined;
+  relatedDocument?: DocumentRelation | undefined;
 }
 
 export interface DocumentEventAttribute
@@ -30,7 +29,8 @@ export interface DocumentEventMetadata
   attributes?: DocumentEventAttribute[] | undefined;
 }
 
-export interface DocumentReference extends MethodologyDocumentReference {
+export interface DocumentRelation extends MethodologyDocumentRelation {
+  bidirectional?: boolean | undefined;
   category?: DocumentCategory | string | undefined;
   subtype?: DocumentSubtype | string | undefined;
   type?: DocumentType | string | undefined;

--- a/libs/shared/methodologies/bold/utils/src/document.mappers.spec.ts
+++ b/libs/shared/methodologies/bold/utils/src/document.mappers.spec.ts
@@ -1,12 +1,12 @@
-import type { DocumentReference } from '@carrot-fndn/shared/methodologies/bold/types';
+import type { DocumentRelation } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { stubDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { faker } from '@faker-js/faker';
 
-import { mapDocumentReference } from './document.mappers';
+import { mapDocumentRelation } from './document.mappers';
 
 describe('Document Mappers', () => {
-  describe('mapDocumentReference', () => {
+  describe('mapDocumentRelation', () => {
     it('should return id, category, type and subtype', () => {
       const document = stubDocument({
         category: faker.string.sample(),
@@ -15,9 +15,9 @@ describe('Document Mappers', () => {
         type: faker.string.sample(),
       });
 
-      const result = mapDocumentReference(document);
+      const result = mapDocumentRelation(document);
 
-      const expected: DocumentReference = {
+      const expected: DocumentRelation = {
         category: document.category,
         documentId: document.id,
         subtype: document.subtype,

--- a/libs/shared/methodologies/bold/utils/src/document.mappers.ts
+++ b/libs/shared/methodologies/bold/utils/src/document.mappers.ts
@@ -1,12 +1,10 @@
 import { pick } from '@carrot-fndn/shared/helpers';
 import {
   type Document,
-  type DocumentReference,
+  type DocumentRelation,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
-export const mapDocumentReference = (
-  document: Document,
-): DocumentReference => ({
+export const mapDocumentRelation = (document: Document): DocumentRelation => ({
   ...pick(document, 'category', 'subtype', 'type'),
   documentId: document.id,
 });

--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -46,8 +46,7 @@ export interface MethodologyDocumentEvent {
   preserveSensitiveData?: boolean | undefined;
   propagatedFrom?: undefined | UnknownObject;
   propagateEvent?: boolean | undefined;
-  referencedDocument?: MethodologyDocumentReference | undefined;
-  relatedDocument?: MethodologyDocumentReference | undefined;
+  relatedDocument?: MethodologyDocumentRelation | undefined;
   target?: undefined | UnknownObject;
   updates?: undefined | UnknownObject;
   value?: (number & tags.Minimum<0>) | undefined;
@@ -90,7 +89,7 @@ export interface MethodologyDocumentEventMetadata {
   attributes?: MethodologyDocumentEventAttribute[] | undefined;
 }
 
-export interface MethodologyDocumentReference {
+export interface MethodologyDocumentRelation {
   category?: string | undefined;
   documentId: string;
   subtype?: string | undefined;


### PR DESCRIPTION
### 🧾 Summary

Remove the referencedDocument property from all relevant types and code, and introduce the bidirectional property to DocumentRelation.

### 🦩 Context

This change is part of an ongoing effort to simplify document relationships in the methodology rules engine and provide more explicit modeling of bidirectional relations.

### 🧱 Scope of this PR

- Removes referencedDocument from types, stubs, and processors.
- Updates relatedDocument to use DocumentRelation (with bidirectional instead referencedDocument).
- Refactors tests, builders, and mappers to match.
- Does not address any unrelated features or bug fixes.

### 🦺 How to test

- Run all unit and integration tests (`nx test`).
- Ensure that all document event processing still works as expected.
- Validate that new bidirectional property is handled correctly in all relevant places.

### 🧠 Considerations for Review

- Ensure no lingering references to referencedDocument remain.
- Confirm that bidirectional is optional and correctly typed.
- Review for unintended side effects in document event logic.

---

- [X] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I a
### 🧱 Scope of this PR

- Removes referencedDocument**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated terminology throughout the application, replacing "Document Reference" with "Document Relation" in all user-facing document relationships.
  - Adjusted related document handling to use the new "relation" structure, including changes to event properties and test scenarios.
  - Removed references to "referencedDocument" in document events; all document relationships are now managed via "relatedDocument".
  - Added a new optional "bidirectional" property to document relations.
- **Chores**
  - Updated `.gitignore` to exclude Windsurf tool files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->