### PR TITLE
feat(rule): change accreditation requirements for WASTE_GENERATOR

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.errors.ts
@@ -11,6 +11,11 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessorError
     MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS: (
       participantNames: string[],
     ) =>
-      `No accreditation documents were found for these participants: ${participantNames.join(', ')}`,
+      `No valid accreditation found for these participants: ${participantNames.join(', ')}`,
+    MULTIPLE_VALID_ACCREDITATIONS_FOR_PARTICIPANT: (
+      participantId: string,
+      actorType: string,
+    ) =>
+      `Multiple valid accreditations found for ${actorType} participant ${participantId}`,
   } as const;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
@@ -1,21 +1,28 @@
 import {
   BoldStubsBuilder,
   stubBoldAccreditationResultEvent,
+  stubDocument,
+  stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  DocumentCategory,
+  DocumentEventAccreditationStatus,
   DocumentEventAttributeName,
   DocumentEventName,
+  DocumentType,
   MassIdDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
+import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
-import { subDays } from 'date-fns';
+import { addDays, subDays } from 'date-fns';
 
 import { ParticipantAccreditationsAndVerificationsRequirementsProcessorErrors } from './participant-accreditations-and-verifications-requirements.errors';
 import { RESULT_COMMENTS } from './participant-accreditations-and-verifications-requirements.processor';
 
-const { HAULER } = MassIdDocumentActorType;
-const { ACCREDITATION_RESULT } = DocumentEventName;
-const { EFFECTIVE_DATE, EXPIRATION_DATE } = DocumentEventAttributeName;
+const { INTEGRATOR, WASTE_GENERATOR } = MassIdDocumentActorType;
+const { ACCREDITATION_CONTEXT, ACCREDITATION_RESULT, LINK } = DocumentEventName;
+const { ACCREDITATION_STATUS, EFFECTIVE_DATE, EXPIRATION_DATE } =
+  DocumentEventAttributeName;
 
 const processorError =
   new ParticipantAccreditationsAndVerificationsRequirementsProcessorErrors();
@@ -34,7 +41,7 @@ const massIdWithExpiredAccreditation = new BoldStubsBuilder()
   .createParticipantAccreditationDocuments(
     new Map([
       [
-        HAULER,
+        INTEGRATOR,
         {
           externalEventsMap: new Map([
             [
@@ -52,6 +59,146 @@ const massIdWithExpiredAccreditation = new BoldStubsBuilder()
     ]),
   )
   .build();
+
+const massIdWithWasteGeneratorNoResult = new BoldStubsBuilder()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
+  .createMethodologyDocument()
+  .createParticipantAccreditationDocuments(
+    new Map([
+      [
+        WASTE_GENERATOR,
+        {
+          externalEventsMap: new Map([
+            // Only ACCREDITATION_CONTEXT, no ACCREDITATION_RESULT
+            [
+              ACCREDITATION_CONTEXT,
+              stubDocumentEvent({
+                name: ACCREDITATION_CONTEXT,
+              }),
+            ],
+          ]),
+        },
+      ],
+    ]),
+  )
+  .build();
+
+const massIdWithWasteGeneratorValidResult = new BoldStubsBuilder()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
+  .createMethodologyDocument()
+  .createParticipantAccreditationDocuments(
+    new Map([
+      [
+        WASTE_GENERATOR,
+        {
+          externalEventsMap: new Map([
+            [
+              ACCREDITATION_RESULT,
+              stubBoldAccreditationResultEvent({
+                metadataAttributes: [
+                  [EFFECTIVE_DATE, subDays(new Date(), 10).toISOString()],
+                  [EXPIRATION_DATE, addDays(new Date(), 10).toISOString()],
+                  [
+                    ACCREDITATION_STATUS,
+                    DocumentEventAccreditationStatus.APPROVED,
+                  ],
+                ],
+              }),
+            ],
+          ]),
+        },
+      ],
+    ]),
+  )
+  .build();
+
+const massIdWithWasteGeneratorInvalidResult = new BoldStubsBuilder()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
+  .createMethodologyDocument()
+  .createParticipantAccreditationDocuments(
+    new Map([
+      [
+        WASTE_GENERATOR,
+        {
+          externalEventsMap: new Map([
+            [
+              ACCREDITATION_RESULT,
+              stubBoldAccreditationResultEvent({
+                metadataAttributes: [
+                  [EFFECTIVE_DATE, subDays(new Date(), 10).toISOString()],
+                  [EXPIRATION_DATE, subDays(new Date(), 2).toISOString()],
+                  [
+                    ACCREDITATION_STATUS,
+                    DocumentEventAccreditationStatus.APPROVED,
+                  ],
+                ],
+              }),
+            ],
+          ]),
+        },
+      ],
+    ]),
+  )
+  .build();
+
+const massIdWithWasteGeneratorMultipleValid = new BoldStubsBuilder()
+  .createMassIdDocuments()
+  .createMassIdAuditDocuments()
+  .createMethodologyDocument()
+  .createParticipantAccreditationDocuments(
+    new Map([
+      [
+        WASTE_GENERATOR,
+        {
+          externalEventsMap: new Map([
+            [
+              ACCREDITATION_RESULT,
+              stubBoldAccreditationResultEvent({
+                metadataAttributes: [
+                  [EFFECTIVE_DATE, subDays(new Date(), 10).toISOString()],
+                  [EXPIRATION_DATE, addDays(new Date(), 10).toISOString()],
+                  [
+                    ACCREDITATION_STATUS,
+                    DocumentEventAccreditationStatus.APPROVED,
+                  ],
+                ],
+              }),
+            ],
+          ]),
+        },
+      ],
+    ]),
+  )
+  .build();
+
+const wasteGeneratorOriginalAccreditation =
+  massIdWithWasteGeneratorMultipleValid.participantsAccreditationDocuments.get(
+    WASTE_GENERATOR,
+  )!;
+
+// Create a second valid accreditation document with same participant but different ID
+// Use stubDocument with stubExternalEvents = false to avoid random events
+const wasteGeneratorSecondAccreditation = stubDocument(
+  {
+    category: DocumentCategory.METHODOLOGY,
+    externalEvents: [
+      stubBoldAccreditationResultEvent({
+        metadataAttributes: [
+          [EFFECTIVE_DATE, subDays(new Date(), 5).toISOString()],
+          [EXPIRATION_DATE, addDays(new Date(), 5).toISOString()],
+          [ACCREDITATION_STATUS, DocumentEventAccreditationStatus.APPROVED],
+        ],
+      }),
+    ],
+    primaryParticipant: wasteGeneratorOriginalAccreditation.primaryParticipant,
+    subtype: WASTE_GENERATOR,
+    type: DocumentType.PARTICIPANT_ACCREDITATION,
+  },
+  false, // stubExternalEvents = false to avoid random events
+);
 
 export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   {
@@ -80,13 +227,13 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
       massIdAuditWithAccreditationsAndVerifications.massIdDocument,
       ...[
         ...massIdAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
-      ].filter((document) => document.subtype !== HAULER),
+      ].filter((document) => document.subtype !== INTEGRATOR),
     ],
     massIdAuditDocument:
       massIdAuditWithAccreditationsAndVerifications.massIdAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
-        [HAULER],
+        [INTEGRATOR],
       ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'some participants accreditation documents are not found',
@@ -124,13 +271,79 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
       ...massIdWithExpiredAccreditation.participantsAccreditationDocuments.values(),
     ],
     massIdAuditDocument: massIdWithExpiredAccreditation.massIdAuditDocument,
-    resultComment: RESULT_COMMENTS.INVALID_ACCREDITATION_DOCUMENTS([
-      massIdWithExpiredAccreditation.participantsAccreditationDocuments.get(
-        HAULER,
-      )!.id,
-    ]),
+    resultComment:
+      processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
+        [INTEGRATOR],
+      ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
       'the participants accreditation documents are found and the accreditation is not active',
+  },
+  {
+    documents: [
+      massIdWithWasteGeneratorNoResult.massIdDocument,
+      ...massIdWithWasteGeneratorNoResult.participantsAccreditationDocuments.values(),
+    ],
+    massIdAuditDocument: massIdWithWasteGeneratorNoResult.massIdAuditDocument,
+    resultComment: RESULT_COMMENTS.PASSED,
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario:
+      'WASTE_GENERATOR has accreditation document without result event (should pass)',
+  },
+  {
+    documents: [
+      massIdWithWasteGeneratorValidResult.massIdDocument,
+      ...massIdWithWasteGeneratorValidResult.participantsAccreditationDocuments.values(),
+    ],
+    massIdAuditDocument:
+      massIdWithWasteGeneratorValidResult.massIdAuditDocument,
+    resultComment: RESULT_COMMENTS.PASSED,
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario:
+      'WASTE_GENERATOR has valid accreditation result event (should pass)',
+  },
+  {
+    documents: [
+      massIdWithWasteGeneratorInvalidResult.massIdDocument,
+      ...massIdWithWasteGeneratorInvalidResult.participantsAccreditationDocuments.values(),
+    ],
+    massIdAuditDocument:
+      massIdWithWasteGeneratorInvalidResult.massIdAuditDocument,
+    resultComment:
+      processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
+        [WASTE_GENERATOR],
+      ),
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario:
+      'WASTE_GENERATOR has invalid accreditation result event (expired) (should fail)',
+  },
+  {
+    documents: [
+      massIdWithWasteGeneratorMultipleValid.massIdDocument,
+      ...massIdWithWasteGeneratorMultipleValid.participantsAccreditationDocuments.values(),
+      wasteGeneratorSecondAccreditation,
+    ],
+    // Add LINK event to mass ID audit document referencing second accreditation
+    massIdAuditDocument: {
+      ...massIdWithWasteGeneratorMultipleValid.massIdAuditDocument,
+      externalEvents: [
+        ...(massIdWithWasteGeneratorMultipleValid.massIdAuditDocument
+          .externalEvents ?? []),
+        stubDocumentEvent({
+          name: LINK,
+          relatedDocument: {
+            ...mapDocumentRelation(wasteGeneratorSecondAccreditation),
+            bidirectional: false,
+          },
+        }),
+      ],
+    },
+    resultComment:
+      processorError.ERROR_MESSAGE.MULTIPLE_VALID_ACCREDITATIONS_FOR_PARTICIPANT(
+        wasteGeneratorOriginalAccreditation.primaryParticipant.id,
+        WASTE_GENERATOR,
+      ),
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario: 'WASTE_GENERATOR has multiple valid accreditations (should fail)',
   },
 ];

--- a/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.ts
+++ b/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.ts
@@ -67,3 +67,19 @@ export const isAccreditationValid = (document: Document): boolean => {
 
   return isEffectiveValid && isExpirationValid;
 };
+
+export const isAccreditationValidWithOptionalDates = (
+  document: Document,
+): boolean => {
+  const event = document.externalEvents?.find(
+    eventNameIsAnyOf([DocumentEventName.ACCREDITATION_RESULT]),
+  );
+
+  // If no ACCREDITATION_RESULT event exists, the accreditation is valid
+  if (!event) {
+    return true;
+  }
+
+  // If ACCREDITATION_RESULT exists, use the same validation as isAccreditationValid
+  return isAccreditationValid(document);
+};


### PR DESCRIPTION
### 🧾 Summary

This PR implements changes to accreditation requirements for `WASTE_GENERATOR` participants. The main change is that `WASTE_GENERATOR` accreditation no longer strictly requires an `Accreditation Result` event. If the event exists, it must be valid; if it doesn't exist but the accreditation document exists, it's assumed to be valid.

Additionally, this PR consolidates validation logic and applies the multiple valid accreditations check to all actor types.

### 🧩 Context

This change aligns the rule processor with updates made to the mass ID audit creation process (see PR #2214). The business requirement is that `WASTE_GENERATOR` participants can have accreditations without explicit `Accreditation Result` events, while other participant types (`INTEGRATOR`, `PROCESSOR`, `RECYCLER`) still require valid `Accreditation Result` events with valid effective and expiration dates.

### 🧱 Scope of this PR

**Included:**
- New validation logic for `WASTE_GENERATOR` with optional `Accreditation Result` event
- Unified validation loop for all actor types (required dates and optional dates)
- Multiple valid accreditations check applied to all actor types
- Consolidated error reporting (collect all errors before reporting)
- Updated error messages to be more generic
- Comprehensive test coverage including new test cases for `WASTE_GENERATOR` scenarios
- Tests for `isAccreditationValidWithOptionalDates` helper function

**Not included:**
- Changes to other rule processors
- Changes to the mass ID audit creation logic (already done in PR #2214)

### 🧪 How to test

Run the test suite:
```bash
pnpm test:affected --testPathPattern=participant-accreditations-and-verifications-requirements
```

All 20 tests should pass with 100% coverage.

Test scenarios covered:
- `WASTE_GENERATOR` with accreditation but no result event (should pass)
- `WASTE_GENERATOR` with valid accreditation result (should pass)
- `WASTE_GENERATOR` with invalid accreditation result (should fail)
- `WASTE_GENERATOR` with multiple valid accreditations (should fail)
- Other actor types still require valid accreditation results
- Multiple valid accreditations check for all actor types

### 🧠 Considerations for Review

- **Validation logic consolidation**: The validation for both actor types (requiring dates vs optional dates) is now unified in a single loop, reducing code duplication
- **Error collection**: Errors are now collected for all participants before reporting, providing a complete picture of issues rather than stopping at the first error
- **Non-null assertions**: Used where values are guaranteed by earlier validation (e.g., `verifyAllParticipantsHaveAccreditationDocuments` ensures documents exist)
- **Helper function reuse**: `isAccreditationValidWithOptionalDates` reuses `isAccreditationValid` when an `Accreditation Result` event is present, ensuring consistent validation logic

### 🔗 Related Links

- PR #2214: feat: change accreditations requirements for audits

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating multiple valid accreditations per participant.

* **Bug Fixes**
  * Improved accreditation document validation and error handling.
  * Updated error messages to provide clearer feedback on missing or invalid accreditations.
  * Enhanced validation logic to properly handle multiple documents per participant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->