### PR TITLE
fix: get participant accreditation from actor relation

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.errors.ts
@@ -7,12 +7,13 @@ import {
 
 const { DROP_OFF, PICK_UP } = DocumentEventName;
 const { MASS_ID } = DocumentCategory;
-const { PARTICIPANT_ACCREDITATION } = DocumentType;
+const { MASS_ID_AUDIT, PARTICIPANT_ACCREDITATION } = DocumentType;
 
 export class GeolocationAndAddressPrecisionProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
     FAILED_BY_ERROR:
       'Unable to validate the geolocation-and-address-precision.',
+    MASS_ID_AUDIT_DOCUMENT_NOT_FOUND: `${MASS_ID_AUDIT} document not found.`,
     MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_REQUIRED_EVENTS: (documentId: string) =>
       `Expected "${DROP_OFF}" and "${PICK_UP}" events in the ${MASS_ID} document ${documentId}.`,
     MASS_ID_DOCUMENT_NOT_FOUND: `${MASS_ID} document not found.`,

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts
@@ -35,7 +35,7 @@ export const getAccreditatedAddressByParticipantIdAndActorType = (
 
   if (isNil(actorEvent)) {
     logger.debug(
-      `[MassID Audit Document${massIdAuditDocument.id}] Actor event not found for participant ${participantId} and actor type ${actorType}`,
+      `[MassID Audit Document ${massIdAuditDocument.id}] Actor event not found for participant ${participantId} and actor type ${actorType}`,
     );
 
     return undefined;
@@ -45,7 +45,7 @@ export const getAccreditatedAddressByParticipantIdAndActorType = (
 
   if (isNil(accreditationDocumentId)) {
     logger.debug(
-      `[MassID Audit Document${massIdAuditDocument.id}] Accreditation document ID not found for actor event ${actorEvent.id}`,
+      `[MassID Audit Document ${massIdAuditDocument.id}] Accreditation document ID not found for actor event ${actorEvent.id}`,
     );
 
     return undefined;
@@ -57,7 +57,7 @@ export const getAccreditatedAddressByParticipantIdAndActorType = (
 
   if (isNil(participantAccreditationDocument)) {
     logger.debug(
-      `[MassID Audit Document${massIdAuditDocument.id}] Participant accreditation document not found for accreditation document ID ${accreditationDocumentId}`,
+      `[MassID Audit Document ${massIdAuditDocument.id}] Participant accreditation document not found for accreditation document ID ${accreditationDocumentId}`,
     );
 
     return undefined;
@@ -70,7 +70,7 @@ export const getAccreditatedAddressByParticipantIdAndActorType = (
 
   if (!facilityAddressEvent) {
     logger.debug(
-      `[MassID Audit Document${massIdAuditDocument.id}] Facility address event not found for participant ${participantId} and actor type ${actorType}`,
+      `[MassID Audit Document ${massIdAuditDocument.id}] Facility address event not found for participant ${participantId} and actor type ${actorType}`,
     );
 
     return undefined;

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
@@ -125,12 +125,11 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
 
           const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
-          expect(ruleOutput).toEqual({
-            requestId: ruleInput.requestId,
-            responseToken: ruleInput.responseToken,
-            responseUrl: ruleInput.responseUrl,
+          expectRuleOutput({
             resultComment: testCase.resultComment,
             resultStatus: testCase.resultStatus,
+            ruleInput,
+            ruleOutput,
           });
         } else {
           spyOnLoadDocument(undefined);
@@ -139,12 +138,11 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
 
           const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
-          expect(ruleOutput).toEqual({
-            requestId: ruleInput.requestId,
-            responseToken: ruleInput.responseToken,
-            responseUrl: ruleInput.responseUrl,
+          expectRuleOutput({
             resultComment: testCase.resultComment,
             resultStatus: testCase.resultStatus,
+            ruleInput,
+            ruleOutput,
           });
         }
       },

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -387,4 +387,11 @@ export const geolocationAndAddressPrecisionErrorTestCases = [
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the accreditation documents are not found',
   },
+  {
+    documents: [],
+    massIdAuditDocument: undefined,
+    resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_AUDIT_DOCUMENT_NOT_FOUND,
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario: 'the MassID Audit document does not exist',
+  },
 ];


### PR DESCRIPTION
### 🧾 Summary

Fix geolocation-and-address-precision to resolve the participant’s accredited facility address via the MassID Audit ACTOR event relation to the Participant Accreditation document. Adds full unit and E2E coverage.

### 🧩 Context

Previously, the rule could not reliably fetch the participant’s accreditation address. This change sources the accredited facility address by:
- Finding the ACTOR event in the MassID Audit document for the event’s participant and actor type
- Following its `relatedDocument.documentId` to the Participant Accreditation document
- Reading the `FACILITY_ADDRESS` event as the “accreditated” address

This ensures distance checks are grounded in the proper per-participant accreditation.

### 🧱 Scope of this PR

- Geolocation-and-address-precision rule for MassID:
  - Uses ACTOR event relation in the MassID Audit document to locate the correct Participant Accreditation document
  - Reads `FACILITY_ADDRESS` as the accredited address

- New helper and error handling:
  - `getAccreditatedAddressByParticipantIdAndActorType(...)` to resolve accreditation via actor relation
  - Clear error messages for missing documents/events

- Tests:
  - Comprehensive unit tests for helpers and processor
  - E2E tests for lambda handler

- No API changes and no deployment config changes

Touched files (representative):
- `libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts`
- `libs/.../geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts`
- `libs/.../geolocation-and-address-precision/src/geolocation-and-address-precision.errors.ts`
- `libs/.../geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts`
- `libs/.../geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts`
- `libs/.../geolocation-and-address-precision/src/geolocation-and-address-precision.lambda.e2e.spec.ts`
- `libs/.../geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts`

### 🧪 How to test

- Run all tests:
  - `pnpm test:all`
- Or target this rule’s tests (Nx):
  - `pnpm nx test methodologies-bold-rule-processors-mass-id-geolocation-and-address-precision`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address resolution now uses MassID Audit context and actor type to select participant addresses.
  * Added an explicit error when the MassID Audit document is missing.

* **Bug Fixes**
  * More robust handling when related accreditation or facility address data are absent to avoid silent failures.

* **Tests**
  * Expanded unit and E2E coverage for actor-based scenarios and missing-document cases; improved test fixtures and event wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->