### PR TITLE
Update participant document lookup to use primaryParticipant.id in Geolocation rule

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
@@ -17,8 +17,7 @@ import {
   getHomologatedAddressByParticipantId,
 } from './geolocation-and-address-precision.helpers';
 
-const { FACILITY_ADDRESS, LEGAL_AND_ADMINISTRATIVE_COMPLIANCE } =
-  DocumentEventName;
+const { FACILITY_ADDRESS } = DocumentEventName;
 const { CAPTURED_GPS_LATITUDE, CAPTURED_GPS_LONGITUDE } =
   DocumentEventAttributeName;
 
@@ -27,12 +26,6 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
     it('should return the homologated address by participant id', () => {
       const participantId = faker.string.uuid();
       const addressId = faker.string.uuid();
-
-      const legalAndAdministrativeComplianceEvent = stubDocumentEvent({
-        address: stubAddress({ id: addressId }),
-        name: LEGAL_AND_ADMINISTRATIVE_COMPLIANCE,
-        participant: stubParticipant({ id: participantId }),
-      });
 
       const documentStub = stubBoldHomologationDocument({
         externalEventsMap: new Map([
@@ -43,31 +36,18 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
               name: FACILITY_ADDRESS,
             }),
           ],
-          [
-            LEGAL_AND_ADMINISTRATIVE_COMPLIANCE,
-            legalAndAdministrativeComplianceEvent,
-          ],
         ]),
+        partialDocument: {
+          primaryParticipant: stubParticipant({ id: participantId }),
+        },
       });
 
       const result = getHomologatedAddressByParticipantId(participantId, [
         documentStub,
-        ...stubArray(() =>
-          stubBoldHomologationDocument({
-            externalEventsMap: new Map([
-              [
-                FACILITY_ADDRESS,
-                stubDocumentEvent({
-                  address: stubAddress({ id: addressId }),
-                  name: FACILITY_ADDRESS,
-                }),
-              ],
-            ]),
-          }),
-        ),
+        ...stubArray(() => stubBoldHomologationDocument()),
       ]);
 
-      expect(result?.id).toBe(legalAndAdministrativeComplianceEvent.address.id);
+      expect(result?.id).toBe(addressId);
     });
 
     it('should return undefined if the participant has no homologated address', () => {

--- a/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.spec.ts
@@ -1,5 +1,4 @@
 import {
-  stubDocumentEvent,
   stubDocumentEventWithMetadataAttributes,
   stubParticipantHomologationDocument,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
@@ -152,19 +151,10 @@ describe('Homologation Document Helpers', () => {
   describe('getParticipantHomologationDocumentByParticipantId', () => {
     it('should return the homologation document for the given participant id', () => {
       const participantId = faker.string.uuid();
-      const homologationContextEvent = stubDocumentEvent({
-        name: DocumentEventName.LEGAL_AND_ADMINISTRATIVE_COMPLIANCE,
-      });
       const document = stubParticipantHomologationDocument({
-        externalEvents: [
-          {
-            ...homologationContextEvent,
-            participant: {
-              ...homologationContextEvent.participant,
-              id: participantId,
-            },
-          },
-        ],
+        primaryParticipant: {
+          id: participantId,
+        },
       });
 
       const result = getParticipantHomologationDocumentByParticipantId({

--- a/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.ts
+++ b/libs/shared/methodologies/bold/helpers/src/homologation-document.helpers.ts
@@ -17,13 +17,9 @@ export const getParticipantHomologationDocumentByParticipantId = ({
   homologationDocuments: Document[];
   participantId: NonEmptyString;
 }): Document | undefined =>
-  homologationDocuments.find((document) => {
-    const event = document.externalEvents?.find(
-      eventNameIsAnyOf([DocumentEventName.LEGAL_AND_ADMINISTRATIVE_COMPLIANCE]),
-    );
-
-    return event?.participant.id === participantId;
-  });
+  homologationDocuments.find(
+    (document) => document.primaryParticipant.id === participantId,
+  );
 
 export const isHomologationValid = (document: Document): boolean => {
   const event = document.externalEvents?.find(


### PR DESCRIPTION
### 🧾 Summary

Refactored participant document lookup logic to use the primaryParticipant.id property instead of searching through external events.

### 🧩 Context

This change simplifies and clarifies how participant documents are identified, reducing complexity and potential for errors homologation data structure and metadata updates.

### 🧱 Scope of this PR

This is part of a ongoing effort to stabilize the rule execution after new recent changes.

- Updates helper functions and tests to use primaryParticipant.id for participant document lookup.
- Removes legacy logic that relied on external events for participant identification.
- Only the lookup logic and related tests are updated; no other features or unrelated refactors are included.

### 🧪 How to test

- Run the test suites for affected helpers and ensure all tests pass.

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**