### PR TITLE
chore: improve some error messages

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
@@ -22,13 +22,13 @@ const { PICK_UP } = DocumentEventName;
 const { SLUDGE_PIPES } = DocumentEventVehicleType;
 
 export const RESULT_COMMENTS = {
-  DRIVER_AND_JUSTIFICATION_PROVIDED: `In the Pick-up event, both the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" and "${DRIVER_IDENTIFIER}" were provided, but only one is allowed.`,
-  DRIVER_IDENTIFIER: `In the Pick-up event, the "${DRIVER_IDENTIFIER}" was provided.`,
+  DRIVER_AND_JUSTIFICATION_PROVIDED: `In the ${PICK_UP} event, both the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" and "${DRIVER_IDENTIFIER}" were provided, but only one is allowed.`,
+  DRIVER_IDENTIFIER: `In the ${PICK_UP} event, the "${DRIVER_IDENTIFIER}" was provided.`,
   JUSTIFICATION_PROVIDED: (justification: string) =>
-    `In the Pick-up event, the "${DRIVER_IDENTIFIER}" was not provided, but a "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" was declared: ${justification}.`,
+    `In the ${PICK_UP} event, the "${DRIVER_IDENTIFIER}" was not provided, but a "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" was declared: ${justification}.`,
   MISSING_JUSTIFICATION: (vehicleType: string) =>
-    `In the Pick-up event, the vehicle "${vehicleType}" requires either a "${DRIVER_IDENTIFIER}" or an "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}".`,
-  SLUDGE_PIPES: `In the Pick-up event, the "${VEHICLE_TYPE}" is "${SLUDGE_PIPES}", so driver identification is not required.`,
+    `In the ${PICK_UP} event, the vehicle "${vehicleType}" requires either a "${DRIVER_IDENTIFIER}" or an "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}".`,
+  SLUDGE_PIPES: `In the ${PICK_UP} event, the "${VEHICLE_TYPE}" is "${SLUDGE_PIPES}", so driver identification is not required.`,
 } as const;
 
 interface RuleSubject {

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
@@ -22,13 +22,13 @@ const { PICK_UP } = DocumentEventName;
 const { SLUDGE_PIPES } = DocumentEventVehicleType;
 
 export const RESULT_COMMENTS = {
-  DRIVER_AND_JUSTIFICATION_PROVIDED: `Both the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" and "${DRIVER_IDENTIFIER}" were provided, but only one is allowed.`,
-  DRIVER_IDENTIFIER: `The "${DRIVER_IDENTIFIER}" was provided.`,
+  DRIVER_AND_JUSTIFICATION_PROVIDED: `In the Pick-up event, both the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" and "${DRIVER_IDENTIFIER}" were provided, but only one is allowed.`,
+  DRIVER_IDENTIFIER: `In the Pick-up event, the "${DRIVER_IDENTIFIER}" was provided.`,
   JUSTIFICATION_PROVIDED: (justification: string) =>
-    `The "${DRIVER_IDENTIFIER}" was not provided, but a "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" was declared: ${justification}.`,
+    `In the Pick-up event, the "${DRIVER_IDENTIFIER}" was not provided, but a "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" was declared: ${justification}.`,
   MISSING_JUSTIFICATION: (vehicleType: string) =>
-    `The vehicle "${vehicleType}" requires either a "${DRIVER_IDENTIFIER}" or an "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}".`,
-  SLUDGE_PIPES: `The "${VEHICLE_TYPE}" is "${SLUDGE_PIPES}", so driver identification is not required.`,
+    `In the Pick-up event, the vehicle "${vehicleType}" requires either a "${DRIVER_IDENTIFIER}" or an "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}".`,
+  SLUDGE_PIPES: `In the Pick-up event, the "${VEHICLE_TYPE}" is "${SLUDGE_PIPES}", so driver identification is not required.`,
 } as const;
 
 interface RuleSubject {

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
@@ -63,9 +63,9 @@ export const RESULT_COMMENTS = {
     actorType: string,
     addressDistance: number,
   ): string =>
-    `(${actorType}) The event address is ${addressDistance}m away from the accredited address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
+    `Non-compliant ${actorType} address: the event address is ${addressDistance}m away from the accredited address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
   INVALID_GPS_DISTANCE: (actorType: string, gpsDistance: number): string =>
-    `(${actorType}) The captured GPS location is ${gpsDistance}m away from the accredited address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
+    `Non-compliant ${actorType} address: the captured GPS location is ${gpsDistance}m away from the accredited address, exceeding the ${MAX_ALLOWED_DISTANCE}m limit.`,
   MISSING_ACCREDITATION_ADDRESS: (actorType: string): string =>
     `No accredited address was found for the ${actorType} actor.`,
   PASSED_WITH_GPS: (
@@ -73,9 +73,9 @@ export const RESULT_COMMENTS = {
     addressDistance: number,
     gpsDistance: number,
   ): string =>
-    `(${actorType}) The event address is within ${MAX_ALLOWED_DISTANCE}m of the accredited address (${addressDistance}m), and the GPS location is within ${MAX_ALLOWED_DISTANCE}m of the event address (${gpsDistance}m).`,
+    `Compliant ${actorType} address: the event address is within ${MAX_ALLOWED_DISTANCE}m of the accredited address (${addressDistance}m), and the GPS location is within ${MAX_ALLOWED_DISTANCE}m of the event address (${gpsDistance}m).`,
   PASSED_WITHOUT_GPS: (actorType: string, addressDistance: number): string =>
-    `(${actorType}) The event address is within ${MAX_ALLOWED_DISTANCE}m of the accredited address (${addressDistance}m). No GPS data was provided.`,
+    `Compliant ${actorType} address: the event address is within ${MAX_ALLOWED_DISTANCE}m of the accredited address (${addressDistance}m) (note: no GPS data was provided).`,
 } as const;
 
 export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -34,7 +34,7 @@ export const RESULT_COMMENTS = {
   CLASSIFICATION_DESCRIPTION_MISSING: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" was not provided.`,
   CLASSIFICATION_ID_MISSING: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" was not provided.`,
   INVALID_CLASSIFICATION_DESCRIPTION: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" does not match the expected IBAMA code description.`,
-  INVALID_CLASSIFICATION_ID: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" does not match any IBAMA code.`,
+  INVALID_CLASSIFICATION_ID: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" does not match an IBAMA code accepted by the methodology.`,
   UNSUPPORTED_COUNTRY: (recyclerCountryCode: string) =>
     `Local waste classification is only validated for recyclers in Brazil, but the recycler country is ${recyclerCountryCode}.`,
   VALID_CLASSIFICATION:

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.ts
@@ -33,18 +33,18 @@ export const VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES = new Set([
 ]);
 
 export const RESULT_COMMENTS = {
-  INVALID_LICENSE_PLATE_FORMAT: `In the Pick-up event, the "${VEHICLE_LICENSE_PLATE}" format is invalid.`,
+  INVALID_LICENSE_PLATE_FORMAT: `In the ${PICK_UP} event, the "${VEHICLE_LICENSE_PLATE}" format is invalid.`,
   INVALID_VEHICLE_TYPE: (vehicleType: string) =>
-    `In the Pick-up event, the "${VEHICLE_TYPE}" "${vehicleType}" is not supported by the methodology.`,
+    `In the ${PICK_UP} event, the "${VEHICLE_TYPE}" "${vehicleType}" is not supported by the methodology.`,
   LICENSE_PLATE_MISSING: (vehicleType: string) =>
-    `In the Pick-up event, the "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_LICENSE_PLATE}", but none was provided.`,
+    `In the ${PICK_UP} event, the "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_LICENSE_PLATE}", but none was provided.`,
   PICK_UP_EVENT_MISSING: `Expected "${PICK_UP}" event to be declared.`,
   VEHICLE_DESCRIPTION_MISSING: (vehicleType: string) =>
-    `In the Pick-up event, the "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_DESCRIPTION}", but none was provided.`,
+    `In the ${PICK_UP} event, the "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_DESCRIPTION}", but none was provided.`,
   VEHICLE_IDENTIFIED_WITH_DESCRIPTION: (vehicleType: string) =>
     `A "${VEHICLE_LICENSE_PLATE}" is not required for "${vehicleType}", and the "${VEHICLE_DESCRIPTION}" was provided.`,
-  VEHICLE_IDENTIFIED_WITH_LICENSE_PLATE: `In the Pick-up event, a valid "${VEHICLE_TYPE}" and correctly formatted "${VEHICLE_LICENSE_PLATE}" were provided.`,
-  VEHICLE_TYPE_MISSING: `In the Pick-up event, the "${VEHICLE_TYPE}" was not provided.`,
+  VEHICLE_IDENTIFIED_WITH_LICENSE_PLATE: `In the ${PICK_UP} event, a valid "${VEHICLE_TYPE}" and correctly formatted "${VEHICLE_LICENSE_PLATE}" were provided.`,
+  VEHICLE_TYPE_MISSING: `In the ${PICK_UP} event, the "${VEHICLE_TYPE}" was not provided.`,
 } as const;
 
 interface RuleSubject {

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.ts
@@ -33,18 +33,18 @@ export const VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES = new Set([
 ]);
 
 export const RESULT_COMMENTS = {
-  INVALID_LICENSE_PLATE_FORMAT: `The "${VEHICLE_LICENSE_PLATE}" format is invalid.`,
+  INVALID_LICENSE_PLATE_FORMAT: `In the Pick-up event, the "${VEHICLE_LICENSE_PLATE}" format is invalid.`,
   INVALID_VEHICLE_TYPE: (vehicleType: string) =>
-    `The "${VEHICLE_TYPE}" "${vehicleType}" is not supported by the methodology.`,
+    `In the Pick-up event, the "${VEHICLE_TYPE}" "${vehicleType}" is not supported by the methodology.`,
   LICENSE_PLATE_MISSING: (vehicleType: string) =>
-    `The "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_LICENSE_PLATE}", but none was provided.`,
+    `In the Pick-up event, the "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_LICENSE_PLATE}", but none was provided.`,
   PICK_UP_EVENT_MISSING: `Expected "${PICK_UP}" event to be declared.`,
   VEHICLE_DESCRIPTION_MISSING: (vehicleType: string) =>
-    `The "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_DESCRIPTION}", but none was provided.`,
+    `In the Pick-up event, the "${VEHICLE_TYPE}" is "${vehicleType}", which requires a "${VEHICLE_DESCRIPTION}", but none was provided.`,
   VEHICLE_IDENTIFIED_WITH_DESCRIPTION: (vehicleType: string) =>
     `A "${VEHICLE_LICENSE_PLATE}" is not required for "${vehicleType}", and the "${VEHICLE_DESCRIPTION}" was provided.`,
-  VEHICLE_IDENTIFIED_WITH_LICENSE_PLATE: `A valid "${VEHICLE_TYPE}" and correctly formatted "${VEHICLE_LICENSE_PLATE}" were provided.`,
-  VEHICLE_TYPE_MISSING: `The "${VEHICLE_TYPE}" was not provided.`,
+  VEHICLE_IDENTIFIED_WITH_LICENSE_PLATE: `In the Pick-up event, a valid "${VEHICLE_TYPE}" and correctly formatted "${VEHICLE_LICENSE_PLATE}" were provided.`,
+  VEHICLE_TYPE_MISSING: `In the Pick-up event, the "${VEHICLE_TYPE}" was not provided.`,
 } as const;
 
 interface RuleSubject {


### PR DESCRIPTION
### 🧾 Summary

This PR improves error message clarity and consistency across multiple rule processors in the BOLD methodology. The changes focus on making error messages more descriptive, context-aware, and user-friendly by adding specific context about which events the validation applies to and improving the overall readability of compliance messages.

### 🧩 Context

Error messages in rule processors are critical for users to understand why their data failed validation and how to fix issues. The current error messages were sometimes too generic and lacked context about which specific events or sections of the document were being validated. This improvement enhances the user experience by providing clearer, more actionable feedback.

This change is part of ongoing efforts to improve the overall quality and usability of the methodology rules system, making it easier for users to understand and resolve validation issues.

### 🧱 Scope of this PR

**Included:**
- Enhanced error messages in 4 rule processors:
  - `driver-identification` - Added "In the Pick-up event" context to all driver-related validation messages
  - `geolocation-and-address-precision` - Improved compliance status messages with clearer "Compliant" vs "Non-compliant" indicators
  - `regional-waste-classification` - Clarified IBAMA code validation message to be more specific about methodology acceptance
  - `vehicle-identification` - Added "In the Pick-up event" context to vehicle validation messages

**Not included:**
- Changes to other rule processors
- Modifications to the core validation logic
- Updates to test coverage (existing tests should continue to pass)

### 🧪 How to test

1. **Run existing tests** to ensure no functionality was broken:
   ```bash
   pnpm test:affected --projects=driver-identification,geolocation-and-address-precision,regional-waste-classification,vehicle-identification
   ```

2. **Verify error message improvements** by checking the updated `RESULT_COMMENTS` constants in each processor:
   - Messages should now include "In the Pick-up event" context where applicable
   - Geolocation messages should clearly indicate "Compliant" vs "Non-compliant" status
   - Regional waste classification message should mention "accepted by the methodology"

3. **Check that validation logic remains unchanged** - only the error message text has been updated

### 🧠 Considerations for Review

**Areas requiring attention:**
- **Message consistency**: Ensure all similar validation contexts use consistent phrasing
- **Context accuracy**: Verify that "In the Pick-up event" context is appropriate for all driver and vehicle validations
- **User experience**: Consider whether the new message format provides clearer guidance to users

**Trade-offs:**
- **Message length**: Some error messages are now longer, but provide more context
- **Maintenance**: More specific messages may require updates if validation logic changes

**Future considerations:**
- Consider applying similar improvements to other rule processors
- Evaluate whether additional context (like document section names) could be added to other error messages

### 🔗 Related Links

- [BOLD Methodology Rules Documentation](https://github.com/carrot-foundation/methodology-rules/tree/main/apps/methodologies/bold)
- [Rule Processor Architecture](https://github.com/carrot-foundation/methodology-rules/tree/main/libs/methodologies/bold/rule-processors)

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Prefixed driver identification messages with "In the Pick-up event," for clearer context; no logic changes.
  * Prefixed vehicle identification messages with "In the Pick-up event," clarifying missing/invalid fields and successes.
  * Reworded geolocation/address messages to label outcomes as "Compliant" or "Non-compliant {actorType} address" with explicit distance info and GPS notes.
  * Clarified regional waste classification text to indicate the local ID isn't an IBAMA code accepted by the methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->