### PR TITLE
Add Greenhouse Gas Type validation and handling

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
@@ -7,6 +7,8 @@ export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
       'The "MassID" document has an invalid subtype.',
     INVALID_WASTE_GENERATOR_BASELINES:
       'The "Waste Generator accreditation" document has no valid baselines.',
+    MISSING_GREENHOUSE_GAS_TYPE:
+      'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
     MISSING_MASS_ID_DOCUMENT: 'The "MassID" document was not found.',
     MISSING_RECYCLER_ACCREDITATION_DOCUMENT:
       'The "Recycler accreditation" document was not found.',

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -1,0 +1,330 @@
+import {
+  stubBoldEmissionAndCompostingMetricsEvent,
+  stubBoldRecyclingBaselinesEvent,
+  stubDocument,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  DocumentEventAttributeName,
+  MassIdOrganicSubtype,
+  MethodologyBaseline,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import { PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON } from './prevented-emissions.constants';
+import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
+import {
+  calculatePreventedEmissions,
+  getGasTypeFromEvent,
+  getPreventedEmissionsFactor,
+  getWasteGeneratorBaselineByWasteSubtype,
+  throwIfMissing,
+} from './prevented-emissions.helpers';
+
+const { BASELINES, EXCEEDING_EMISSION_COEFFICIENT, GREENHOUSE_GAS_TYPE } =
+  DocumentEventAttributeName;
+
+describe('PreventedEmissionsHelpers', () => {
+  describe('getPreventedEmissionsFactor', () => {
+    it('should return the correct prevented emissions factor for food waste and landfills without flaring', () => {
+      const result = getPreventedEmissionsFactor(
+        MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+        MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
+      );
+
+      expect(result).toBe(
+        PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[
+          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES
+        ][MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS],
+      );
+    });
+
+    it('should return the correct prevented emissions factor for domestic sludge and open air dump', () => {
+      const result = getPreventedEmissionsFactor(
+        MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+        MethodologyBaseline.OPEN_AIR_DUMP,
+      );
+
+      expect(result).toBe(
+        PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[
+          MassIdOrganicSubtype.DOMESTIC_SLUDGE
+        ][MethodologyBaseline.OPEN_AIR_DUMP],
+      );
+    });
+  });
+
+  describe('calculatePreventedEmissions', () => {
+    it('should calculate prevented emissions correctly with positive values', () => {
+      const exceedingEmissionCoefficient = 0.8;
+      const preventedEmissionsByMaterialAndBaselinePerTon = 1500;
+      const massIdDocumentValue = 100;
+
+      const result = calculatePreventedEmissions(
+        exceedingEmissionCoefficient,
+        preventedEmissionsByMaterialAndBaselinePerTon,
+        massIdDocumentValue,
+      );
+
+      expect(result).toBeCloseTo(30_000, 10); // Use toBeCloseTo for floating point
+    });
+
+    it('should calculate prevented emissions correctly with zero coefficient', () => {
+      const exceedingEmissionCoefficient = 0;
+      const preventedEmissionsByMaterialAndBaselinePerTon = 1000;
+      const massIdDocumentValue = 50;
+
+      const result = calculatePreventedEmissions(
+        exceedingEmissionCoefficient,
+        preventedEmissionsByMaterialAndBaselinePerTon,
+        massIdDocumentValue,
+      );
+
+      expect(result).toBe(50_000); // (1 - 0) * 1000 * 50
+    });
+
+    it('should handle fractional values correctly', () => {
+      const exceedingEmissionCoefficient = 0.25;
+      const preventedEmissionsByMaterialAndBaselinePerTon = 800.5;
+      const massIdDocumentValue = 10.5;
+
+      const result = calculatePreventedEmissions(
+        exceedingEmissionCoefficient,
+        preventedEmissionsByMaterialAndBaselinePerTon,
+        massIdDocumentValue,
+      );
+
+      expect(result).toBe(6303.9375); // (1 - 0.25) * 800.5 * 10.5
+    });
+  });
+
+  describe('getWasteGeneratorBaselineByWasteSubtype', () => {
+    const processorErrors = new PreventedEmissionsProcessorErrors();
+
+    it('should return the baseline for the specified waste subtype', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldRecyclingBaselinesEvent({
+            metadataAttributes: [
+              [
+                BASELINES,
+                {
+                  [MassIdOrganicSubtype.DOMESTIC_SLUDGE]:
+                    MethodologyBaseline.OPEN_AIR_DUMP,
+                  [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+                    MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+                },
+              ],
+            ],
+          }),
+        ],
+      });
+
+      const result = getWasteGeneratorBaselineByWasteSubtype(
+        document,
+        MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+        processorErrors,
+      );
+
+      expect(result).toBe(
+        MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+      );
+    });
+
+    it('should return undefined when baseline for waste subtype is not available', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldRecyclingBaselinesEvent({
+            metadataAttributes: [
+              [
+                BASELINES,
+                {
+                  [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+                    MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+                },
+              ],
+            ],
+          }),
+        ],
+      });
+
+      const result = getWasteGeneratorBaselineByWasteSubtype(
+        document,
+        MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+        processorErrors,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should throw an error when baselines are invalid', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldRecyclingBaselinesEvent({
+            metadataAttributes: [[BASELINES, 'invalid_baselines']],
+          }),
+        ],
+      });
+
+      expect(() =>
+        getWasteGeneratorBaselineByWasteSubtype(
+          document,
+          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          processorErrors,
+        ),
+      ).toThrow(
+        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
+      );
+    });
+
+    it('should throw an error when baselines are null', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldRecyclingBaselinesEvent({
+            metadataAttributes: [[BASELINES, null]],
+          }),
+        ],
+      });
+
+      expect(() =>
+        getWasteGeneratorBaselineByWasteSubtype(
+          document,
+          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          processorErrors,
+        ),
+      ).toThrow(
+        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
+      );
+    });
+
+    it('should throw an error when baselines are undefined', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldRecyclingBaselinesEvent({
+            metadataAttributes: [[BASELINES, undefined]],
+          }),
+        ],
+      });
+
+      expect(() =>
+        getWasteGeneratorBaselineByWasteSubtype(
+          document,
+          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          processorErrors,
+        ),
+      ).toThrow(
+        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
+      );
+    });
+
+    it('should throw an error when recycling baselines event is not found', () => {
+      const document = stubDocument({
+        externalEvents: [], // No events
+      });
+
+      expect(() =>
+        getWasteGeneratorBaselineByWasteSubtype(
+          document,
+          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          processorErrors,
+        ),
+      ).toThrow(
+        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
+      );
+    });
+  });
+
+  describe('throwIfMissing', () => {
+    const processorErrors = new PreventedEmissionsProcessorErrors();
+    const errorMessage = 'Test error message';
+
+    it('should not throw when value is defined', () => {
+      expect(() => {
+        throwIfMissing('valid value', errorMessage, processorErrors);
+      }).not.toThrow();
+    });
+
+    it('should not throw when value is 0', () => {
+      expect(() => {
+        throwIfMissing(0, errorMessage, processorErrors);
+      }).not.toThrow();
+    });
+
+    it('should not throw when value is false', () => {
+      expect(() => {
+        throwIfMissing(false, errorMessage, processorErrors);
+      }).not.toThrow();
+    });
+
+    it('should not throw when value is empty string', () => {
+      expect(() => {
+        throwIfMissing('', errorMessage, processorErrors);
+      }).not.toThrow();
+    });
+
+    it('should throw when value is null', () => {
+      expect(() => {
+        throwIfMissing(null, errorMessage, processorErrors);
+      }).toThrow(errorMessage);
+    });
+
+    it('should throw when value is undefined', () => {
+      expect(() => {
+        throwIfMissing(undefined, errorMessage, processorErrors);
+      }).toThrow(errorMessage);
+    });
+  });
+
+  describe('getGasTypeFromEvent', () => {
+    it('should return the gas type when the attribute exists and is valid', () => {
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [
+          [EXCEEDING_EMISSION_COEFFICIENT, 0.8],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ],
+      });
+      const result = getGasTypeFromEvent(event);
+
+      expect(result).toBe('Methane (CH4)');
+    });
+
+    it('should throw an error when the gas type attribute is missing', () => {
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [[EXCEEDING_EMISSION_COEFFICIENT, 0.8]],
+      });
+
+      expect(() => getGasTypeFromEvent(event)).toThrow(
+        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+      );
+    });
+
+    it('should throw an error when the gas type attribute is empty', () => {
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [
+          [EXCEEDING_EMISSION_COEFFICIENT, 0.8],
+          [GREENHOUSE_GAS_TYPE, ''],
+        ],
+      });
+
+      expect(() => getGasTypeFromEvent(event)).toThrow(
+        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+      );
+    });
+
+    it('should throw an error when the gas type attribute is null', () => {
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [
+          [EXCEEDING_EMISSION_COEFFICIENT, 0.8],
+          [GREENHOUSE_GAS_TYPE, null],
+        ],
+      });
+
+      expect(() => getGasTypeFromEvent(event)).toThrow(
+        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+      );
+    });
+
+    it('should throw an error when the event is undefined', () => {
+      expect(() => getGasTypeFromEvent(undefined)).toThrow(
+        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+      );
+    });
+  });
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -65,7 +65,7 @@ describe('PreventedEmissionsHelpers', () => {
         massIdDocumentValue,
       );
 
-      expect(result).toBeCloseTo(30_000, 10); // Use toBeCloseTo for floating point
+      expect(result).toBeCloseTo(30_000, 10);
     });
 
     it('should calculate prevented emissions correctly with zero coefficient', () => {
@@ -79,7 +79,7 @@ describe('PreventedEmissionsHelpers', () => {
         massIdDocumentValue,
       );
 
-      expect(result).toBe(50_000); // (1 - 0) * 1000 * 50
+      expect(result).toBe(50_000);
     });
 
     it('should handle fractional values correctly', () => {
@@ -93,7 +93,7 @@ describe('PreventedEmissionsHelpers', () => {
         massIdDocumentValue,
       );
 
-      expect(result).toBe(6303.9375); // (1 - 0.25) * 800.5 * 10.5
+      expect(result).toBe(6303.9375);
     });
   });
 
@@ -216,7 +216,7 @@ describe('PreventedEmissionsHelpers', () => {
 
     it('should throw an error when recycling baselines event is not found', () => {
       const document = stubDocument({
-        externalEvents: [], // No events
+        externalEvents: [],
       });
 
       expect(() =>

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -23,6 +23,8 @@ const { BASELINES, EXCEEDING_EMISSION_COEFFICIENT, GREENHOUSE_GAS_TYPE } =
   DocumentEventAttributeName;
 
 describe('PreventedEmissionsHelpers', () => {
+  const processorErrors = new PreventedEmissionsProcessorErrors();
+
   describe('getPreventedEmissionsFactor', () => {
     it('should return the correct prevented emissions factor for food waste and landfills without flaring', () => {
       const result = getPreventedEmissionsFactor(
@@ -96,8 +98,6 @@ describe('PreventedEmissionsHelpers', () => {
   });
 
   describe('getWasteGeneratorBaselineByWasteSubtype', () => {
-    const processorErrors = new PreventedEmissionsProcessorErrors();
-
     it('should return the baseline for the specified waste subtype', () => {
       const document = stubDocument({
         externalEvents: [
@@ -232,7 +232,6 @@ describe('PreventedEmissionsHelpers', () => {
   });
 
   describe('throwIfMissing', () => {
-    const processorErrors = new PreventedEmissionsProcessorErrors();
     const errorMessage = 'Test error message';
 
     it('should not throw when value is defined', () => {
@@ -291,7 +290,7 @@ describe('PreventedEmissionsHelpers', () => {
       });
 
       expect(() => getGasTypeFromEvent(event)).toThrow(
-        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+        processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
       );
     });
 
@@ -304,7 +303,7 @@ describe('PreventedEmissionsHelpers', () => {
       });
 
       expect(() => getGasTypeFromEvent(event)).toThrow(
-        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+        processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
       );
     });
 
@@ -317,13 +316,13 @@ describe('PreventedEmissionsHelpers', () => {
       });
 
       expect(() => getGasTypeFromEvent(event)).toThrow(
-        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+        processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
       );
     });
 
     it('should throw an error when the event is undefined', () => {
       expect(() => getGasTypeFromEvent(undefined)).toThrow(
-        'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
+        processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
       );
     });
   });

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -1,12 +1,14 @@
-import { isNil } from '@carrot-fndn/shared/helpers';
+import { isNil, isNonEmptyString } from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   type Document,
+  type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
   MassIdOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
+import { type NonEmptyString } from '@carrot-fndn/shared/types';
 
 import { PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON } from './prevented-emissions.constants';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
@@ -65,4 +67,23 @@ export const throwIfMissing = <T>(
   if (isNil(value)) {
     throw processorErrors.getKnownError(errorMessage);
   }
+};
+
+export const getGasTypeFromEvent = (
+  lastEmissionAndCompostingMetricsEvent: DocumentEvent | undefined,
+): NonEmptyString => {
+  const gasType = getEventAttributeValue(
+    lastEmissionAndCompostingMetricsEvent,
+    DocumentEventAttributeName.GREENHOUSE_GAS_TYPE,
+  );
+
+  if (!isNonEmptyString(gasType)) {
+    const processorErrors = new PreventedEmissionsProcessorErrors();
+
+    throw processorErrors.getKnownError(
+      processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
+    );
+  }
+
+  return gasType;
 };

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
@@ -40,7 +40,7 @@ describe('PreventedEmissionsProcessor E2E', () => {
         .createMassIdDocuments({
           partialDocument: {
             currentValue: massIdDocumentValue as number,
-            ...(externalCreatedAt && { externalCreatedAt }),
+            externalCreatedAt,
             subtype,
           },
         })

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
@@ -36,7 +36,7 @@ describe('PreventedEmissionsProcessor', () => {
           massIdDocumentsParams: {
             partialDocument: {
               currentValue: massIdDocumentValue as number,
-              ...(externalCreatedAt && { externalCreatedAt }),
+              externalCreatedAt,
               subtype,
             },
           },

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -38,6 +38,7 @@ import { is } from 'typia';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
 import {
   calculatePreventedEmissions,
+  getGasTypeFromEvent,
   getPreventedEmissionsFactor,
   getWasteGeneratorBaselineByWasteSubtype,
   throwIfMissing,
@@ -136,6 +137,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         massIdDocumentValue,
       ),
       resultContent: {
+        gasType: ruleSubject.gasType,
         preventedCo2e: preventedEmissions,
       },
       resultStatus: RuleOutputStatus.PASSED,
@@ -171,6 +173,8 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         documentYear: getYear(massIdDocument.externalCreatedAt),
       });
 
+    const gasType = getGasTypeFromEvent(lastEmissionAndCompostingMetricsEvent);
+
     if (!is<MassIdOrganicSubtype>(massIdDocument.subtype)) {
       throw this.processorErrors.getKnownError(
         this.processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
@@ -188,6 +192,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         lastEmissionAndCompostingMetricsEvent,
         EXCEEDING_EMISSION_COEFFICIENT,
       ),
+      gasType,
       massIdDocumentValue: massIdDocument.currentValue,
       wasteGeneratorBaseline,
       wasteSubtype: massIdDocument.subtype,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -102,7 +102,7 @@ export const preventedEmissionsTestCases = [
             [EMISSION_AND_COMPOSTING_METRICS]:
               stubBoldEmissionAndCompostingMetricsEvent({
                 metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, null], // null is not non-zero positive
+                  [EXCEEDING_EMISSION_COEFFICIENT, null],
                   [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
                 ],
               }),
@@ -245,7 +245,7 @@ export const preventedEmissionsTestCases = [
             [EMISSION_AND_COMPOSTING_METRICS]:
               stubBoldEmissionAndCompostingMetricsEvent({
                 metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, 0], // 0 is not non-zero positive
+                  [EXCEEDING_EMISSION_COEFFICIENT, 0],
                   [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
                 ],
               }),
@@ -288,7 +288,7 @@ export const preventedEmissionsTestCases = [
             [EMISSION_AND_COMPOSTING_METRICS]:
               stubBoldEmissionAndCompostingMetricsEvent({
                 metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, -0.5], // negative is not non-zero positive
+                  [EXCEEDING_EMISSION_COEFFICIENT, -0.5],
                   [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
                 ],
               }),

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -2,12 +2,16 @@ import {
   MassIdOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared/types';
+import {
+  MethodologyDocumentEventAttributeValue,
+  NonEmptyString,
+} from '@carrot-fndn/shared/types';
 
 export interface RuleSubject {
   exceedingEmissionCoefficient:
     | MethodologyDocumentEventAttributeValue
     | undefined;
+  gasType: NonEmptyString;
   massIdDocumentValue: number;
   wasteGeneratorBaseline: MethodologyBaseline | undefined;
   wasteSubtype: MassIdOrganicSubtype;

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -48,6 +48,7 @@ export enum DocumentEventAttributeName {
   EXCEEDING_EMISSION_COEFFICIENT = 'Exceeding Emission Coefficient (per ton)',
   EXEMPTION_JUSTIFICATION = 'Exemption Justification',
   EXPIRATION_DATE = 'Expiration Date',
+  GREENHOUSE_GAS_TYPE = 'Greenhouse Gas Type (GHG)',
   GROSS_WEIGHT = 'Gross Weight',
   ISSUE_DATE = 'Issue Date',
   LOCAL_WASTE_CLASSIFICATION_DESCRIPTION = 'Local Waste Classification Description',


### PR DESCRIPTION
### 🧾 Summary

Added Greenhouse Gas Type (GHG) validation and handling to the Prevented Emissions processor, including error handling and result content updates.

### 🧩 Context

This change ensures proper validation and tracking of greenhouse gas types in the emissions processing pipeline.

### 🧱 Scope of this PR

Included:
- New error message for missing greenhouse gas type
- New helper function `getGasTypeFromEvent` with comprehensive tests
- Integration of gas type validation in the processor
- Addition of gas type to result content
- Updated test cases to cover gas type scenarios

### 🧪 How to test

1. Run the test suite:
```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-prevented-emissions
```

2. Verify new test cases for:
   - Valid gas type handling
   - Missing gas type validation
   - Invalid gas type error handling
   - Integration with existing emission calculations

### 🔗 Related Links

[Item](https://www.notion.so/carrot-fndn/Methodologies-Overhaul-Q2-2025-1f89703d8e9c80928051ffd2cd2ddb4a?source=copy_link#23e9703d8e9c8018af1ec326bef0fd34)

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for capturing and validating the "Greenhouse Gas Type (GHG)" attribute in emissions processing.
  * The processed output now includes the greenhouse gas type information.

* **Bug Fixes**
  * Improved error handling for missing or invalid greenhouse gas type attributes.

* **Tests**
  * Expanded and updated test coverage to validate scenarios involving the greenhouse gas type attribute.
  * Enhanced test data to consistently include the greenhouse gas type attribute across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->