### PR TITLE
fix: correct typo accreditated to accredited

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
@@ -15,7 +15,7 @@ import { stubArray } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
 
 import {
-  getAccreditatedAddressByParticipantIdAndActorType,
+  getAccreditedAddressByParticipantIdAndActorType,
   getEventGpsGeolocation,
 } from './geolocation-and-address-precision.helpers';
 
@@ -24,8 +24,8 @@ const { CAPTURED_GPS_LATITUDE, CAPTURED_GPS_LONGITUDE } =
   DocumentEventAttributeName;
 
 describe('GeolocationAndAddressPrecisionHelpers', () => {
-  describe('getAccreditatedAddressByParticipantIdAndActorType', () => {
-    it('should return the accreditated address by participant id and actor type', () => {
+  describe('getAccreditedAddressByParticipantIdAndActorType', () => {
+    it('should return the accredited address by participant id and actor type', () => {
       const participantId = faker.string.uuid();
       const actorType = MassIdDocumentActorType.RECYCLER;
       const addressId = faker.string.uuid();
@@ -56,7 +56,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         ]),
       });
 
-      const result = getAccreditatedAddressByParticipantIdAndActorType(
+      const result = getAccreditedAddressByParticipantIdAndActorType(
         massIdAuditDocument,
         participantId,
         actorType,
@@ -79,7 +79,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         externalEventsMap: new Map(),
       });
 
-      const result = getAccreditatedAddressByParticipantIdAndActorType(
+      const result = getAccreditedAddressByParticipantIdAndActorType(
         massIdAuditDocument,
         participantId,
         actorType,
@@ -109,7 +109,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         ]),
       });
 
-      const result = getAccreditatedAddressByParticipantIdAndActorType(
+      const result = getAccreditedAddressByParticipantIdAndActorType(
         massIdAuditDocument,
         participantId,
         actorType,
@@ -139,7 +139,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         ]),
       });
 
-      const result = getAccreditatedAddressByParticipantIdAndActorType(
+      const result = getAccreditedAddressByParticipantIdAndActorType(
         massIdAuditDocument,
         participantId,
         actorType,
@@ -171,7 +171,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         ]),
       });
 
-      const result = getAccreditatedAddressByParticipantIdAndActorType(
+      const result = getAccreditedAddressByParticipantIdAndActorType(
         massIdAuditDocument,
         participantId,
         actorType,

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts
@@ -20,7 +20,7 @@ import {
 } from '@carrot-fndn/shared/types';
 import { is } from 'typia';
 
-export const getAccreditatedAddressByParticipantIdAndActorType = (
+export const getAccreditedAddressByParticipantIdAndActorType = (
   massIdAuditDocument: Document,
   participantId: string,
   actorType: MassIdDocumentActorType,

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
@@ -39,7 +39,7 @@ import {
 
 import { GeolocationAndAddressPrecisionProcessorErrors } from './geolocation-and-address-precision.errors';
 import {
-  getAccreditatedAddressByParticipantIdAndActorType,
+  getAccreditedAddressByParticipantIdAndActorType,
   getEventGpsGeolocation,
 } from './geolocation-and-address-precision.helpers';
 
@@ -52,7 +52,7 @@ export interface RuleSubject {
 }
 
 interface ParticipantAddressData {
-  accreditatedAddress: MethodologyAddress | undefined;
+  accreditedAddress: MethodologyAddress | undefined;
   eventAddress: MethodologyAddress;
   gpsGeolocation: Geolocation | undefined;
 }
@@ -63,19 +63,19 @@ export const RESULT_COMMENTS = {
     actorType: string,
     addressDistance: number,
   ): string =>
-    `(${actorType}) The event address is ${addressDistance}m away from the accreditated address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
+    `(${actorType}) The event address is ${addressDistance}m away from the accredited address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
   INVALID_GPS_DISTANCE: (actorType: string, gpsDistance: number): string =>
-    `(${actorType}) The captured GPS location is ${gpsDistance}m away from the accreditated address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
+    `(${actorType}) The captured GPS location is ${gpsDistance}m away from the accredited address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
   MISSING_ACCREDITATION_ADDRESS: (actorType: string): string =>
-    `No accreditated address was found for the ${actorType} actor.`,
+    `No accredited address was found for the ${actorType} actor.`,
   PASSED_WITH_GPS: (
     actorType: string,
     addressDistance: number,
     gpsDistance: number,
   ): string =>
-    `(${actorType}) The event address is within ${MAX_ALLOWED_DISTANCE}m of the accreditated address (${addressDistance}m), and the GPS location is within ${MAX_ALLOWED_DISTANCE}m of the event address (${gpsDistance}m).`,
+    `(${actorType}) The event address is within ${MAX_ALLOWED_DISTANCE}m of the accredited address (${addressDistance}m), and the GPS location is within ${MAX_ALLOWED_DISTANCE}m of the event address (${gpsDistance}m).`,
   PASSED_WITHOUT_GPS: (actorType: string, addressDistance: number): string =>
-    `(${actorType}) The event address is within ${MAX_ALLOWED_DISTANCE}m of the accreditated address (${addressDistance}m). No GPS data was provided.`,
+    `(${actorType}) The event address is within ${MAX_ALLOWED_DISTANCE}m of the accredited address (${addressDistance}m). No GPS data was provided.`,
 } as const;
 
 export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
@@ -174,7 +174,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
       }
 
       participantsAddressData.set(actorType, {
-        accreditatedAddress: getAccreditatedAddressByParticipantIdAndActorType(
+        accreditedAddress: getAccreditedAddressByParticipantIdAndActorType(
           massIdAuditDocument,
           event.participant.id,
           actorType,
@@ -190,16 +190,16 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
 
   private calculateAddressDistance(
     eventAddress: MethodologyAddress,
-    accreditatedAddress: MethodologyAddress,
+    accreditedAddress: MethodologyAddress,
   ): number {
-    return calculateDistance(eventAddress, accreditatedAddress);
+    return calculateDistance(eventAddress, accreditedAddress);
   }
 
   private calculateGpsDistance(
-    accreditatedAddress: MethodologyAddress,
+    accreditedAddress: MethodologyAddress,
     gpsGeolocation: Geolocation,
   ): number {
-    return calculateDistance(accreditatedAddress, gpsGeolocation);
+    return calculateDistance(accreditedAddress, gpsGeolocation);
   }
 
   private async collectDocuments(
@@ -234,9 +234,9 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
     actorType: MassIdDocumentActorType,
     addressData: ParticipantAddressData,
   ): EvaluateResultOutput[] {
-    const { accreditatedAddress, eventAddress, gpsGeolocation } = addressData;
+    const { accreditedAddress, eventAddress, gpsGeolocation } = addressData;
 
-    if (isNil(accreditatedAddress)) {
+    if (isNil(accreditedAddress)) {
       return [
         {
           resultComment:
@@ -248,7 +248,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
 
     const addressDistance = this.calculateAddressDistance(
       eventAddress,
-      accreditatedAddress,
+      accreditedAddress,
     );
 
     if (addressDistance > MAX_ALLOWED_DISTANCE) {
@@ -265,7 +265,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
 
     if (!isNil(gpsGeolocation)) {
       const gpsDistance = this.calculateGpsDistance(
-        accreditatedAddress,
+        accreditedAddress,
         gpsGeolocation,
       );
 

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -172,7 +172,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
     actorParticipants,
     resultComment: `${RESULT_COMMENTS.MISSING_ACCREDITATION_ADDRESS(WASTE_GENERATOR)} ${RESULT_COMMENTS.MISSING_ACCREDITATION_ADDRESS(RECYCLER)}`,
     resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the accreditated address is not set',
+    scenario: 'the accredited address is not set',
   },
   {
     accreditationDocuments: validAccreditationDocuments,
@@ -297,7 +297,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
     resultComment: `${RESULT_COMMENTS.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
-      'the gps is not set, but the accreditated address is set and is valid',
+      'the gps is not set, but the accredited address is set and is valid',
   },
   {
     accreditationDocuments: validAccreditationDocuments,
@@ -331,7 +331,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
     resultComment: `${RESULT_COMMENTS.INVALID_ADDRESS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.INVALID_ADDRESS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
-      'the gps is not set, but the accreditated address is set and not valid',
+      'the gps is not set, but the accredited address is set and not valid',
   },
 ];
 


### PR DESCRIPTION
### 🧾 Summary

This PR corrects a typo throughout the geolocation and address precision rule processor, changing "accreditated" to "accredited" in function names, variable names, comments, and test descriptions.

### 🧩 Context

During code review, it was discovered that the word "accreditated" was incorrectly used instead of "accredited" throughout the geolocation and address precision rule processor. This typo appeared in function names, variable names, comments, and test descriptions, which could lead to confusion and inconsistency in the codebase.

### 🧱 Scope of this PR

**Included:**
- Function name: `getAccreditatedAddressByParticipantIdAndActorType` → `getAccreditedAddressByParticipantIdAndActorType`
- Variable names: `accreditatedAddress` → `accreditedAddress`
- All related comments and error messages
- Test descriptions and scenario names

**Not included:**
- No functional changes to the rule logic
- No changes to other rule processors
- No changes to external interfaces or APIs

### 🧪 How to test

1. **Run the existing tests** to ensure the typo fix doesn't break functionality:
   ```bash
   pnpm test libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision
   ```

2. **Verify the typo is fixed** by checking that all instances of "accreditated" have been replaced with "accredited" in:
   - Function names
   - Variable names
   - Comments and error messages
   - Test descriptions

3. **Ensure no functionality is broken** by running the broader test suite:
   ```bash
   pnpm test:affected
   ```

### 🧠 Considerations for Review

- **Simple typo fix**: This is a straightforward text replacement with no logic changes
- **Consistency**: All instances of the typo have been corrected across all affected files
- **No breaking changes**: Function signatures and behavior remain identical
- **Test coverage**: All existing tests continue to pass

### 🔗 Related Links

- [Pull Request #295](https://github.com/carrot-foundation/methodology-rules/pull/295)
- [Geolocation and Address Precision Rule Processor](libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/)

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized terminology from “accreditated” to “accredited” across the feature, including a public API name and a related data field.
  * Updated processing flow and user-facing result messages to use the corrected term for consistency. No behavioral changes.

* **Tests**
  * Aligned test names and scenarios with the updated “accredited” terminology.

* **Chores**
  * Cleaned up references and imports to reflect the renamed public API and data field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->