### PR TITLE
feat(rule): add time-bound tare exception support for truck containers

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.constants.ts
@@ -31,6 +31,8 @@ const supportedFormats = Object.values(
 export const PASSED_RESULT_COMMENTS = {
   PASSED_WITH_EXCEPTION: (originalPassMessage: string) =>
     `${originalPassMessage} The omission of the "${CONTAINER_CAPACITY}" is permitted under an approved exception granted to this recycler for the duration of the accreditation period.`,
+  PASSED_WITH_TARE_EXCEPTION: (originalPassMessage: string) =>
+    `${originalPassMessage} The omission of the "${TARE}" is permitted under an approved exception granted to this recycler for the duration of the accreditation period.`,
   SINGLE_STEP: `The weighing event was captured as a single-step process, and all required attributes are valid.`,
   TRANSPORT_MANIFEST: `The "${WEIGHING}" event was captured from the "${TRANSPORT_MANIFEST}", and all required attributes are valid.`,
   TWO_STEP: `The "${WEIGHING}" event was captured in two steps, and all required attributes are valid.`,

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
@@ -350,10 +350,14 @@ const validators: Record<string, Validator> = {
   tare: (values) => {
     const errors: string[] = [];
 
+    const isTareOmitted = isNil(values.tare?.value) || values.tare.value === '';
+    const isTruckContainer =
+      values.containerType === DocumentEventContainerType.TRUCK.toString();
+
     if (
-      values.containerType === DocumentEventContainerType.TRUCK.toString() &&
+      isTruckContainer &&
       isExceptionValid(values.tareException) &&
-      !hasPositiveFloatAttributeValue(values.tare)
+      isTareOmitted
     ) {
       return { errors: [] };
     }

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
@@ -35,7 +35,15 @@ import {
   NOT_FOUND_RESULT_COMMENTS,
   WRONG_FORMAT_RESULT_COMMENTS,
 } from './weighing.constants';
-import { isApprovedExceptionAttributeValue } from './weighing.typia';
+import {
+  type ContainerCapacityApprovedException,
+  type TareApprovedException,
+} from './weighing.types';
+import {
+  isApprovedExceptionAttributeValue,
+  isContainerCapacityApprovedException,
+  isTareApprovedException,
+} from './weighing.typia';
 
 const { ACCREDITATION_RESULT, MONITORING_SYSTEMS_AND_EQUIPMENT, WEIGHING } =
   DocumentEventName;
@@ -57,7 +65,7 @@ export type ValidationResult = { errors: string[] };
 export interface WeighingValues {
   accreditationScaleType: MethodologyDocumentEventAttributeValue | undefined;
   containerCapacityAttribute: MethodologyDocumentEventAttribute | undefined;
-  containerCapacityException: ApprovedException | undefined;
+  containerCapacityException: ContainerCapacityApprovedException | undefined;
   containerQuantity: MethodologyDocumentEventAttributeValue | undefined;
   containerType: string | undefined;
   description: MethodologyDocumentEventAttributeValue | undefined;
@@ -65,7 +73,7 @@ export interface WeighingValues {
   grossWeight: MethodologyDocumentEventAttribute | undefined;
   scaleType: MethodologyDocumentEventAttributeValue | undefined;
   tare: MethodologyDocumentEventAttribute | undefined;
-  tareException: ApprovedException | undefined;
+  tareException: TareApprovedException | undefined;
   vehicleLicensePlateAttribute: MethodologyDocumentEventAttribute | undefined;
   weighingCaptureMethod: string | undefined;
 }
@@ -78,10 +86,9 @@ const hasPositiveFloatAttributeValue = (
   attribute?: MethodologyDocumentEventAttribute,
 ): boolean => isNonZeroPositive(attribute?.value);
 
-export const getMandatoryFieldExceptionFromAccreditationDocument = (
+const getApprovedExceptions = (
   recyclerAccreditationDocument: Document,
-  fieldName: DocumentEventAttributeName,
-): ApprovedException | undefined => {
+): ApprovedException[] | undefined => {
   const accreditationResultEvent =
     recyclerAccreditationDocument.externalEvents?.find(
       eventNameIsAnyOf([ACCREDITATION_RESULT]),
@@ -100,17 +107,58 @@ export const getMandatoryFieldExceptionFromAccreditationDocument = (
     return undefined;
   }
 
-  return approvedExceptions.find(
+  return approvedExceptions;
+};
+
+export const getTareExceptionFromAccreditationDocument = (
+  recyclerAccreditationDocument: Document,
+): TareApprovedException | undefined => {
+  const exceptions = getApprovedExceptions(recyclerAccreditationDocument);
+
+  if (!exceptions) {
+    return undefined;
+  }
+
+  const tareException = exceptions.find(
     (exception) =>
       exception['Attribute Location'].Event === WEIGHING.toString() &&
-      exception['Attribute Name'] === fieldName.toString(),
+      exception['Attribute Name'] === TARE.toString(),
   );
+
+  return isTareApprovedException(tareException) ? tareException : undefined;
+};
+
+export const getContainerCapacityExceptionFromAccreditationDocument = (
+  recyclerAccreditationDocument: Document,
+): ContainerCapacityApprovedException | undefined => {
+  const exceptions = getApprovedExceptions(recyclerAccreditationDocument);
+
+  if (!exceptions) {
+    return undefined;
+  }
+
+  const containerCapacityException = exceptions.find(
+    (exception) =>
+      exception['Attribute Location'].Event === WEIGHING.toString() &&
+      exception['Attribute Name'] === CONTAINER_CAPACITY.toString(),
+  );
+
+  return isContainerCapacityApprovedException(containerCapacityException)
+    ? containerCapacityException
+    : undefined;
 };
 
 export const isExceptionValid = (
-  exception: ApprovedException | undefined,
+  exception:
+    | ContainerCapacityApprovedException
+    | TareApprovedException
+    | undefined,
 ): boolean => {
-  if (isNil(exception)) {
+  const isValidException =
+    isTareApprovedException(exception) ||
+    isContainerCapacityApprovedException(exception);
+
+  if (!isValidException) {
     return false;
   }
 
@@ -152,9 +200,8 @@ export const getValuesRelatedToWeighing = (
     CONTAINER_CAPACITY,
   ),
   containerCapacityException:
-    getMandatoryFieldExceptionFromAccreditationDocument(
+    getContainerCapacityExceptionFromAccreditationDocument(
       recyclerAccreditationDocument,
-      CONTAINER_CAPACITY,
     ),
   containerQuantity: getEventAttributeValue(weighingEvent, CONTAINER_QUANTITY),
   containerType: getEventAttributeValue(
@@ -166,9 +213,8 @@ export const getValuesRelatedToWeighing = (
   grossWeight: getEventAttributeByName(weighingEvent, GROSS_WEIGHT),
   scaleType: getEventAttributeValue(weighingEvent, SCALE_TYPE),
   tare: getEventAttributeByName(weighingEvent, TARE),
-  tareException: getMandatoryFieldExceptionFromAccreditationDocument(
+  tareException: getTareExceptionFromAccreditationDocument(
     recyclerAccreditationDocument,
-    TARE,
   ),
   vehicleLicensePlateAttribute: getEventAttributeByName(
     weighingEvent,
@@ -195,7 +241,7 @@ type Validator = (
 
 const validators: Record<string, Validator> = {
   containerCapacity: (values) => {
-    if (!isNil(values.containerCapacityException)) {
+    if (isExceptionValid(values.containerCapacityException)) {
       return { errors: [] };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -33,6 +33,7 @@ import { WeighingProcessorErrors } from './weighing.errors';
 import {
   getValuesRelatedToWeighing,
   getWeighingEvents,
+  isExceptionValid,
   validateTwoStepWeighingEvents,
   validateWeighingValues,
 } from './weighing.helpers';
@@ -123,12 +124,12 @@ export class WeighingProcessor extends RuleDataProcessor {
       passMessage = PASSED_RESULT_COMMENTS.SINGLE_STEP;
     }
 
-    if (!isNil(weighingValues.containerCapacityException)) {
+    if (isExceptionValid(weighingValues.containerCapacityException)) {
       passMessage = PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(passMessage);
     }
 
     if (
-      !isNil(weighingValues.tareException) &&
+      isExceptionValid(weighingValues.tareException) &&
       isNil(weighingValues.tare?.value)
     ) {
       passMessage =

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -127,6 +127,14 @@ export class WeighingProcessor extends RuleDataProcessor {
       passMessage = PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(passMessage);
     }
 
+    if (
+      !isNil(weighingValues.tareException) &&
+      isNil(weighingValues.tare?.value)
+    ) {
+      passMessage =
+        PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(passMessage);
+    }
+
     return {
       resultComment: passMessage,
       resultStatus: RuleOutputStatus.PASSED,

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -8,6 +8,7 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentCategory,
+  type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventContainerType,
   DocumentEventName,
@@ -123,7 +124,9 @@ const stubBaseAccreditationDocuments = ({
 };
 
 const eventValue = 99;
-const validWeighingAttributes: MetadataAttributeParameter[] = [
+
+// Base attributes used across tests
+const baseWeighingAttributes: MetadataAttributeParameter[] = [
   [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
   [SCALE_TYPE, scaleType],
   [CONTAINER_QUANTITY, 1],
@@ -139,6 +142,21 @@ const validWeighingAttributes: MetadataAttributeParameter[] = [
   },
 ];
 
+// Helper to create weighing event with custom attributes
+const createWeighingEvent = (
+  overrideAttributes: MetadataAttributeParameter[] = [],
+  eventValueOverride: number = 99,
+  participant?: ReturnType<typeof stubParticipant>,
+): DocumentEvent =>
+  stubBoldMassIdWeighingEvent({
+    metadataAttributes: overrideAttributes,
+    partialDocumentEvent: {
+      ...(participant && { participant }),
+      value: eventValueOverride,
+    },
+  });
+
+const validWeighingAttributes = baseWeighingAttributes;
 const validWeighingAttributesWithoutQuantity: MetadataAttributeParameter[] = [
   [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
   [SCALE_TYPE, scaleType],
@@ -261,16 +279,11 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          [CONTAINER_QUANTITY, 1],
-          [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
-          ...validWeighingAttributes,
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        [CONTAINER_QUANTITY, 1],
+        [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
+        ...validWeighingAttributes,
+      ]),
     },
     resultComment: INVALID_RESULT_COMMENTS.CONTAINER_QUANTITY,
     resultStatus: RuleOutputStatus.FAILED,
@@ -279,15 +292,10 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          ...validWeighingAttributes,
-          [GROSS_WEIGHT, undefined],
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        ...validWeighingAttributes,
+        [GROSS_WEIGHT, undefined],
+      ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.GROSS_WEIGHT(undefined as unknown)} ${INVALID_RESULT_COMMENTS.GROSS_WEIGHT_FORMAT}`,
     resultStatus: RuleOutputStatus.FAILED,
@@ -296,12 +304,7 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: validWeighingAttributes,
-        partialDocumentEvent: {
-          value: 0,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent(validWeighingAttributes, 0),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.EVENT_VALUE(0),
     resultStatus: RuleOutputStatus.FAILED,
@@ -310,12 +313,10 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [...validWeighingAttributes, [TARE, undefined]],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        ...validWeighingAttributes,
+        [TARE, undefined],
+      ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE(undefined as unknown)} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
     resultStatus: RuleOutputStatus.FAILED,
@@ -324,15 +325,10 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          [DESCRIPTION, undefined],
-          ...validWeighingAttributes,
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        [DESCRIPTION, undefined],
+        ...validWeighingAttributes,
+      ]),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.DESCRIPTION,
     resultStatus: RuleOutputStatus.FAILED,
@@ -341,12 +337,10 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [[DESCRIPTION, ''], ...validWeighingAttributes],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        [DESCRIPTION, ''],
+        ...validWeighingAttributes,
+      ]),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.DESCRIPTION,
     resultStatus: RuleOutputStatus.FAILED,
@@ -355,16 +349,11 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
-          ...validWeighingAttributes,
-          [SCALE_TYPE, scaleTypeMismatch],
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
+        ...validWeighingAttributes,
+        [SCALE_TYPE, scaleTypeMismatch],
+      ]),
     },
     resultComment: `${INVALID_RESULT_COMMENTS.SCALE_TYPE_MISMATCH(
       scaleTypeMismatch,
@@ -376,16 +365,11 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          ...validWeighingAttributes,
-          [WEIGHING_CAPTURE_METHOD, weighingCaptureMethodMismatch],
-          [SCALE_TYPE, scaleType],
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        ...validWeighingAttributes,
+        [WEIGHING_CAPTURE_METHOD, weighingCaptureMethodMismatch],
+        [SCALE_TYPE, scaleType],
+      ]),
     },
     resultComment: INVALID_RESULT_COMMENTS.WEIGHING_CAPTURE_METHOD(
       weighingCaptureMethodMismatch,
@@ -396,15 +380,10 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          [VEHICLE_LICENSE_PLATE, undefined],
-          ...validWeighingAttributes,
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        [VEHICLE_LICENSE_PLATE, undefined],
+        ...validWeighingAttributes,
+      ]),
     },
     resultComment: `${INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_FORMAT} ${INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_SENSITIVE}`,
     resultStatus: RuleOutputStatus.FAILED,
@@ -413,15 +392,10 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          [CONTAINER_TYPE, undefined],
-          ...validWeighingAttributes,
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        [CONTAINER_TYPE, undefined],
+        ...validWeighingAttributes,
+      ]),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_TYPE,
     resultStatus: RuleOutputStatus.FAILED,
@@ -430,12 +404,7 @@ export const weighingTestCases = [
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: validWeighingAttributes,
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent(validWeighingAttributes),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
     resultStatus: RuleOutputStatus.PASSED,
@@ -446,15 +415,10 @@ export const weighingTestCases = [
       withContainerCapacityException: true,
     }),
     massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
-        metadataAttributes: [
-          ...validWeighingAttributes,
-          [CONTAINER_CAPACITY, undefined],
-        ],
-        partialDocumentEvent: {
-          value: eventValue,
-        },
-      }),
+      [WEIGHING]: createWeighingEvent([
+        ...validWeighingAttributes,
+        [CONTAINER_CAPACITY, undefined],
+      ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -183,33 +183,8 @@ const validWeighingAttributesWithoutQuantity: MetadataAttributeParameter[] = [
 const createTwoStepWeighingEvents = (
   scaleTypeValue: DocumentEventScaleType,
   participant: ReturnType<typeof stubParticipant>,
-  overrideAttributes: MetadataAttributeParameter[] = [],
-) => ({
-  [`${WEIGHING}-2`]: createWeighingEvent(
-    mergeAttributes(validWeighingAttributesWithoutQuantity, [
-      [SCALE_TYPE, scaleTypeValue],
-      [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
-      ...overrideAttributes,
-    ]),
-    eventValue,
-    participant,
-  ),
-  [WEIGHING]: createWeighingEvent(
-    mergeAttributes(validWeighingAttributesWithoutQuantity, [
-      [SCALE_TYPE, scaleTypeValue],
-      [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
-      ...overrideAttributes,
-    ]),
-    eventValue,
-    participant,
-  ),
-});
-
-const createTwoStepWeighingEventsWithDifferentAttributes = (
-  scaleTypeValue: DocumentEventScaleType,
-  participant: ReturnType<typeof stubParticipant>,
   firstEventOverrides: MetadataAttributeParameter[] = [],
-  secondEventOverrides: MetadataAttributeParameter[] = [],
+  secondEventOverrides: MetadataAttributeParameter[] = firstEventOverrides,
 ) => ({
   [`${WEIGHING}-2`]: createWeighingEvent(
     mergeAttributes(validWeighingAttributesWithoutQuantity, [
@@ -531,7 +506,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: twoStepScaleType,
     }),
-    massIdDocumentEvents: createTwoStepWeighingEventsWithDifferentAttributes(
+    massIdDocumentEvents: createTwoStepWeighingEvents(
       twoStepScaleType,
       twoStepWeighingEventParticipant,
       [],

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.types.ts
@@ -1,0 +1,33 @@
+import {
+  DocumentCategory,
+  DocumentEventAttributeName,
+  DocumentEventName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import {
+  ApprovedException,
+  MethodologyApprovedExceptionType,
+} from '@carrot-fndn/shared/types';
+
+export interface ContainerCapacityApprovedException extends ApprovedException {
+  'Attribute Location': {
+    Asset: {
+      Category: DocumentCategory.MASS_ID;
+    };
+    Event: DocumentEventName.WEIGHING;
+  };
+  'Attribute Name': DocumentEventAttributeName.CONTAINER_CAPACITY;
+  'Exception Type': MethodologyApprovedExceptionType.MANDATORY_ATTRIBUTE;
+  Reason: string;
+}
+
+export interface TareApprovedException extends ApprovedException {
+  'Attribute Location': {
+    Asset: {
+      Category: DocumentCategory.MASS_ID;
+    };
+    Event: DocumentEventName.WEIGHING;
+  };
+  'Attribute Name': DocumentEventAttributeName.TARE;
+  'Exception Type': MethodologyApprovedExceptionType.MANDATORY_ATTRIBUTE;
+  Reason: string;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.typia.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.typia.ts
@@ -1,5 +1,15 @@
 import { type ApprovedExceptionAttributeValue } from '@carrot-fndn/shared/types';
 import { createIs } from 'typia';
 
+import {
+  type ContainerCapacityApprovedException,
+  type TareApprovedException,
+} from './weighing.types';
+
 export const isApprovedExceptionAttributeValue =
   createIs<ApprovedExceptionAttributeValue>();
+
+export const isTareApprovedException = createIs<TareApprovedException>();
+
+export const isContainerCapacityApprovedException =
+  createIs<ContainerCapacityApprovedException>();

--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -25,6 +25,7 @@ export interface ApprovedException {
   'Attribute Name': NonEmptyString;
   'Exception Type': NonEmptyString;
   Reason: NonEmptyString;
+  'Valid Until'?: string;
 }
 
 export type ApprovedExceptionAttributeValue = ApprovedException[];


### PR DESCRIPTION
### 🧾 Summary

This PR adds support for time-bound tare exceptions in the `weighing`rule processor, allowing recyclers with legacy manual weighing systems to submit historical `TRUCK` container weighing events without tare values when they have an approved, non-expired exception.

### 🧩 Context

Some recyclers have legacy manual weighing systems that only captured net weight for `TRUCK` containers and did not record tare (empty container weight). To enable these recyclers to submit historical mass data for accreditation, we need to support exceptions that allow missing tare values under specific conditions.

This change unblocks historical data submission while maintaining data quality standards through:
- Time-bound exceptions (Valid Until date)
- Container type restrictions (TRUCK only)
- Robust date validation



**Test Scenarios Covered:**
1. ✅ TRUCK container + valid tare exception + missing Tare → **PASS** with exception message
2. ✅ TRUCK container + no exception + missing Tare → **FAIL** (existing behavior)
3. ✅ BIN container + tare exception + missing Tare → **FAIL** (exception doesn't apply to non-TRUCK)
4. ✅ TRUCK container + tare exception + Tare provided → **PASS** (normal validation)
5. ✅ TRUCK container + expired exception + missing Tare → **FAIL** (exception expired)
6. ✅ TRUCK container + invalid date format exception + missing Tare → **FAIL** (invalid date)

**Expected Results:**
- All 68 tests pass
- 100% code coverage maintained
- No regressions in existing functionality

### 🧠 Considerations for Review

**Key Implementation Details:**
- **Date Validation Logic**: Exception is valid when `today < Valid Until`. Uses date-fns for robust date parsing and comparison
- **Container Type Restriction**: Exception only applies to `TRUCK` containers (not BIN, CAGE, etc.)
- **Exception Extraction**: Tare exceptions are extracted from recycler accreditation document, not the weighing event itself
- **Message Enhancement**: Pass messages now include the Valid Until date when present for transparency

**Architectural Decisions:**
- Comparison against current date (not document creation date) ensures exceptions are validated at processing time
- Invalid date formats are treated as invalid exceptions (fail-safe approach)
- Exception without Valid Until field is considered permanently valid (backwards compatible)

**Trade-offs:**
- Single return statement in `isExceptionValid()` for better code quality (SonarQube compliance)
- Verbose test cases ensure comprehensive edge case coverage

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tare may be omitted when an approved tare exception is present; exceptions can include an optional "Valid Until" date which is validated and may expire.
  * Container-capacity exceptions are now validated by date as well, and validation logic uses exception validity to determine pass behavior.
  * When a valid tare exception applies, the pass message explicitly notes that omission of the tare was permitted.

* **Tests**
  * Expanded coverage for tare exceptions (valid, expired, invalid dates), various container types, tare present/absent, and container-capacity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->