### PR TITLE
Rename preventedEmissions to preventedCo2e in processor and test cases

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -135,7 +135,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         massIdDocumentValue,
       ),
       resultContent: {
-        preventedEmissions,
+        preventedCo2e: preventedEmissions,
       },
       resultStatus: RuleOutputStatus.PASSED,
     };

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -109,7 +109,7 @@ export const preventedEmissionsTestCases = [
       massIdDocumentValue,
     ),
     resultContent: {
-      preventedEmissions: expectedPreventedEmissions,
+      preventedCo2e: expectedPreventedEmissions,
       ruleSubject: {
         exceedingEmissionCoefficient,
         massIdDocumentValue,


### PR DESCRIPTION
### 🧾 Summary

Renamed all occurrences of `preventedEmissions` to `preventedCo2e` in the processor and related test cases to reflect request changes about naming conventions.

### 🧩 Context

This change standardizes the naming convention for prevented emissions, making it clearer that the value represents CO2e. It is part of ongoing refactoring for better code readability and maintainability.

### 🧱 Scope of this PR

- Updated the processor to use `preventedCo2e` instead of `preventedEmissions`.
- Updated test cases to match the new naming.
- No other logic or files were changed.

### 🧪 How to test

- Run all existing tests to ensure they pass.
- Verify that the processor and test cases reference `preventedCo2e`.

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the output field name for prevented emissions from "preventedEmissions" to "preventedCo2e" to improve clarity and consistency in results and test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->