### PR TITLE
Update AI Attachment Validation to Use System Prompt Parameter

### DIFF
--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/recycling-manifest-data/src/lambda.ts
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/recycling-manifest-data/src/lambda.ts
@@ -6,7 +6,7 @@ const { RECYCLING_MANIFEST } = DocumentEventName;
 
 export const handler = documentManifestDataLambda({
   aiParameters: {
-    additionalContext: RECYCLING_MANIFEST_AI_CONTEXT,
+    systemPrompt: RECYCLING_MANIFEST_AI_CONTEXT,
   },
   documentManifestType: RECYCLING_MANIFEST,
 });

--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/transport-manifest-data/src/lambda.ts
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/transport-manifest-data/src/lambda.ts
@@ -6,7 +6,7 @@ const { TRANSPORT_MANIFEST } = DocumentEventName;
 
 export const handler = documentManifestDataLambda({
   aiParameters: {
-    additionalContext: TRANSPORT_MANIFEST_AI_CONTEXT,
+    systemPrompt: TRANSPORT_MANIFEST_AI_CONTEXT,
   },
   documentManifestType: TRANSPORT_MANIFEST,
 });

--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/recycling-manifest-data/src/lambda.ts
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/recycling-manifest-data/src/lambda.ts
@@ -6,7 +6,7 @@ const { RECYCLING_MANIFEST } = DocumentEventName;
 
 export const handler = documentManifestDataLambda({
   aiParameters: {
-    additionalContext: RECYCLING_MANIFEST_AI_CONTEXT,
+    systemPrompt: RECYCLING_MANIFEST_AI_CONTEXT,
   },
   documentManifestType: RECYCLING_MANIFEST,
 });

--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/transport-manifest-data/src/lambda.ts
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/transport-manifest-data/src/lambda.ts
@@ -6,7 +6,7 @@ const { TRANSPORT_MANIFEST } = DocumentEventName;
 
 export const handler = documentManifestDataLambda({
   aiParameters: {
-    additionalContext: TRANSPORT_MANIFEST_AI_CONTEXT,
+    systemPrompt: TRANSPORT_MANIFEST_AI_CONTEXT,
   },
   documentManifestType: TRANSPORT_MANIFEST,
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
@@ -116,9 +116,7 @@ describe('DocumentManifestDataProcessor', () => {
       await ruleDataProcessor.process(ruleInput);
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'AI attachment validation failed for document manifest type',
-        ),
+        expect.stringContaining('AI Attachment Validation failed'),
       );
 
       loggerWarnSpy.mockRestore();
@@ -167,6 +165,42 @@ describe('DocumentManifestDataProcessor', () => {
         Namespace: CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE,
       });
 
+      delete process.env['VALIDATE_ATTACHMENTS_CONSISTENCY_WITH_AI'];
+    });
+
+    it('should log error when recordAIValidationFailure fails to put metric', async () => {
+      jest
+        .spyOn(CloudWatchMetricsService.prototype, 'isEnabled')
+        .mockReturnValue(true);
+      const cloudWatchMock = mockClient(CloudWatchClient);
+      const loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation();
+
+      const mockError = new Error('CloudWatch service unavailable');
+
+      cloudWatchMock.on(PutMetricDataCommand).rejects(mockError);
+
+      process.env['VALIDATE_ATTACHMENTS_CONSISTENCY_WITH_AI'] = 'true';
+
+      const ruleDataProcessor = new DocumentManifestDataProcessor({
+        aiParameters: {},
+        documentManifestType: DocumentEventName.TRANSPORT_MANIFEST,
+      });
+      const ruleInput = random<Required<RuleInput>>();
+      const { massIdDocument } = new BoldStubsBuilder()
+        .createMassIdDocuments({
+          externalEventsMap: {},
+        })
+        .build();
+
+      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      await ruleDataProcessor.process(ruleInput);
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Failed to record CloudWatch metric for AI validation failure (Transport Manifest)',
+        mockError,
+      );
+
+      loggerErrorSpy.mockRestore();
       delete process.env['VALIDATE_ATTACHMENTS_CONSISTENCY_WITH_AI'];
     });
   });

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.ts
@@ -46,7 +46,7 @@ const { RECYCLER } = MethodologyDocumentEventLabel;
 const { DATE } = MethodologyDocumentEventAttributeFormat;
 
 export interface AIParameters {
-  additionalContext?: NonEmptyString;
+  systemPrompt?: NonEmptyString;
 }
 
 export type DocumentManifestType =
@@ -241,17 +241,25 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
     for (const attachmentPath of attachmentPaths) {
       const aiValidationResult =
         await aiAttachmentValidatorService.validateAttachment({
-          additionalContext: this.aiParameters.additionalContext,
           attachmentPath,
           document,
+          systemPrompt: this.aiParameters.systemPrompt,
         });
 
-      if (aiValidationResult.isValid === false) {
-        logger.warn(
-          `AI attachment validation failed for document manifest type ${this.documentManifestType} (${attachmentPath}): ${aiValidationResult.validationResponse}`,
-        );
+      const baseLogInfo = {
+        reasoning: aiValidationResult.reasoning,
+        validationResponse: aiValidationResult.validationResponse,
+      };
 
-        const cloudWatchMetricsService = CloudWatchMetricsService.getInstance();
+      logger.warn(
+        'AI Attachment Validation performed',
+        JSON.stringify(baseLogInfo),
+      );
+
+      const cloudWatchMetricsService = CloudWatchMetricsService.getInstance();
+
+      if (aiValidationResult.isValid === false) {
+        logger.warn('AI Attachment Validation failed');
 
         if (cloudWatchMetricsService.isEnabled()) {
           try {
@@ -259,9 +267,9 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
               documentManifestType: this.documentManifestType,
             });
           } catch (error) {
-            logger.warn(
+            logger.error(
               `Failed to record CloudWatch metric for AI validation failure (${this.documentManifestType})`,
-              error instanceof Error ? error.message : String(error),
+              error,
             );
           }
         }

--- a/libs/shared/methodologies/ai-attachment-validator/src/ai-attachment-validator.api.dto.ts
+++ b/libs/shared/methodologies/ai-attachment-validator/src/ai-attachment-validator.api.dto.ts
@@ -1,20 +1,38 @@
 import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
-import { NonEmptyArray, NonEmptyString } from '@carrot-fndn/shared/types';
+import { NonEmptyString, NonZeroPositiveInt } from '@carrot-fndn/shared/types';
 
 export interface AiValidateAttachmentDto {
-  additionalContext?: NonEmptyString | undefined;
   attachmentPath: NonEmptyString;
   document: Document;
+  systemPrompt?: NonEmptyString | undefined;
 }
 
-export type ApiAiValidationResponse = NonEmptyArray<{
+export interface ApiAiValidationResponse {
+  usage: TokenUsage;
+  validation: ValidationResult;
+}
+
+export interface ApiValidateAttachmentResponse {
+  isValid: boolean;
+  reasoning?: NonEmptyString;
+  usage: TokenUsage;
+  validationResponse: NonEmptyString;
+}
+
+export interface TokenUsage {
+  inputTokens: NonZeroPositiveInt;
+  outputTokens: NonZeroPositiveInt;
+  totalTokens: NonZeroPositiveInt;
+}
+
+export interface ValidationField {
   fieldName: NonEmptyString;
   invalidReason: NonEmptyString | null;
   isValid: boolean;
   value: unknown;
-}>;
+}
 
-export interface ApiValidateAttachmentResponse {
-  isValid: boolean;
-  validationResponse: NonEmptyString;
+export interface ValidationResult {
+  fields: ValidationField[];
+  reasoning: NonEmptyString;
 }

--- a/libs/shared/methodologies/ai-attachment-validator/src/ai-attachment-validator.constants.ts
+++ b/libs/shared/methodologies/ai-attachment-validator/src/ai-attachment-validator.constants.ts
@@ -5,7 +5,6 @@ import { assert } from 'typia';
 export const getAiAttachmentValidatorApiUri = (): Uri =>
   assert<Uri>(process.env['AI_ATTACHMENT_VALIDATOR_API_URI']);
 
-export const VALIDATION_MODE = 'flexible' as const;
 export const VALID_MESSAGE = 'Attachment is valid';
 export const FIELD_SEPARATOR = '; ';
 export const VALIDATION_UNAVAILABLE_MESSAGE =


### PR DESCRIPTION
### 🧾 Summary

This PR updates the AI attachment validation system to use a `systemPrompt` parameter instead of `additionalContext`, enhances error handling for CloudWatch integration, and improves the validation response structure with token usage tracking.

### 🧩 Context

The changes are part of improving the AI validation service to provide better context management and more detailed validation results. The rename from `additionalContext` to `systemPrompt` better reflects the parameter's purpose, and the enhanced error handling ensures better reliability when CloudWatch metrics fail.

### 🧱 Scope of this PR

- Renamed `additionalContext` parameter to `systemPrompt` across all rule processors
- Enhanced error logging and CloudWatch metric handling
- Added token usage tracking in validation responses
- Improved validation response structure with reasoning fields
- Updated tests to reflect new response format

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**