### PR TITLE
Add null safety and type conversion for reference year comparison

### DIFF
--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -35,7 +35,7 @@ export const getLastYearEmissionAndCompostingMetricsEvent = ({
           DocumentEventAttributeName.REFERENCE_YEAR,
         );
 
-        return referenceYear === lastDocumentYearYear;
+        return referenceYear?.toString() === lastDocumentYearYear.toString();
       }
 
       return false;


### PR DESCRIPTION
### 🧾 Summary

This PR adds null safety and proper type conversion to the reference year comparison logic in the document getters module.

### 🧩 Context

The existing comparison between `referenceYear` and `lastDocumentYearYear` was vulnerable to null/undefined values and potential type mismatches. This could lead to incorrect filtering of emission and composting metrics events when the reference year is null or when the types don't match exactly.

### 🧱 Scope of this PR

**Included:**
- Added optional chaining (`?.`) to safely handle null/undefined `referenceYear` values
- Added `.toString()` conversion to both values to ensure consistent string comparison

**Not included:**
- No changes to the overall logic flow or other comparison methods

### 🧪 How to test

1. Test with documents that have null/undefined reference years
2. Test with documents where reference years are different data types (string vs number)
3. Verify that the filtering still works correctly for valid reference years
4. Run existing unit tests to ensure no regressions

### 🧠 Considerations for Review

- **Type Safety**: The change ensures both values are converted to strings before comparison
- **Null Safety**: Optional chaining prevents runtime errors when `referenceYear` is null/undefined
- **Backward Compatibility**: The change maintains the same comparison logic while being more robust

### 🔗 Related Links

_No related links for this bug fix._

---

- [ ] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of year comparisons to prevent issues when the reference year is undefined or not in string format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->