### PR TITLE
Add a resourceName parameter to package-lambda to avoid being limited when definind rules name

### DIFF
--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "methodologies-bold-carbon-rule-processors-mass-id-participant-accreditations-and-verifications-requirements",
+  "name": "methodologies-bold-carbon-rule-processors-mass-id-participant-accreditations",
   "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
   "tags": ["methodology:bold", "processor:mass-id", "type:app"],
   "sourceRoot": "apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src",

--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "methodologies-bold-carbon-rule-processors-mass-id-participant-accreditations",
+  "name": "methodologies-bold-carbon-rule-processors-mass-id-participant-accreditations-and-verifications-requirements",
   "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
   "tags": ["methodology:bold", "processor:mass-id", "type:app"],
   "sourceRoot": "apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src",
@@ -7,7 +7,11 @@
   "targets": {
     "build-lambda": {},
     "lint": {},
-    "package-lambda": {},
+    "package-lambda": {
+      "options": {
+        "resourceName": "methodologies-bold-carbon-rule-processors-mass-id-participant-accreditations"
+      }
+    },
     "upload-lambda": {},
     "ts": {}
   }

--- a/nx.json
+++ b/nx.json
@@ -87,8 +87,9 @@
       "dependsOn": ["build-lambda"],
       "outputs": ["{options.zipPath}"],
       "options": {
-        "command": "{workspaceRoot}/scripts/package-lambda.sh {args.buildPath} {args.zipPath}",
+        "command": "{workspaceRoot}/scripts/package-lambda.sh {args.buildPath} {args.zipPath} {args.resourceName}",
         "buildPath": "{workspaceRoot}/dist/.prod/{projectRoot}",
+        "resourceName": "{projectName}",
         "zipPath": "{workspaceRoot}/dist/.zip/{projectName}.zip"
       }
     },

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -9,6 +9,17 @@ fi
 BUILD_PATH=$1
 ZIP_PATH=$2
 
+# Extract path components and validate lambda name length
+ZIP_DIR=$(dirname "$ZIP_PATH")
+ZIP_FILE_NAME=$(basename "$ZIP_PATH")
+LAMBDA_NAME=$(echo "$ZIP_FILE_NAME" | sed 's/\.zip$//')
+
+if [ ${#LAMBDA_NAME} -gt 80 ]; then
+  echo "Error: Lambda name '$LAMBDA_NAME' is ${#LAMBDA_NAME} characters long."
+  echo "Lambda names must be 80 characters or less for SQS queue compatibility."
+  exit 1
+fi
+
 echo "Zipping $BUILD_PATH to $ZIP_PATH"
 
 # Check if the build path exists
@@ -24,8 +35,6 @@ then
   exit 1
 fi
 
-ZIP_DIR=$(dirname "$ZIP_PATH")
-
 # Create the zip folder if it doesn't exist
 if ! mkdir -p "$ZIP_DIR"
 then
@@ -34,8 +43,6 @@ then
 fi
 
 # IMPORTANT: change to the build path to create the zip file with the correct relative structure
-ZIP_DIR=$(dirname "$ZIP_PATH")
-ZIP_FILE_NAME=$(basename "$ZIP_PATH")
 ABSOLUTE_ZIP_PATH="$(realpath "$ZIP_DIR")/$ZIP_FILE_NAME"
 cd "$BUILD_PATH"
 

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -1,22 +1,28 @@
 #!/bin/sh
 
 # Check if the correct number of arguments are provided
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <build_path> <zip_path>"
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <build_path> <zip_path> [resource_name]"
   exit 1
 fi
 
 BUILD_PATH=$1
 ZIP_PATH=$2
 
-# Extract path components and validate lambda name length
+# Extract path components and validate resource name length
 ZIP_DIR=$(dirname "$ZIP_PATH")
 ZIP_FILE_NAME=$(basename "$ZIP_PATH")
-LAMBDA_NAME=$(echo "$ZIP_FILE_NAME" | sed 's/\.zip$//')
+
+# Use provided resource name or extract from zip file name
+if [ "$#" -eq 3 ]; then
+  LAMBDA_NAME=$3
+else
+  LAMBDA_NAME=$(echo "$ZIP_FILE_NAME" | sed 's/\.zip$//')
+fi
 
 if [ ${#LAMBDA_NAME} -gt 80 ]; then
-  echo "Error: Lambda name '$LAMBDA_NAME' is ${#LAMBDA_NAME} characters long."
-  echo "Lambda names must be 80 characters or less for SQS queue compatibility."
+  echo "Error: Resource name '$LAMBDA_NAME' is ${#LAMBDA_NAME} characters long."
+  echo "Resource names must be 80 characters or less for SQS queue compatibility."
   exit 1
 fi
 


### PR DESCRIPTION
### 🧾 Summary

Added resource name length validation to the lambda packaging script to ensure compatibility with SQS queue naming limitations. The script now validates that resource names are 80 characters or less and accepts an optional `resourceName` parameter.

### 🧩 Context

SQS queues and DLQs have a maximum name length of 80 characters. In our deployment flow, these resources are created based on the lambda zip name, which can sometimes exceed this limit, causing deployment failures. This change prevents such issues by validating resource names upfront during the packaging stage.

### 🧱 Scope of this PR

**Included:**
- Modified `scripts/package-lambda.sh` to accept optional third parameter for resource name
- Added 80-character validation with clear error messages
- Updated `nx.json` to pass `resourceName` parameter to the script
- Renamed parameter from `shortName` to `resourceName` for clarity
- Updated existing project configuration to use new parameter name

**Not included:**
- Retroactive validation of existing resource names
- Automatic name shortening suggestions

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**