### PR TITLE
Fix accreditation validation for optional expiration dates

### DIFF
--- a/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.spec.ts
@@ -146,6 +146,22 @@ describe('Accreditation Document Helpers', () => {
 
       expect(isAccreditationValid(document)).toBe(false);
     });
+
+    it('should return true if the document has a ACCREDITATION_RESULT event with valid effective date but no expiration date', () => {
+      const document = stubParticipantAccreditationDocument({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes(
+            { name: ACCREDITATION_RESULT },
+            [
+              [EFFECTIVE_DATE, subDays(new Date(), 5).toISOString()],
+              [ACCREDITATION_STATUS, DocumentEventAccreditationStatus.APPROVED],
+            ],
+          ),
+        ],
+      });
+
+      expect(isAccreditationValid(document)).toBe(true);
+    });
   });
 
   describe('getParticipantAccreditationDocumentByParticipantId', () => {

--- a/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.ts
+++ b/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.ts
@@ -43,9 +43,11 @@ export const isAccreditationValid = (document: Document): boolean => {
     DocumentEventAttributeName.ACCREDITATION_STATUS,
   );
 
+  const expirationDateExists = expirationDate !== undefined;
+
   if (
     !is<DateTime>(effectiveDate) ||
-    !is<DateTime>(expirationDate) ||
+    (expirationDateExists && !is<DateTime>(expirationDate)) ||
     !is<DocumentEventAccreditationStatus>(status) ||
     status !== DocumentEventAccreditationStatus.APPROVED
   ) {
@@ -54,7 +56,9 @@ export const isAccreditationValid = (document: Document): boolean => {
 
   const today = new Date();
   const effectiveDateObject = new Date(effectiveDate);
-  const expirationDateObject = new Date(expirationDate);
+  const expirationDateObject = expirationDateExists
+    ? new Date(expirationDate)
+    : new Date();
 
   const isEffectiveValid =
     isToday(effectiveDateObject) || isBefore(effectiveDateObject, today);


### PR DESCRIPTION
### 🧾 Summary

Fix accreditation document validation to properly handle cases where expiration date is optional, preventing false negatives in the validation process.

### 🧩 Context

**Why this change?** The current accreditation validation logic requires both effective date and expiration date to be present, but some accreditation documents may legitimately not have an expiration date.

**Problem it solves:** Documents without expiration dates were incorrectly being marked as invalid, blocking legitimate accreditation flows.

**Business value:** Ensures accurate validation of accreditation documents, preventing valid documents from being rejected due to missing optional expiration dates.

### 🧱 Scope of this PR

**This PR includes:**

- [x] Bug fixes
- [x] Test coverage improvements
- [ ] New features
- [ ] Refactoring
- [ ] Documentation updates
- [ ] Configuration changes

**What's included:**
- Updated `isAccreditationValid` function to handle optional expiration dates
- Added comprehensive test case for validation without expiration date
- Improved validation logic to only check expiration when it exists

**Intentionally excluded:** No changes to the broader accreditation workflow or document structure - this is a focused fix for the validation logic only.

### 🧪 How to test

1. Run the updated unit tests:
   ```bash
   pnpm nx test shared-methodologies-bold-helpers
   ```

2. Test the specific validation scenario:
   ```bash
   # Run the specific test for optional expiration date
   pnpm nx test shared-methodologies-bold-helpers --testNamePattern="should return true if the document has a ACCREDITATION_RESULT event with valid effective date but no expiration date"
   ```

3. Verify existing functionality still works:
   ```bash
   # All existing accreditation validation tests should continue to pass
   pnpm nx test shared-methodologies-bold-helpers --testPathPattern="accreditation-document.helpers.spec.ts"
   ```

### 🧠 Considerations for Review

**Key files to review:**
- `libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.ts` - Core validation logic changes
- `libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.spec.ts` - New test case

**Areas requiring attention:**
- The conditional logic for expiration date validation - ensure it correctly handles both cases (with/without expiration)
- The new test case comprehensively covers the edge case scenario
- Verify that existing validation behavior remains unchanged for documents with expiration dates

**Technical considerations:**
- The fix maintains backward compatibility while extending support for optional expiration dates
- No breaking changes to the validation interface or return types

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Accreditation validation now treats approved accreditations without an expiration date as valid when the effective date is in the past, preventing unintended invalidation.
  - Improved handling of optional expiration dates to avoid errors when the date is missing.

- **Tests**
  - Added test coverage to ensure approved, no-expiration accreditations with past effective dates are considered valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->