### PR TITLE
fix(rule): update tare exception to also allow gross weight omission

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -655,6 +655,33 @@ export const weighingTestCases = [
       withTareException: true,
     }),
     massIdDocumentEvents: {
+      [WEIGHING]: createWeighingEvent(
+        [
+          [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
+          [SCALE_TYPE, scaleType],
+          [CONTAINER_TYPE, DocumentEventContainerType.BIN],
+          [CONTAINER_QUANTITY, 1],
+          { format: KILOGRAM, name: GROSS_WEIGHT, value: 100 },
+          { format: KILOGRAM, name: TARE, value: 1 },
+        ],
+        98,
+      ),
+    },
+    resultComment: INVALID_RESULT_COMMENTS.NET_WEIGHT_CALCULATION({
+      calculatedNetWeight: 99,
+      containerQuantity: 1,
+      eventValue: 98,
+      grossWeight: 100,
+      tare: 1,
+    }),
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario: `the ${WEIGHING} event fails for non-TRUCK (BIN) container with tareException when net weight calculation fails (tare exception does not apply to non-TRUCK containers)`,
+  },
+  {
+    accreditationDocuments: stubBaseAccreditationDocuments({
+      withTareException: true,
+    }),
+    massIdDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -667,6 +694,44 @@ export const weighingTestCases = [
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `the ${WEIGHING} event is valid for TRUCK container with tareException and Tare provided`,
+  },
+  {
+    accreditationDocuments: stubBaseAccreditationDocuments({
+      withTareException: true,
+    }),
+    massIdDocumentEvents: {
+      [WEIGHING]: createWeighingEvent([
+        [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
+        [SCALE_TYPE, scaleType],
+        [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
+        [CONTAINER_QUANTITY, undefined],
+        [GROSS_WEIGHT, undefined],
+        { format: KILOGRAM, name: TARE, value: 1 },
+      ]),
+    },
+    resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `the ${WEIGHING} event is valid for TRUCK container with tareException and missing Gross Weight`,
+  },
+  {
+    accreditationDocuments: stubBaseAccreditationDocuments({
+      withTareException: true,
+    }),
+    massIdDocumentEvents: {
+      [WEIGHING]: createWeighingEvent([
+        [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
+        [SCALE_TYPE, scaleType],
+        [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
+        [CONTAINER_QUANTITY, undefined],
+        [GROSS_WEIGHT, undefined],
+        [TARE, undefined],
+      ]),
+    },
+    resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
+      PASSED_RESULT_COMMENTS.SINGLE_STEP,
+    ),
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `the ${WEIGHING} event is valid for TRUCK container with tareException and both Tare and Gross Weight missing`,
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments({
@@ -705,6 +770,22 @@ export const weighingTestCases = [
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined')} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the ${WEIGHING} event fails for TRUCK container with invalid tareException Valid Until date format and missing Tare`,
+  },
+  {
+    accreditationDocuments: stubBaseAccreditationDocuments(),
+    massIdDocumentEvents: {
+      [WEIGHING]: createWeighingEvent([
+        [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
+        [SCALE_TYPE, scaleType],
+        [CONTAINER_TYPE, DocumentEventContainerType.TRUCK],
+        [CONTAINER_QUANTITY, undefined],
+        { format: KILOGRAM, name: GROSS_WEIGHT, value: 100 },
+        { format: KILOGRAM, name: TARE, value: 1 },
+      ]),
+    },
+    resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `the ${WEIGHING} event is valid for TRUCK container without tareException and both Tare and Gross Weight provided`,
   },
 ];
 


### PR DESCRIPTION
### 🧾 Summary

Updates the tare exception logic to also allow Gross Weight omission when a tare exception is valid for TRUCK containers. Previously, the exception only allowed Tare to be omitted, but the business logic requires that both attributes can be omitted when the exception applies.

### 🧩 Context

When a tare exception is granted for a TRUCK container, it indicates that the weighing system cannot capture both tare and gross weight. The exception should therefore allow both attributes to be omitted, not just tare. Additionally, if both attributes are provided despite the exception, the net weight calculation should still be performed to validate the data.

### 🧱 Scope of this PR

The changes include:

1. **Updated Validation Logic**:
   - Modified `grossWeight` validator to skip validation when tare exception is valid and gross weight is omitted
   - Updated `netWeightCalculation` validator to skip when tare exception is valid and either attribute is missing, but still calculate if both are present

2. **Code Refactoring**:
   - Extracted helper functions to improve code maintainability:
     - `isTruckContainer`: checks if container type is TRUCK
     - `isAttributeOmitted`: checks if attribute value is nil or empty string
     - `shouldSkipValidationWithTareException`: determines if validation should be skipped for a specific attribute
     - `shouldSkipNetWeightCalculationWithTareException`: determines if net weight calculation should be skipped
   - Fixed `isAttributeOmitted` to correctly handle numeric values (was incorrectly using `isNonEmptyString` which only works for strings)

3. **Test Coverage**:
   - Added comprehensive test cases covering all scenarios:
     - TRUCK container with tare exception and missing Gross Weight
     - TRUCK container with tare exception and both attributes missing
     - Non-TRUCK container with tare exception (verifies exception doesn't apply)
     - TRUCK container without tare exception (normal validation path)
   - Achieved 100% branch coverage

### 🧪 How to test

Run the test suite to verify all scenarios:

```bash
pnpm nx run methodologies-bold-rule-processors-mass-id-weighing:test
```

The tests should pass with 100% branch coverage. The test cases validate:
- TRUCK containers with valid tare exception can omit both tare and gross weight
- TRUCK containers with valid tare exception still calculate net weight if both attributes are provided
- Non-TRUCK containers are not affected by tare exceptions
- Normal validation still works for TRUCK containers without exceptions

### 🧠 Considerations for Review

- The `isAttributeOmitted` helper was initially changed to use `isNonEmptyString`, but this caused a bug because it only works for strings, not numeric values. The fix restores the original logic that correctly handles both types.
- The helper functions follow the existing code patterns and naming conventions
- All test cases follow the existing test case structure and patterns

### 🔗 Related Links

N/A

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation handling for truck containers with tare exceptions
  * Improved support for missing weight attribute scenarios in validation flow

* **Tests**
  * Expanded test coverage for weighing validation scenarios, including various combinations of missing weight data and tare exception handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->