### PR TITLE
Simplify year handling in emission metrics event retrieval

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -36,6 +36,7 @@ import {
   RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { type MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared/types';
+import { getYear } from 'date-fns';
 
 import { MassIdSortingProcessorErrors } from './mass-id-sorting.errors';
 
@@ -197,7 +198,7 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
       getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent:
           recyclerHomologationDocument,
-        documentWithYear: massIdDocument,
+        documentYear: getYear(massIdDocument.externalCreatedAt),
       });
     const sortingFactor = getEventAttributeValue(
       emissionAndCompostingMetricsEvent,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -32,6 +32,7 @@ import {
   type RuleOutput,
   RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
+import { getYear } from 'date-fns';
 import { is } from 'typia';
 
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
@@ -167,7 +168,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent:
           recyclerHomologationDocument,
-        documentWithYear: massIdDocument,
+        documentYear: getYear(massIdDocument.externalCreatedAt),
       });
 
     if (!is<MassIdOrganicSubtype>(massIdDocument.subtype)) {

--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -1,8 +1,4 @@
-import {
-  isNonEmptyArray,
-  isNonEmptyString,
-  isNonZeroPositiveInt,
-} from '@carrot-fndn/shared/helpers';
+import { isNonEmptyArray } from '@carrot-fndn/shared/helpers';
 import {
   type Document,
   type DocumentEvent,
@@ -10,7 +6,7 @@ import {
   DocumentEventName,
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { getYear } from 'date-fns';
+import { NonZeroPositiveInt } from '@carrot-fndn/shared/types';
 
 import { getEventAttributeValue } from './event.getters';
 
@@ -20,17 +16,16 @@ const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
 
 interface LastYearEmissionAndCompostingMetricsEventParameters {
   documentWithEmissionAndCompostingMetricsEvent: Document;
-  documentWithYear: Document;
+  documentYear: NonZeroPositiveInt;
 }
 
 export const getLastYearEmissionAndCompostingMetricsEvent = ({
   documentWithEmissionAndCompostingMetricsEvent,
-  documentWithYear,
+  documentYear,
 }: LastYearEmissionAndCompostingMetricsEventParameters):
   | DocumentEvent
   | undefined => {
-  const currentYear = getYear(documentWithYear.externalCreatedAt);
-  const lastYear = currentYear - 1;
+  const lastDocumentYearYear = documentYear - 1;
 
   return documentWithEmissionAndCompostingMetricsEvent.externalEvents?.find(
     (event) => {
@@ -40,12 +35,7 @@ export const getLastYearEmissionAndCompostingMetricsEvent = ({
           DocumentEventAttributeName.REFERENCE_YEAR,
         );
 
-        if (
-          isNonEmptyString(referenceYear) ||
-          isNonZeroPositiveInt(referenceYear)
-        ) {
-          return lastYear === Number.parseInt(String(referenceYear));
-        }
+        return referenceYear === lastDocumentYearYear;
       }
 
       return false;


### PR DESCRIPTION
### 🧾 Summary

This PR refactors the year handling logic in emission metrics event retrieval by simplifying the API to accept direct year values instead of full document objects.

### 🧩 Context

The previous implementation required passing entire document objects to extract year information, which created unnecessary coupling and complexity. This refactoring simplifies the API by extracting the year at the call site and passing it directly as a parameter.

### 🧱 Scope of this PR

**Included:**
- Updated `getLastYearEmissionAndCompostingMetricsEvent` function to accept `documentYear` parameter instead of `documentWithYear`
- Added `getYear` import from `date-fns` in processor files
- Updated all callers to extract year using `getYear(document.externalCreatedAt)`
- Simplified logic by removing unnecessary type checking and string parsing for reference year
- Updated unit tests to reflect the new parameter structure

**Not included:**
- No breaking changes to external APIs or database schemas

### 🧪 How to test

Run the existing test suite to ensure all functionality remains intact:
```bash
pnpm test:affected
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of year values by passing explicit year parameters instead of full document objects in emissions-related features.
  * Simplified and clarified logic for retrieving last year’s emission and composting metrics.

* **Tests**
  * Updated and expanded test coverage to ensure accurate results when using explicit year inputs, including additional edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->