### PR TITLE
Refactor helper to return newest emission and composting metrics instead the first found

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -10,8 +10,8 @@ import {
   isNonZeroPositive,
 } from '@carrot-fndn/shared/helpers';
 import {
-  getLastEmissionAndCompostingMetricsEvent,
   getEventAttributeValue,
+  getLastEmissionAndCompostingMetricsEvent,
 } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   type DocumentQuery,

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -10,7 +10,7 @@ import {
   isNonZeroPositive,
 } from '@carrot-fndn/shared/helpers';
 import {
-  getEmissionAndCompostingMetricsEvent,
+  getLastEmissionAndCompostingMetricsEvent,
   getEventAttributeValue,
 } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
@@ -194,7 +194,7 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
     const valueBeforeSorting = eventBeforeSorting?.value;
     const valueAfterSorting = sortingEvent?.value;
     const emissionAndCompostingMetricsEvent =
-      getEmissionAndCompostingMetricsEvent(recyclerHomologationDocument);
+      getLastEmissionAndCompostingMetricsEvent(recyclerHomologationDocument);
     const sortingFactor = getEventAttributeValue(
       emissionAndCompostingMetricsEvent,
       SORTING_FACTOR,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -8,8 +8,8 @@ import {
   isNonZeroPositive,
 } from '@carrot-fndn/shared/helpers';
 import {
-  getEmissionAndCompostingMetricsEvent,
   getEventAttributeValue,
+  getLastEmissionAndCompostingMetricsEvent,
 } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   type DocumentQuery,
@@ -163,8 +163,8 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     recyclerHomologationDocument,
     wasteGeneratorHomologationDocument,
   }: Documents): RuleSubject {
-    const emissionAndCompostingMetricsEvent =
-      getEmissionAndCompostingMetricsEvent(recyclerHomologationDocument);
+    const lastEmissionAndCompostingMetricsEvent =
+      getLastEmissionAndCompostingMetricsEvent(recyclerHomologationDocument);
 
     if (!is<MassIdOrganicSubtype>(massIdDocument.subtype)) {
       throw this.processorErrors.getKnownError(
@@ -180,7 +180,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
 
     return {
       exceedingEmissionCoefficient: getEventAttributeValue(
-        emissionAndCompostingMetricsEvent,
+        lastEmissionAndCompostingMetricsEvent,
         EXCEEDING_EMISSION_COEFFICIENT,
       ),
       massIdDocumentValue: massIdDocument.currentValue,

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -6,6 +6,7 @@ import {
   stubMassIdDocument,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -14,7 +15,7 @@ import { getYear } from 'date-fns';
 
 import {
   getDocumentEventById,
-  getEmissionAndCompostingMetricsEvent,
+  getLastEmissionAndCompostingMetricsEvent,
   getParticipantActorType,
   getRulesMetadataEvent,
 } from './document.getters';
@@ -29,28 +30,51 @@ const {
 const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
 describe('Document getters', () => {
-  describe('getEmissionAndCompostingMetricsEvent', () => {
-    it('should return the emission and composting metrics event', () => {
-      const emissionAndCompostingMetricsEvent = stubDocumentEvent({
+  describe('getLastEmissionAndCompostingMetricsEvent', () => {
+    it('should return last emission and composting metrics event', () => {
+      const firstEmissionAndCompostingMetricsEvent = stubDocumentEvent({
+        metadata: {
+          attributes: [
+            {
+              isPublic: true,
+              name: DocumentEventAttributeName.REFERENCE_YEAR,
+              value: '2023',
+            },
+          ],
+        },
+        name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
+      });
+
+      const secondEmissionAndCompostingMetricsEvent = stubDocumentEvent({
+        metadata: {
+          attributes: [
+            {
+              isPublic: true,
+              name: DocumentEventAttributeName.REFERENCE_YEAR,
+              value: '2024',
+            },
+          ],
+        },
         name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
       });
 
       const document = stubDocument({
         externalEvents: [
           ...stubArray(() => stubDocumentEvent()),
-          emissionAndCompostingMetricsEvent,
+          firstEmissionAndCompostingMetricsEvent,
+          secondEmissionAndCompostingMetricsEvent,
         ],
       });
 
-      const result = getEmissionAndCompostingMetricsEvent(document);
+      const result = getLastEmissionAndCompostingMetricsEvent(document);
 
-      expect(result).toEqual(emissionAndCompostingMetricsEvent);
+      expect(result).toEqual(secondEmissionAndCompostingMetricsEvent);
     });
 
     it('should return undefined if the emission and composting metrics event is not found', () => {
       const document = stubDocument();
 
-      const result = getEmissionAndCompostingMetricsEvent(document);
+      const result = getLastEmissionAndCompostingMetricsEvent(document);
 
       expect(result).toBeUndefined();
     });

--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -1,21 +1,52 @@
-import { isNonEmptyArray } from '@carrot-fndn/shared/helpers';
+import {
+  assertNonEmptyString,
+  isNonEmptyArray,
+} from '@carrot-fndn/shared/helpers';
 import {
   type Document,
   type DocumentEvent,
+  DocumentEventAttributeName,
   DocumentEventName,
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
+
+import { getEventAttributeValue } from './event.getters';
 
 const { DROP_OFF, EMISSION_AND_COMPOSTING_METRICS, PICK_UP, RULES_METADATA } =
   DocumentEventName;
 const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
-export const getEmissionAndCompostingMetricsEvent = (
+export const getLastEmissionAndCompostingMetricsEvent = (
   document: Document,
-): DocumentEvent | undefined =>
-  document.externalEvents?.find((event) =>
-    event.name.toString().includes(EMISSION_AND_COMPOSTING_METRICS),
+): DocumentEvent | undefined => {
+  const emissionAndCompostingMetricsEvents = document.externalEvents?.filter(
+    (event) => event.name.toString().includes(EMISSION_AND_COMPOSTING_METRICS),
   );
+
+  return emissionAndCompostingMetricsEvents
+    ?.sort((firstEvent, secondEvent) => {
+      const firstReferenceYear = getEventAttributeValue(
+        firstEvent,
+        DocumentEventAttributeName.REFERENCE_YEAR,
+      );
+
+      const numberFirstReferenceYear = Number.parseInt(
+        assertNonEmptyString(firstReferenceYear),
+      );
+
+      const secondReferenceYear = getEventAttributeValue(
+        secondEvent,
+        DocumentEventAttributeName.REFERENCE_YEAR,
+      );
+
+      const numberSecondReferenceYear = Number.parseInt(
+        assertNonEmptyString(secondReferenceYear),
+      );
+
+      return numberSecondReferenceYear - numberFirstReferenceYear;
+    })
+    .at(0);
+};
 
 export const getDocumentEventById = (
   document: Document,

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-participant-homologation.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-participant-homologation.stubs.ts
@@ -43,6 +43,7 @@ const {
   EXCEEDING_EMISSION_COEFFICIENT,
   EXPIRATION_DATE,
   HOMOLOGATION_STATUS,
+  REFERENCE_YEAR,
   SCALE_TYPE,
   SORTING_FACTOR,
 } = DocumentEventAttributeName;
@@ -83,6 +84,10 @@ const defaultEmissionAndCompostingMetricsEventMetadataAttributes: MetadataAttrib
       valueSuffix: 'tCO2e/ton',
     },
     [SORTING_FACTOR, faker.number.float({ max: 1, min: 0 })],
+    {
+      name: REFERENCE_YEAR,
+      value: getYear(new Date()),
+    },
   ];
 
 export const stubBoldEmissionAndCompostingMetricsEvent = ({

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -50,6 +50,7 @@ export enum DocumentEventAttributeName {
   METHODOLOGY_SLUG = 'Methodology Slug',
   RECEIVING_OPERATOR_IDENTIFIER = 'Receiving Operator Identifier',
   RECYCLER_OPERATOR_IDENTIFIER = 'Recycler Operator Identifier',
+  REFERENCE_YEAR = 'Reference Year',
   RULE_PROCESSOR_RESULT_CONTENT = 'Rule Processor Result Content',
   RULE_RESULT_DETAILS = 'Rule Result Details',
   SCALE_HOMOLOGATION = 'Scale Homologation',


### PR DESCRIPTION
### 🧾 Summary

Refactored the `getEmissionAndCompostingMetricsEvent` function to `getLastEmissionAndCompostingMetricsEvent` to more accurately reflect its new behavior of returning the most recent emission and composting metrics event based on reference year.

### 🧩 Context

The previous implementation would return any matching emission and composting metrics event. This change ensures we consistently retrieve the latest event by sorting them by reference year in descending order.

### 🧱 Scope of this PR

This PR is needed because we may have multiple Emission and Composting Metrics event in homologation. So we need to get newest.

**Included:**
- Renamed function from `getEmissionAndCompostingMetricsEvent` to `getLastEmissionAndCompostingMetricsEvent`
- Updated function implementation to sort events by reference year and return the most recent one
- Added `REFERENCE_YEAR` enum to `DocumentEventAttributeName`
- Updated all imports and function calls across affected files
- Updated corresponding unit tests
- Updated test stubs to include reference year attribute

### 🧪 How to test

1. Run the existing unit tests to ensure all functionality works as expected:
   ```bash
   pnpm nx run-many -t test
   ```

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a "Reference Year" attribute in emission and composting metrics events.
  * Emission and composting metrics data now uses the most recent reference year when multiple events are present.

* **Bug Fixes**
  * Improved selection of emission and composting metrics events to ensure the latest data is used.

* **Tests**
  * Updated tests to validate correct handling of the "Reference Year" attribute and selection of the latest event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->