### PR TITLE
Clean up RULE_NAME by removing methodologies and rule-processors prefixes

### DIFF
--- a/scripts/upload-lambda.sh
+++ b/scripts/upload-lambda.sh
@@ -36,6 +36,8 @@ else
   RULE_NAME=$(echo "$S3_FOLDER" | sed 's/\//-/g')
 fi
 
+RULE_NAME=$(echo "$RULE_NAME" | sed 's/methodologies-//g' | sed 's/rule-processors-//g')
+
 GIT_REPO_URL=$(git config --get remote.origin.url | sed 's/\.git//g')
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
### 🧾 Summary

_This PR refactors the upload-lambda.sh script to clean up the RULE_NAME variable by removing unnecessary prefixes._

### 🧩 Context

_The RULE_NAME variable was including redundant prefixes like "methodologies-" and "rule-processors-" which were making the rule names unnecessarily verbose. This change improves the naming consistency and readability of the generated rule names._

### 🧱 Scope of this PR

_This PR includes:_
- _Addition of sed commands to strip "methodologies-" and "rule-processors-" prefixes from RULE_NAME_
- _Improvement of rule name formatting in the upload script_

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved handling of rule names by automatically removing specific prefixes during the upload process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->