### PR TITLE
Move resource name handling from package to upload lambda scripts

### DIFF
--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
@@ -7,12 +7,12 @@
   "targets": {
     "build-lambda": {},
     "lint": {},
-    "package-lambda": {
+    "package-lambda": {},
+    "upload-lambda": {
       "options": {
         "resourceName": "methodologies-bold-carbon-rule-processors-mass-id-participant-accreditations"
       }
     },
-    "upload-lambda": {},
     "ts": {}
   }
 }

--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
@@ -7,12 +7,12 @@
   "targets": {
     "build-lambda": {},
     "lint": {},
-    "package-lambda": {
+    "package-lambda": {},
+    "upload-lambda": {
       "options": {
         "resourceName": "methodologies-bold-recycling-rule-processors-mass-id-participant-accreditations"
       }
     },
-    "upload-lambda": {},
     "ts": {}
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -87,9 +87,8 @@
       "dependsOn": ["build-lambda"],
       "outputs": ["{options.zipPath}"],
       "options": {
-        "command": "{workspaceRoot}/scripts/package-lambda.sh {args.buildPath} {args.zipPath} {args.resourceName}",
+        "command": "{workspaceRoot}/scripts/package-lambda.sh {args.buildPath} {args.zipPath}",
         "buildPath": "{workspaceRoot}/dist/.prod/{projectRoot}",
-        "resourceName": "{projectName}",
         "zipPath": "{workspaceRoot}/dist/.zip/{projectName}.zip"
       }
     },
@@ -105,12 +104,13 @@
       "dependsOn": ["package-lambda"],
       "options": {
         "commands": [
-          "{workspaceRoot}/scripts/upload-lambda.sh {projectRoot} {args.zipPath} {args.environment}",
+          "{workspaceRoot}/scripts/upload-lambda.sh {projectRoot} {args.zipPath} {args.environment} {args.resourceName}",
           "rm -rf {args.zipPath}"
         ],
+        "environment": "development",
         "parallel": false,
-        "zipPath": "{workspaceRoot}/dist/.zip/{projectName}.zip",
-        "environment": "development"
+        "resourceName": "{projectRoot}",
+        "zipPath": "{workspaceRoot}/dist/.zip/{projectName}.zip"
       }
     }
   },

--- a/nx.json
+++ b/nx.json
@@ -109,7 +109,7 @@
         ],
         "environment": "development",
         "parallel": false,
-        "resourceName": "{projectRoot}",
+        "resourceName": "{projectName}",
         "zipPath": "{workspaceRoot}/dist/.zip/{projectName}.zip"
       }
     }

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Check if the correct number of arguments are provided
-if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
-  echo "Usage: $0 <build_path> <zip_path> [resource_name]"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <build_path> <zip_path>"
   exit 1
 fi
 
@@ -12,20 +12,6 @@ ZIP_PATH=$2
 # Extract path components and validate resource name length
 ZIP_DIR=$(dirname "$ZIP_PATH")
 ZIP_FILE_NAME=$(basename "$ZIP_PATH")
-
-# Use provided resource name or extract from zip file name
-if [ "$#" -eq 3 ]; then
-  RESOURCE_NAME=$3
-else
-  RESOURCE_NAME=$(echo "$ZIP_FILE_NAME" | sed 's/\.zip$//')
-fi
-
-MAX_RESOURCE_NAME_LENGTH=107  # excludes mandatory 'methodology-' prefix and 'rule-processors' suffix
-if [ ${#RESOURCE_NAME} -gt $MAX_RESOURCE_NAME_LENGTH ]; then
-  echo "Error: Resource name '$RESOURCE_NAME' is ${#RESOURCE_NAME} characters long."
-  echo "Resource names must be $MAX_RESOURCE_NAME_LENGTH characters or less (after removing the 'methodology-' prefix and 'rule-processors) to stay within the 80-char SQS queue limit."
-   exit 1
-fi
 
 echo "Zipping $BUILD_PATH to $ZIP_PATH"
 

--- a/scripts/upload-lambda.sh
+++ b/scripts/upload-lambda.sh
@@ -42,8 +42,6 @@ GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 COMMIT_HASH=$(git rev-parse HEAD)
 SOURCE_CODE_URL=$GIT_REPO_URL/tree/$COMMIT_HASH/$PROJECT_FOLDER
 
-echo $RULE_NAME
-
 # Upload zip file to S3 bucket
 if aws s3 cp "$ZIP_PATH" "s3://$S3_BUCKET/$S3_KEY"
 then

--- a/scripts/upload-lambda.sh
+++ b/scripts/upload-lambda.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Check if the correct number of arguments are provided
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <project_folder> <zip_path> <environment>"
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: $0 <project_folder> <zip_path> <environment> [resource_name]"
   exit 1
 fi
 
@@ -21,7 +21,20 @@ S3_URL=s3://$S3_BUCKET/$S3_KEY
 
 METHODOLOGY_SLUG=$(echo "$PROJECT_FOLDER" | sed -n 's/^apps\/methodologies\/\([^/]*\)\/rule-processors\/.*/\1/p')
 
-RULE_NAME=$(echo "$S3_FOLDER" | sed 's/\//-/g')
+# Use provided resource name or derive from S3_FOLDER
+if [ "$#" -eq 4 ]; then
+  RESOURCE_NAME=$4
+  # Validate resource name length
+  MAX_RESOURCE_NAME_LENGTH=110  # excludes mandatory 'methodologies-' prefix and 'rule-processors' suffix
+  if [ ${#RESOURCE_NAME} -gt $MAX_RESOURCE_NAME_LENGTH ]; then
+    echo "Error: Resource name '$RESOURCE_NAME' is ${#RESOURCE_NAME} characters long."
+    echo "Resource names must be $MAX_RESOURCE_NAME_LENGTH characters or less (after removing the 'methodologies-' prefix and 'rule-processors) to stay within the 80-char SQS queue limit."
+    exit 1
+  fi
+  RULE_NAME=$RESOURCE_NAME
+else
+  RULE_NAME=$(echo "$S3_FOLDER" | sed 's/\//-/g')
+fi
 
 GIT_REPO_URL=$(git config --get remote.origin.url | sed 's/\.git//g')
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -29,19 +42,21 @@ GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 COMMIT_HASH=$(git rev-parse HEAD)
 SOURCE_CODE_URL=$GIT_REPO_URL/tree/$COMMIT_HASH/$PROJECT_FOLDER
 
+echo $RULE_NAME
+
 # Upload zip file to S3 bucket
-if aws s3 cp "$ZIP_PATH" "s3://$S3_BUCKET/$S3_KEY"
-then
-  echo "Uploaded $ZIP_PATH to $S3_URL"
-
-  # concatenates metadata rules in rules metadata file
-  METADATA_FILE="rules-metadata.json"
-  METADATA_TEMP_FILE="temp-rules-metadata.json"
-
-  if [ -s "$METADATA_FILE" ]; then
-    jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"methodology-slug\": \"$METHODOLOGY_SLUG\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"
-  fi
-else
-  echo "Error: Failed to upload file $ZIP_PATH"
-  exit 1
-fi
+# if aws s3 cp "$ZIP_PATH" "s3://$S3_BUCKET/$S3_KEY"
+# then
+#   echo "Uploaded $ZIP_PATH to $S3_URL"
+#
+#   # concatenates metadata rules in rules metadata file
+#   METADATA_FILE="rules-metadata.json"
+#   METADATA_TEMP_FILE="temp-rules-metadata.json"
+#
+#   if [ -s "$METADATA_FILE" ]; then
+#     jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"methodology-slug\": \"$METHODOLOGY_SLUG\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"
+#   fi
+# else
+#   echo "Error: Failed to upload file $ZIP_PATH"
+#   exit 1
+# fi

--- a/scripts/upload-lambda.sh
+++ b/scripts/upload-lambda.sh
@@ -45,18 +45,18 @@ SOURCE_CODE_URL=$GIT_REPO_URL/tree/$COMMIT_HASH/$PROJECT_FOLDER
 echo $RULE_NAME
 
 # Upload zip file to S3 bucket
-# if aws s3 cp "$ZIP_PATH" "s3://$S3_BUCKET/$S3_KEY"
-# then
-#   echo "Uploaded $ZIP_PATH to $S3_URL"
-#
-#   # concatenates metadata rules in rules metadata file
-#   METADATA_FILE="rules-metadata.json"
-#   METADATA_TEMP_FILE="temp-rules-metadata.json"
-#
-#   if [ -s "$METADATA_FILE" ]; then
-#     jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"methodology-slug\": \"$METHODOLOGY_SLUG\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"
-#   fi
-# else
-#   echo "Error: Failed to upload file $ZIP_PATH"
-#   exit 1
-# fi
+if aws s3 cp "$ZIP_PATH" "s3://$S3_BUCKET/$S3_KEY"
+then
+  echo "Uploaded $ZIP_PATH to $S3_URL"
+
+  # concatenates metadata rules in rules metadata file
+  METADATA_FILE="rules-metadata.json"
+  METADATA_TEMP_FILE="temp-rules-metadata.json"
+
+  if [ -s "$METADATA_FILE" ]; then
+    jq ".rulesMetadata += [{\"rule-name\": \"$RULE_NAME\", \"methodology-slug\": \"$METHODOLOGY_SLUG\", \"commit-hash\": \"$COMMIT_HASH\", \"file-checksum\": \"$FILE_CHECKSUM\", \"source-code-url\": \"$SOURCE_CODE_URL\", \"s3-bucket\": \"$S3_BUCKET\", \"s3-key\": \"$S3_KEY\"}]" "$METADATA_FILE" > "$METADATA_TEMP_FILE" && mv "$METADATA_TEMP_FILE" "$METADATA_FILE"
+  fi
+else
+  echo "Error: Failed to upload file $ZIP_PATH"
+  exit 1
+fi


### PR DESCRIPTION
### 🧾 Summary

This PR refactors the lambda packaging and upload scripts by moving resource name handling logic from the package script to the upload script. The package script is simplified to only handle zipping, while the upload script now manages resource name validation and processing.

### 🧩 Context

The current implementation had resource name handling split between packaging and upload scripts, creating unnecessary complexity in the packaging phase. This refactoring centralizes resource name logic in the upload script where it's actually needed, making the codebase more maintainable and the packaging process simpler.

### 🧱 Scope of this PR

**Included:**
- Removed resource name parameter and validation from `package-lambda.sh`
- Added resource name parameter and validation to `upload-lambda.sh`
- Updated nx.json configuration to reflect the new parameter structure
- Updated project.json to properly configure the upload-lambda target


### 🧪 How to test

1. Run the package-lambda target for any methodology rule processor
2. Verify that packaging completes successfully without resource name validation
3. Run the upload-lambda target and confirm resource name validation occurs during upload
4. Test both with and without explicit resource name parameters

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration and scripts to change how resource names are handled during packaging and uploading processes.
  * Improved validation and error messaging for resource names during uploads.
  * Clarified and reordered environment and resource naming options in build configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->