### PR TITLE
Update emission metrics retrieval to use last year logic

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.lambda.e2e.spec.ts
@@ -28,6 +28,7 @@ describe('MassIdSortingProcessor E2E', () => {
       actorParticipants,
       homologationDocuments,
       massIdEvents,
+      partialDocument,
       resultComment,
       resultStatus,
     }) => {
@@ -36,7 +37,10 @@ describe('MassIdSortingProcessor E2E', () => {
         massIdDocument,
         participantsHomologationDocuments,
       } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-        .createMassIdDocuments({ externalEventsMap: massIdEvents })
+        .createMassIdDocuments({
+          externalEventsMap: massIdEvents,
+          partialDocument,
+        })
         .createMassIdAuditDocuments()
         .createMethodologyDocument()
         .createParticipantHomologationDocuments(homologationDocuments)

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.spec.ts
@@ -26,6 +26,7 @@ describe('MassIdSortingProcessor', () => {
         actorParticipants,
         homologationDocuments,
         massIdEvents,
+        partialDocument,
         resultComment,
         resultStatus,
       }) => {
@@ -34,6 +35,7 @@ describe('MassIdSortingProcessor', () => {
           massIdActorParticipants: actorParticipants,
           massIdDocumentsParams: {
             externalEventsMap: massIdEvents,
+            partialDocument,
           },
           ruleDataProcessor,
           spyOnDocumentQueryServiceLoad,

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -11,7 +11,7 @@ import {
 } from '@carrot-fndn/shared/helpers';
 import {
   getEventAttributeValue,
-  getLastEmissionAndCompostingMetricsEvent,
+  getLastYearEmissionAndCompostingMetricsEvent,
 } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   type DocumentQuery,
@@ -194,7 +194,11 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
     const valueBeforeSorting = eventBeforeSorting?.value;
     const valueAfterSorting = sortingEvent?.value;
     const emissionAndCompostingMetricsEvent =
-      getLastEmissionAndCompostingMetricsEvent(recyclerHomologationDocument);
+      getLastYearEmissionAndCompostingMetricsEvent({
+        documentWithEmissionAndCompostingMetricsEvent:
+          recyclerHomologationDocument,
+        documentWithYear: massIdDocument,
+      });
     const sortingFactor = getEventAttributeValue(
       emissionAndCompostingMetricsEvent,
       SORTING_FACTOR,

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -16,6 +16,7 @@ import {
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
+import { addYears } from 'date-fns';
 
 import { MassIdSortingProcessorErrors } from './mass-id-sorting.errors';
 import { RESULT_COMMENTS } from './mass-id-sorting.processor';
@@ -43,6 +44,28 @@ const actorParticipants = new Map(
   ]),
 );
 
+const {
+  massIdAuditDocument,
+  massIdDocument,
+  participantsHomologationDocuments,
+} = new BoldStubsBuilder()
+  .createMassIdDocuments({
+    externalEventsMap: {
+      [DROP_OFF]: stubBoldMassIdDropOffEvent({
+        partialDocumentEvent: {
+          value: 0,
+        },
+      }),
+    },
+    partialDocument: {
+      externalCreatedAt: addYears(new Date(), 1).toISOString(),
+    },
+  })
+  .createMassIdAuditDocuments()
+  .createMethodologyDocument()
+  .createParticipantHomologationDocuments()
+  .build();
+
 export const massIdSortingTestCases = [
   {
     actorParticipants,
@@ -51,6 +74,7 @@ export const massIdSortingTestCases = [
         metadataAttributes: [[DESCRIPTION, undefined]],
       }),
     },
+    partialDocument: massIdDocument,
     resultComment: RESULT_COMMENTS.MISSING_SORTING_DESCRIPTION,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the sorting description is missing',
@@ -93,6 +117,7 @@ export const massIdSortingTestCases = [
         },
       }),
     },
+    partialDocument: massIdDocument,
     resultComment: RESULT_COMMENTS.PASSED(0),
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -136,6 +161,7 @@ export const massIdSortingTestCases = [
         },
       }),
     },
+    partialDocument: massIdDocument,
     resultComment: RESULT_COMMENTS.FAILED(
       Math.abs(calculatedSortingValue - wrongSortingValue),
     ),
@@ -143,25 +169,6 @@ export const massIdSortingTestCases = [
     scenario: 'the sorting value calculation difference is greater than 0.1',
   },
 ];
-
-const {
-  massIdAuditDocument,
-  massIdDocument,
-  participantsHomologationDocuments,
-} = new BoldStubsBuilder()
-  .createMassIdDocuments({
-    externalEventsMap: {
-      [DROP_OFF]: stubBoldMassIdDropOffEvent({
-        partialDocumentEvent: {
-          value: 0,
-        },
-      }),
-    },
-  })
-  .createMassIdAuditDocuments()
-  .createMethodologyDocument()
-  .createParticipantHomologationDocuments()
-  .build();
 
 const invalidSortingValue = new BoldStubsBuilder()
   .createMassIdDocuments({
@@ -171,6 +178,9 @@ const invalidSortingValue = new BoldStubsBuilder()
           value: 0,
         },
       }),
+    },
+    partialDocument: {
+      externalCreatedAt: addYears(new Date(), 1).toISOString(),
     },
   })
   .createMassIdAuditDocuments()

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
@@ -25,6 +25,7 @@ describe('PreventedEmissionsProcessor E2E', () => {
   it.each(preventedEmissionsTestCases)(
     'should return $resultStatus when $scenario',
     async ({
+      externalCreatedAt,
       homologationDocuments,
       massIdDocumentValue,
       resultComment,
@@ -39,6 +40,7 @@ describe('PreventedEmissionsProcessor E2E', () => {
         .createMassIdDocuments({
           partialDocument: {
             currentValue: massIdDocumentValue as number,
+            ...(externalCreatedAt && { externalCreatedAt }),
             subtype,
           },
         })

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
@@ -23,6 +23,7 @@ describe('PreventedEmissionsProcessor', () => {
     it.each(preventedEmissionsTestCases)(
       'should return $resultStatus when $scenario',
       async ({
+        externalCreatedAt,
         homologationDocuments,
         massIdDocumentValue,
         resultComment,
@@ -35,6 +36,7 @@ describe('PreventedEmissionsProcessor', () => {
           massIdDocumentsParams: {
             partialDocument: {
               currentValue: massIdDocumentValue as number,
+              ...(externalCreatedAt && { externalCreatedAt }),
               subtype,
             },
           },

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -9,7 +9,7 @@ import {
 } from '@carrot-fndn/shared/helpers';
 import {
   getEventAttributeValue,
-  getLastEmissionAndCompostingMetricsEvent,
+  getLastYearEmissionAndCompostingMetricsEvent,
 } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   type DocumentQuery,
@@ -164,7 +164,11 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     wasteGeneratorHomologationDocument,
   }: Documents): RuleSubject {
     const lastEmissionAndCompostingMetricsEvent =
-      getLastEmissionAndCompostingMetricsEvent(recyclerHomologationDocument);
+      getLastYearEmissionAndCompostingMetricsEvent({
+        documentWithEmissionAndCompostingMetricsEvent:
+          recyclerHomologationDocument,
+        documentWithYear: massIdDocument,
+      });
 
     if (!is<MassIdOrganicSubtype>(massIdDocument.subtype)) {
       throw this.processorErrors.getKnownError(

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -12,6 +12,7 @@ import {
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import { addYears } from 'date-fns';
 
 import { PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON } from './prevented-emissions.constants';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
@@ -31,6 +32,23 @@ const baselineValue =
   PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[subtype][baseline];
 const expectedPreventedEmissions =
   (1 - exceedingEmissionCoefficient) * baselineValue * massIdDocumentValue;
+
+const processorErrors = new PreventedEmissionsProcessorErrors();
+
+const {
+  massIdAuditDocument,
+  massIdDocument,
+  participantsHomologationDocuments,
+} = new BoldStubsBuilder()
+  .createMassIdDocuments({
+    partialDocument: {
+      externalCreatedAt: addYears(new Date(), 1).toISOString(),
+    },
+  })
+  .createMassIdAuditDocuments()
+  .createMethodologyDocument()
+  .createParticipantHomologationDocuments()
+  .build();
 
 export const preventedEmissionsTestCases = [
   {
@@ -73,6 +91,7 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
+    externalCreatedAt: massIdDocument.externalCreatedAt,
     homologationDocuments: new Map([
       [
         RECYCLER,
@@ -122,6 +141,7 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
+    externalCreatedAt: massIdDocument.externalCreatedAt,
     homologationDocuments: new Map([
       [
         RECYCLER,
@@ -167,19 +187,6 @@ export const preventedEmissionsTestCases = [
     subtype: MassIdOrganicSubtype.DOMESTIC_SLUDGE,
   },
 ];
-
-const processorErrors = new PreventedEmissionsProcessorErrors();
-
-const {
-  massIdAuditDocument,
-  massIdDocument,
-  participantsHomologationDocuments,
-} = new BoldStubsBuilder()
-  .createMassIdDocuments()
-  .createMassIdAuditDocuments()
-  .createMethodologyDocument()
-  .createParticipantHomologationDocuments()
-  .build();
 
 const wasteGeneratorHomologationDocument =
   participantsHomologationDocuments.get(WASTE_GENERATOR) as Document;

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -29,64 +29,53 @@ const {
 } = DocumentEventName;
 const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
+const testEmissionAndCompostingMetricsEvent = (
+  referenceYearValue: number | string,
+) => {
+  const targetEvent = stubDocumentEvent({
+    metadata: {
+      attributes: [
+        {
+          isPublic: true,
+          name: DocumentEventAttributeName.REFERENCE_YEAR,
+          value: referenceYearValue,
+        },
+      ],
+    },
+    name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
+  });
+
+  const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
+    externalEvents: [...stubArray(() => stubDocumentEvent()), targetEvent],
+  });
+
+  const documentWithYear = stubDocument({
+    externalCreatedAt: addYears(new Date(), 1).toISOString(),
+  });
+
+  return {
+    result: getLastYearEmissionAndCompostingMetricsEvent({
+      documentWithEmissionAndCompostingMetricsEvent,
+      documentWithYear,
+    }),
+    targetEvent,
+  };
+};
+
 describe('Document getters', () => {
   describe('getLastYearEmissionAndCompostingMetricsEvent', () => {
     it('should return correct emission and composting metrics event with string reference year', () => {
-      const targetEvent = stubDocumentEvent({
-        metadata: {
-          attributes: [
-            {
-              isPublic: true,
-              name: DocumentEventAttributeName.REFERENCE_YEAR,
-              value: getYear(new Date()).toString(),
-            },
-          ],
-        },
-        name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
-      });
-
-      const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-        externalEvents: [...stubArray(() => stubDocumentEvent()), targetEvent],
-      });
-
-      const documentWithYear = stubDocument({
-        externalCreatedAt: addYears(new Date(), 1).toISOString(),
-      });
-
-      const result = getLastYearEmissionAndCompostingMetricsEvent({
-        documentWithEmissionAndCompostingMetricsEvent,
-        documentWithYear,
-      });
+      const { result, targetEvent } = testEmissionAndCompostingMetricsEvent(
+        getYear(new Date()).toString(),
+      );
 
       expect(result).toEqual(targetEvent);
     });
 
     it('should return correct emission and composting metrics event with integer reference year', () => {
-      const targetEvent = stubDocumentEvent({
-        metadata: {
-          attributes: [
-            {
-              isPublic: true,
-              name: DocumentEventAttributeName.REFERENCE_YEAR,
-              value: getYear(new Date()),
-            },
-          ],
-        },
-        name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
-      });
-
-      const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-        externalEvents: [...stubArray(() => stubDocumentEvent()), targetEvent],
-      });
-
-      const documentWithYear = stubDocument({
-        externalCreatedAt: addYears(new Date(), 1).toISOString(),
-      });
-
-      const result = getLastYearEmissionAndCompostingMetricsEvent({
-        documentWithEmissionAndCompostingMetricsEvent,
-        documentWithYear,
-      });
+      const { result, targetEvent } = testEmissionAndCompostingMetricsEvent(
+        getYear(new Date()),
+      );
 
       expect(result).toEqual(targetEvent);
     });


### PR DESCRIPTION
### 🧾 Summary

This PR refactors the emission and composting metrics event retrieval logic to use year-based filtering instead of simply getting the last event. The changes introduce a new function `getLastYearEmissionAndCompostingMetricsEvent` that retrieves events based on the document's creation year minus one, with proper validation for reference years.

### 🧩 Context

The previous implementation (`getLastEmissionAndCompostingMetricsEvent`) was retrieving the most recent emission and composting metrics event without considering the temporal relationship to the document being processed. This change ensures that the correct metrics are used based on the year context of the mass ID document.

### 🧱 Scope of this PR

**Included:**
- Refactored `getLastEmissionAndCompostingMetricsEvent` to `getLastYearEmissionAndCompostingMetricsEvent`
- Added year-based filtering logic using document creation date
- Updated function signature to accept two documents: one with events and one with year reference
- Added proper validation for reference year values (handles strings, integers, empty strings, zero, and negative values)
- Updated all rule processors (mass-id-sorting and prevented-emissions) to use the new function
- Updated test cases to include `partialDocument` and `externalCreatedAt` parameters


### 🧪 How to test

1. Run the existing test suites for the affected processors:
   ```bash
   pnpm test:affected
   ```

2. Verify E2E tests pass for both processors

### 🧠 Considerations for Review

- **Calculation logic**: The new year calculation logic that determines `lastYear = currentYear - 1`
- **Breaking change**: Function signature has changed from single parameter to object with two document parameters

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced test cases and processors to support specifying document creation dates, allowing for more precise year-based logic in emissions and sorting calculations.

* **Bug Fixes**
  * Improved handling of emission and composting metrics events to ensure correct matching based on the previous year derived from document creation dates.

* **Refactor**
  * Consolidated and streamlined test data setup for better consistency and maintainability.
  * Updated internal logic to use a new method for retrieving year-specific emission and composting metrics events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->