### PR TITLE
fix(rule): allow participants with multiple roles to have separate accreditations

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
@@ -20,7 +20,10 @@ import {
   PARTICIPANT_ACCREDITATION_PARTIAL_MATCH,
 } from '@carrot-fndn/shared/methodologies/bold/matchers';
 import { eventLabelIsAnyOf } from '@carrot-fndn/shared/methodologies/bold/predicates';
-import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
+import {
+  type Document,
+  DocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
@@ -196,7 +199,15 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
     }>,
     isValidAccreditation: (document: Document) => boolean,
   ): void {
-    const validAccreditations = participantDocuments.filter((document) =>
+    const documentsForActorType = participantDocuments.filter((document) => {
+      const documentRelation = mapDocumentRelation(document);
+
+      return (
+        documentRelation.subtype === (actorType as unknown as DocumentSubtype)
+      );
+    });
+
+    const validAccreditations = documentsForActorType.filter((document) =>
       isValidAccreditation(document),
     );
 


### PR DESCRIPTION
### 🧾 Summary

Fixes validation logic to allow participants with multiple roles (e.g., Processor and Recycler) to have separate valid accreditations without triggering false positive errors.

### 🧩 Context

The validation was incorrectly flagging participants who had one valid accreditation per role (e.g., one as Processor and one as Recycler) as having "multiple valid accreditations". This is actually a valid use case - participants can have multiple accreditations as long as they are for different roles. The error should only occur when a participant has multiple valid accreditations for the same role.

### 🧱 Scope of this PR

The changes include:

1. **Validation Logic Fix**:
   - Modified `validateActor` method to filter accreditation documents by role (subtype) before checking for multiple valid accreditations
   - This ensures validation only checks accreditations for the specific role being validated

2. **Test Coverage**:
   - Added test case to verify a participant with one valid accreditation as Processor and one as Recycler passes validation
   - Ensures the fix works correctly for the reported scenario

### 🧪 How to test

1. Run the test suite:
   ```bash
   pnpm test participant-accreditations-and-verifications-requirements
   ```

2. Verify the new test case passes:
   - Test case: "participant has one valid accreditation as PROCESSOR and one as RECYCLER (should pass)"

3. Verify existing tests still pass to ensure no regressions

### 🧠 Considerations for Review

- The fix filters accreditation documents by `documentRelation.subtype` which matches the `actorType` (MethodologyDocumentEventLabel)
- Both `MethodologyDocumentEventLabel` and `DocumentSubtype` use the same underlying `MethodologyActorType` enum values, so the comparison is valid
- The change maintains backward compatibility - it only affects the filtering logic, not the validation criteria

### 🔗 Related Links

N/A

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant accreditation validation to apply document type filtering before checking validity, ensuring more precise validation.

* **Tests**
  * Expanded test coverage to validate participant accreditations for additional role types.
  * Added test scenarios for participants with multiple assigned roles to ensure proper validation handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->