### PR TITLE
Add Others (if organic) waste subtype to BOLD methodology

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
@@ -87,6 +87,8 @@ export const REWARDS_DISTRIBUTION_BY_WASTE_TYPE: Record<
     RewardsDistributionWasteType.MIXED_ORGANIC_WASTE,
   [MassIdOrganicSubtype.INDUSTRIAL_SLUDGE]:
     RewardsDistributionWasteType.SLUDGE_FROM_WASTE_TREATMENT,
+  [MassIdOrganicSubtype.OTHERS_IF_ORGANIC]:
+    RewardsDistributionWasteType.MIXED_ORGANIC_WASTE,
   [MassIdOrganicSubtype.TOBACCO]:
     RewardsDistributionWasteType.TOBACCO_INDUSTRY_RESIDUES,
   [MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS]:

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/README.md
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/README.md
@@ -7,7 +7,8 @@ the **BOLD Carbon (CH₄)** methodology, using:
 
 - Static prevented-emissions factors for most organic subtypes
 - A dynamic factor for subtype **Others (if organic)** (CDM **8.7D**) based on
-  the IBAMA waste classification code and a configured carbon fraction
+  the local waste classification code (Ibama, Brazil) and a configured carbon
+  fraction
 
 The baseline framing and emission-factor approach are aligned with **UNFCCC
 AMS-III.F v12.0** and **IPCC standards**, as referenced by the BOLD Carbon (CH₄)
@@ -33,14 +34,14 @@ factor per baseline.
 ### Dynamic factor for Others (if organic) (CDM 8.7D)
 
 For **Others (if organic)**, the factor is not fixed. It varies depending on
-the waste type (as identified by its IBAMA code) and the baseline selected by
-the waste generator.
+the waste type (as identified by its local waste classification code) and the
+baseline selected by the waste generator.
 
 The baseline coefficients below are derived from an internal Carrot calculator.
 
 At a high level, the rule:
 
-- Identifies the IBAMA waste code recorded for the pickup
+- Identifies the local waste classification code recorded for the pickup
 - Looks up the configured carbon fraction for that code
 - Applies the baseline-specific coefficients to derive the factor
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/README.md
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/README.md
@@ -7,8 +7,11 @@ the **BOLD Carbon (CH₄)** methodology, using:
 
 - Static prevented-emissions factors for most organic subtypes
 - A dynamic factor for subtype **Others (if organic)** (CDM **8.7D**) based on
-  the local waste classification code (Ibama, Brazil) and a configured carbon
-  fraction
+  the local waste classification code and a configured carbon fraction
+
+  > **Note**: The local waste classification codes referenced here (Ibama) are
+  > specific to Brazil operations. For other regions, different classification
+  > systems may apply.
 
 The baseline framing and emission-factor approach are aligned with **UNFCCC
 AMS-III.F v12.0** and **IPCC standards**, as referenced by the BOLD Carbon (CH₄)
@@ -37,7 +40,8 @@ For **Others (if organic)**, the factor is not fixed. It varies depending on
 the waste type (as identified by its local waste classification code) and the
 baseline selected by the waste generator.
 
-The baseline coefficients below are derived from an internal Carrot calculator.
+The baseline coefficients are derived from methodology-aligned calculations
+that follow the BOLD Carbon (CH₄) methodology framework.
 
 At a high level, the rule:
 
@@ -45,11 +49,9 @@ At a high level, the rule:
 - Looks up the configured carbon fraction for that code
 - Applies the baseline-specific coefficients to derive the factor
 
-Baseline-specific coefficients:
-
-- Landfills without methane flaring: multiplier **6.901715**, offset **-0.1297012**
-- Open-air dumps: multiplier **5.521373**, offset **-0.1297013**
-- Landfills with flaring/capture: multiplier **3.795947**, offset **-0.129701**
+The baseline-specific coefficients (slope and intercept values) are defined in
+`prevented-emissions.constants.ts` as `OTHERS_IF_ORGANIC_BASELINE_FORMULA`. Each
+baseline uses a linear formula: `factor = slope × carbonFraction + intercept`.
 
 ## References
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/README.md
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/README.md
@@ -1,17 +1,56 @@
-# BOLD Carbon CH₄ – [PREVENTED_EMISSIONS_BY_MATERIAL_AND_BASELINE_PER_TON](./prevented-emissions.constants.ts)
+# Prevented emissions (mass-id)
 
-This constant file provides precomputed baseline methane emissions for organic waste disposal scenarios as defined in the **BOLD Carbon CH₄ Methodology**.
+## Overview
 
-## 📘 Context
+This rule calculates prevented emissions (kg CO₂e) for MassID documents under
+the **BOLD Carbon (CH₄)** methodology, using:
 
-When calculating prevented emissions for composting projects, it is essential to compare each material's potential emissions under traditional waste disposal scenarios. These reference scenarios (baselines) are:
+- Static prevented-emissions factors for most organic subtypes
+- A dynamic factor for subtype **Others (if organic)** (CDM **8.7D**) based on
+  the IBAMA waste classification code and a configured carbon fraction
 
-- **Landfills with flaring of methane gas (and/or capture of biogas)**
-- **Landfills without methane flaring**
-- **Open-air dumps**
+The baseline framing and emission-factor approach are aligned with **UNFCCC
+AMS-III.F v12.0** and **IPCC standards**, as referenced by the BOLD Carbon (CH₄)
+methodology.
 
-Each organic waste subtype is assigned emission factors (in **tons of CO₂e per ton of waste**) based on default values and decay models aligned with **AMS-III.F v12.0** and IPCC standards.
+## Core concepts
 
-## 🧪 Source Model
+### Baselines
 
-The emission factors were generated using the official Carrot calculator.
+The waste generator baseline must be provided by the Waste Generator accreditation document. See the Carrot methodology glossary definition of **Baseline**: [Glossary | Carrot White Paper](https://whitepaper.carrot.eco/carrot-methodologies/glossary).
+
+The supported baselines are:
+
+- Landfills with flaring of methane gas (and/or capture of biogas)
+- Landfills without methane flaring
+- Open-air dumps
+
+### Static factors
+
+For most organic subtypes, the methodology uses a fixed prevented-emissions
+factor per baseline.
+
+### Dynamic factor for Others (if organic) (CDM 8.7D)
+
+For **Others (if organic)**, the factor is not fixed. It varies depending on
+the waste type (as identified by its IBAMA code) and the baseline selected by
+the waste generator.
+
+The baseline coefficients below are derived from an internal Carrot calculator.
+
+At a high level, the rule:
+
+- Identifies the IBAMA waste code recorded for the pickup
+- Looks up the configured carbon fraction for that code
+- Applies the baseline-specific coefficients to derive the factor
+
+Baseline-specific coefficients:
+
+- Landfills without methane flaring: multiplier **6.901715**, offset **-0.1297012**
+- Open-air dumps: multiplier **5.521373**, offset **-0.1297013**
+- Landfills with flaring/capture: multiplier **3.795947**, offset **-0.129701**
+
+## References
+
+- [BOLD Carbon (CH₄) | Carrot White Paper](https://whitepaper.carrot.eco/carrot-methodologies/bold-carbon-ch4)
+- [BOLD Carbon (CH₄) methodology PDF (v1.0.2)](https://drive.google.com/file/d/1TwEGKA_YAhgsb_1pFmbVxZxNN5uVEVY6/view)

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -35,6 +35,11 @@ export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.512_684,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.384_207,
   },
+  [MassIdOrganicSubtype.OTHERS_IF_ORGANIC]: {
+    [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.459_152,
+    [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.940_301,
+    [MethodologyBaseline.OPEN_AIR_DUMP]: 0.726_812,
+  },
   [MassIdOrganicSubtype.TOBACCO]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.459_152,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.940_301,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -2,9 +2,9 @@ import {
   MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
+import { NonEmptyString } from '@carrot-fndn/shared/types';
 
 import { type OthersIfOrganicCarbonEntry } from './prevented-emissions.types';
-import { NonEmptyString } from '@carrot-fndn/shared/types';
 
 export const CDM_CODE_OTHERS_IF_ORGANIC = '8.7D';
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -3,11 +3,24 @@ import {
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
+import { type OthersIfOrganicCarbonEntry } from './prevented-emissions.types';
+import { NonEmptyString } from '@carrot-fndn/shared/types';
+
+export const CDM_CODE_OTHERS_IF_ORGANIC = '8.7D';
+
+/** Subtypes that use static factors. OTHERS_IF_ORGANIC is computed by formula. */
+export type StaticFactorSubtype = Exclude<
+  MassIDOrganicSubtype,
+  MassIDOrganicSubtype.OTHERS_IF_ORGANIC
+>;
+
 /**
  * Read the file README.md for more information about the constants in this file.
+ * OTHERS_IF_ORGANIC is excluded; its factor is computed via baseline-specific
+ * linear formulas from carbon fraction per IBAMA code.
  */
 export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
-  MassIDOrganicSubtype,
+  StaticFactorSubtype,
   Record<MethodologyBaseline, number>
 > = {
   [MassIDOrganicSubtype.DOMESTIC_SLUDGE]: {
@@ -35,11 +48,6 @@ export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.512_684,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.384_207,
   },
-  [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: {
-    [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.459_152,
-    [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.940_301,
-    [MethodologyBaseline.OPEN_AIR_DUMP]: 0.726_812,
-  },
   [MassIDOrganicSubtype.TOBACCO]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.459_152,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.940_301,
@@ -51,3 +59,44 @@ export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
     [MethodologyBaseline.OPEN_AIR_DUMP]: 1.106_767,
   },
 };
+
+export const OTHERS_IF_ORGANIC_BASELINE_FORMULA: Record<
+  MethodologyBaseline,
+  { intercept: number; slope: number }
+> = {
+  [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: {
+    intercept: Number.parseFloat('-0.129701'),
+    slope: Number.parseFloat('3.795947'),
+  },
+  [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: {
+    intercept: Number.parseFloat('-0.1297012'),
+    slope: Number.parseFloat('6.901715'),
+  },
+  [MethodologyBaseline.OPEN_AIR_DUMP]: {
+    intercept: Number.parseFloat('-0.1297013'),
+    slope: Number.parseFloat('5.521373'),
+  },
+};
+
+export type OthersIfOrganicCarbonFractionByCanonicalIbamaCode = Record<
+  NonEmptyString,
+  OthersIfOrganicCarbonEntry
+>;
+
+/**
+ * Carbon fractions per IBAMA waste classification code for subtype
+ * "Others (if organic)" (CDM 8.7D).
+ *
+ * Keys MUST be the canonical IBAMA code as it appears in
+ * `WASTE_CLASSIFICATION_CODES.BR` (e.g. '02 01 06').
+ */
+export const OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE: OthersIfOrganicCarbonFractionByCanonicalIbamaCode =
+  {
+    /**
+     * IBAMA: 02 01 06
+     * Carbon fraction: 15% -> 0.15
+     */
+    '02 01 06': {
+      carbonFraction: 0.15,
+    },
+  };

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -17,7 +17,7 @@ export type StaticFactorSubtype = Exclude<
 /**
  * Read the file README.md for more information about the constants in this file.
  * OTHERS_IF_ORGANIC is excluded; its factor is computed via baseline-specific
- * linear formulas from carbon fraction per IBAMA code.
+ * linear formulas from carbon fraction per local waste classification code.
  */
 export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
   StaticFactorSubtype,
@@ -78,22 +78,22 @@ export const OTHERS_IF_ORGANIC_BASELINE_FORMULA: Record<
   },
 };
 
-export type OthersIfOrganicCarbonFractionByCanonicalIbamaCode = Record<
+export type OthersIfOrganicCarbonFractionsByCode = Record<
   NonEmptyString,
   OthersIfOrganicCarbonEntry
 >;
 
 /**
- * Carbon fractions per IBAMA waste classification code for subtype
+ * Carbon fractions per local waste classification code (Ibama, Brazil) for subtype
  * "Others (if organic)" (CDM 8.7D).
  *
- * Keys MUST be the canonical IBAMA code as it appears in
+ * Keys MUST be the canonical local waste classification code as it appears in
  * `WASTE_CLASSIFICATION_CODES.BR` (e.g. '02 01 06').
  */
-export const OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE: OthersIfOrganicCarbonFractionByCanonicalIbamaCode =
+export const OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE: OthersIfOrganicCarbonFractionsByCode =
   {
     /**
-     * IBAMA: 02 01 06
+     * Local waste classification (Ibama, Brazil): 02 01 06
      * Carbon fraction: 15% -> 0.15
      */
     '02 01 06': {

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -62,19 +62,19 @@ export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
 
 export const OTHERS_IF_ORGANIC_BASELINE_FORMULA: Record<
   MethodologyBaseline,
-  { intercept: number; slope: number }
+  { intercept: string; slope: string }
 > = {
   [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: {
-    intercept: Number.parseFloat('-0.129701'),
-    slope: Number.parseFloat('3.795947'),
+    intercept: '-0.129701',
+    slope: '3.795947',
   },
   [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: {
-    intercept: Number.parseFloat('-0.1297012'),
-    slope: Number.parseFloat('6.901715'),
+    intercept: '-0.1297003',
+    slope: '6.901715',
   },
   [MethodologyBaseline.OPEN_AIR_DUMP]: {
-    intercept: Number.parseFloat('-0.1297013'),
-    slope: Number.parseFloat('5.521373'),
+    intercept: '-0.1297013',
+    slope: '5.521373',
   },
 };
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -97,6 +97,6 @@ export const OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE: OthersIfOrganicCar
      * Carbon fraction: 15% -> 0.15
      */
     '02 01 06': {
-      carbonFraction: 0.15,
+      carbonFraction: '0.15',
     },
   };

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
@@ -9,6 +9,10 @@ export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
       'The "MassID" document has an invalid subtype.',
     INVALID_WASTE_GENERATOR_BASELINES:
       'The "Waste Generator accreditation" document has no valid baselines.',
+    MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE: (
+      normalizedLocalWasteClassificationId: string,
+    ) =>
+      `The carbon fraction for the "Others (if organic)" local waste classification code "${normalizedLocalWasteClassificationId}" is not configured.`,
     MISSING_GREENHOUSE_GAS_TYPE:
       'Greenhouse Gas Type (GHG) metadata attribute is missing or invalid',
     MISSING_MASS_ID_DOCUMENT: 'The "MassID" document was not found.',

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
@@ -4,7 +4,7 @@ export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
     FAILED_BY_ERROR: 'Unable to validate the prevented-emissions process.',
     INVALID_CLASSIFICATION_ID:
-      'The "Local Waste Classification ID" does not match an IBAMA code accepted by the methodology.',
+      'The "Local Waste Classification ID" does not match the local waste classification code accepted by the methodology.',
     INVALID_MASS_ID_DOCUMENT_SUBTYPE:
       'The "MassID" document has an invalid subtype.',
     INVALID_WASTE_GENERATOR_BASELINES:

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
@@ -3,6 +3,8 @@ import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/proc
 export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
     FAILED_BY_ERROR: 'Unable to validate the prevented-emissions process.',
+    INVALID_CLASSIFICATION_ID:
+      'The "Local Waste Classification ID" does not match an IBAMA code accepted by the methodology.',
     INVALID_MASS_ID_DOCUMENT_SUBTYPE:
       'The "MassID" document has an invalid subtype.',
     INVALID_WASTE_GENERATOR_BASELINES:
@@ -14,5 +16,7 @@ export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
       'The "Recycler accreditation" document was not found.',
     MISSING_WASTE_GENERATOR_VERIFICATION_DOCUMENT:
       'The "Waste Generator accreditation" document was not found.',
+    SUBTYPE_CDM_CODE_MISMATCH:
+      'The "Local Waste Classification ID" does not correspond to CDM code 8.7D (Others if organic).',
   } as const;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -141,8 +141,7 @@ describe('PreventedEmissionsHelpers', () => {
 
     it('should throw when IBAMA code exists but entry is undefined (defensive branch)', () => {
       const canonicalIbamaCode = '02 01 06';
-      const carbonMap =
-        OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE as OthersIfOrganicCarbonFractionByCanonicalIbamaCode;
+      const carbonMap = OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE;
       const original = carbonMap[canonicalIbamaCode];
 
       try {

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -179,7 +179,7 @@ describe('PreventedEmissionsHelpers', () => {
         ),
       ).toEqual({
         canonicalLocalWasteClassificationCode: '02 01 06',
-        carbonFraction: 0.15,
+        carbonFraction: '0.15',
         computedFactor: Number.parseFloat('0.698505'),
         formulaCoeffs: {
           intercept: Number.parseFloat('-0.1297013'),

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -171,8 +171,7 @@ describe('PreventedEmissionsHelpers', () => {
       ).toEqual({
         canonicalIbamaCode: '02 01 06',
         carbonFraction: 0.15,
-        computedFactor:
-          Number.parseFloat('5.521373') * 0.15 - Number.parseFloat('0.1297013'),
+        computedFactor: Number.parseFloat('0.698505'),
         formulaCoeffs: {
           intercept: Number.parseFloat('-0.1297013'),
           slope: Number.parseFloat('5.521373'),
@@ -480,7 +479,7 @@ describe('PreventedEmissionsHelpers', () => {
       {
         description: 'should floor round down when 4th decimal is 9',
         expected: '1006.312',
-        input: 1006.312_230_000_001,
+        input: Number.parseFloat('1006.312230000001'),
       },
       {
         description: 'should handle exact 3 decimal places',
@@ -511,7 +510,7 @@ describe('PreventedEmissionsHelpers', () => {
       {
         description: 'should handle large numbers',
         expected: '12345.678',
-        input: 12_345.6789,
+        input: Number.parseFloat('12345.6789'),
       },
       {
         description: 'should handle zero',

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -19,12 +19,14 @@ import {
   calculatePreventedEmissions,
   formatNumber,
   getGasTypeFromEvent,
-  getOthersIfOrganicAuditDetails,
   getPreventedEmissionsFactor,
   getWasteGeneratorBaselineByWasteSubtype,
-  resolveCanonicalLocalWasteClassificationId,
   throwIfMissing,
 } from './prevented-emissions.helpers';
+import {
+  getOthersIfOrganicAuditDetails,
+  resolveCanonicalLocalWasteClassificationId,
+} from './prevented-emissions.others-organic.helpers';
 
 const { BASELINES, EXCEEDING_EMISSION_COEFFICIENT, GREENHOUSE_GAS_TYPE } =
   DocumentEventAttributeName;
@@ -123,7 +125,9 @@ describe('PreventedEmissionsHelpers', () => {
             },
           ),
         ).toThrow(
-          `The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "${canonicalLocalWasteClassificationCode}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.`,
+          processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+            canonicalLocalWasteClassificationCode,
+          ),
         );
       } finally {
         // @ts-expect-error - we want to test the defensive branch
@@ -134,12 +138,12 @@ describe('PreventedEmissionsHelpers', () => {
 
   describe('getOthersIfOrganicAuditDetails', () => {
     it('should throw when local waste classification code is not configured', () => {
-      expect(() =>
+      expect(() => {
         getOthersIfOrganicAuditDetails(
           '00 00 00',
           MethodologyBaseline.OPEN_AIR_DUMP,
-        ),
-      ).toThrow(
+        );
+      }).toThrow(
         'getOthersIfOrganicAuditDetails: no carbon entry for "00 00 00"',
       );
     });
@@ -153,12 +157,12 @@ describe('PreventedEmissionsHelpers', () => {
         // @ts-expect-error - we want to test the defensive branch
         carbonMap[canonicalLocalWasteClassificationCode] = undefined;
 
-        expect(() =>
+        expect(() => {
           getOthersIfOrganicAuditDetails(
             canonicalLocalWasteClassificationCode,
             MethodologyBaseline.OPEN_AIR_DUMP,
-          ),
-        ).toThrow(
+          );
+        }).toThrow(
           `getOthersIfOrganicAuditDetails: no carbon entry for "${canonicalLocalWasteClassificationCode}"`,
         );
       } finally {

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -1,5 +1,10 @@
-import { isNil, isNonEmptyString } from '@carrot-fndn/shared/helpers';
+import {
+  isNil,
+  isNonEmptyString,
+  normalizeString,
+} from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
+import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/regional-waste-classification';
 import {
   type Document,
   type DocumentEvent,
@@ -10,7 +15,12 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type NonEmptyString } from '@carrot-fndn/shared/types';
 
-import { PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON } from './prevented-emissions.constants';
+import {
+  CDM_CODE_OTHERS_IF_ORGANIC,
+  OTHERS_IF_ORGANIC_BASELINE_FORMULA,
+  OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE,
+  PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON,
+} from './prevented-emissions.constants';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
 import { isWasteGeneratorBaselineValues } from './prevented-emissions.typia';
 
@@ -23,16 +33,168 @@ const formatter = new Intl.NumberFormat('en-US', {
   useGrouping: false,
 });
 
+export interface OthersIfOrganicAuditDetails {
+  canonicalIbamaCode: string;
+  carbonFraction: number;
+  computedFactor: number;
+  formulaCoeffs: { intercept: number; slope: number };
+}
+
+export interface OthersIfOrganicContext {
+  localWasteClassificationId?: string;
+  normalizedLocalWasteClassificationId?: string;
+}
+
+export interface ResolvedIbamaIds {
+  localWasteClassificationId?: string;
+  normalizedLocalWasteClassificationId?: string;
+}
+
+export const resolveCanonicalIbamaId = (
+  localWasteClassificationIdRaw: NonEmptyString | undefined,
+): ResolvedIbamaIds => {
+  const localWasteClassificationId = isNonEmptyString(
+    localWasteClassificationIdRaw,
+  )
+    ? localWasteClassificationIdRaw
+    : undefined;
+
+  if (isNil(localWasteClassificationId)) {
+    return {};
+  }
+
+  const validClassificationIds = Object.keys(WASTE_CLASSIFICATION_CODES.BR);
+  const normalizedLocalWasteClassificationId = validClassificationIds.find(
+    (validId) =>
+      normalizeString(validId) === normalizeString(localWasteClassificationId),
+  );
+
+  return {
+    ...(!isNil(localWasteClassificationId) && { localWasteClassificationId }),
+    ...(!isNil(normalizedLocalWasteClassificationId) && {
+      normalizedLocalWasteClassificationId,
+    }),
+  };
+};
+
+export const calculateOthersIfOrganicFactor = (
+  baseline: MethodologyBaseline,
+  carbonFraction: number,
+): number => {
+  const { intercept, slope } = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
+
+  return slope * carbonFraction + intercept;
+};
+
 export const getPreventedEmissionsFactor = (
   wasteSubtype: MassIDOrganicSubtype,
   wasteGeneratorBaseline: MethodologyBaseline,
+  processorErrors: PreventedEmissionsProcessorErrors,
+  othersIfOrganicContext?: OthersIfOrganicContext,
 ): number => {
-  const factor =
-    PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[wasteSubtype][
-      wasteGeneratorBaseline
+  if (wasteSubtype !== MassIDOrganicSubtype.OTHERS_IF_ORGANIC) {
+    return PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[
+      wasteSubtype
+    ][wasteGeneratorBaseline];
+  }
+
+  const { normalizedLocalWasteClassificationId } = othersIfOrganicContext ?? {};
+
+  if (!isNonEmptyString(normalizedLocalWasteClassificationId)) {
+    throw processorErrors.getKnownError(
+      processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
+    );
+  }
+
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      WASTE_CLASSIFICATION_CODES.BR,
+      normalizedLocalWasteClassificationId,
+    )
+  ) {
+    throw processorErrors.getKnownError(
+      processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
+    );
+  }
+
+  const classificationEntry =
+    WASTE_CLASSIFICATION_CODES.BR[
+      normalizedLocalWasteClassificationId as keyof typeof WASTE_CLASSIFICATION_CODES.BR
     ];
 
-  return factor;
+  if (
+    normalizeString(classificationEntry.CDM_CODE) !==
+    normalizeString(CDM_CODE_OTHERS_IF_ORGANIC)
+  ) {
+    throw processorErrors.getKnownError(
+      processorErrors.ERROR_MESSAGE.SUBTYPE_CDM_CODE_MISMATCH,
+    );
+  }
+
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE,
+      normalizedLocalWasteClassificationId,
+    )
+  ) {
+    throw processorErrors.getKnownError(
+      `The carbon fraction for the "Others (if organic)" IBAMA code "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE.`,
+    );
+  }
+
+  const carbonEntry =
+    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE[
+      normalizedLocalWasteClassificationId
+    ];
+
+  if (!carbonEntry) {
+    throw processorErrors.getKnownError(
+      `The carbon fraction for the "Others (if organic)" IBAMA code "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE.`,
+    );
+  }
+
+  return calculateOthersIfOrganicFactor(
+    wasteGeneratorBaseline,
+    carbonEntry.carbonFraction,
+  );
+};
+
+export const getOthersIfOrganicAuditDetails = (
+  normalizedIbamaCode: string,
+  baseline: MethodologyBaseline,
+): OthersIfOrganicAuditDetails => {
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE,
+      normalizedIbamaCode,
+    )
+  ) {
+    throw new Error(
+      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedIbamaCode}"`,
+    );
+  }
+
+  const entry =
+    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE[normalizedIbamaCode];
+
+  if (!entry) {
+    throw new Error(
+      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedIbamaCode}"`,
+    );
+  }
+
+  const formulaCoeffs = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
+  const computedFactor = calculateOthersIfOrganicFactor(
+    baseline,
+    entry.carbonFraction,
+  );
+
+  return {
+    canonicalIbamaCode: normalizedIbamaCode,
+    carbonFraction: entry.carbonFraction,
+    computedFactor,
+    formulaCoeffs,
+  };
 };
 
 export const calculatePreventedEmissions = (

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -19,7 +19,7 @@ import BigNumber from 'bignumber.js';
 import {
   CDM_CODE_OTHERS_IF_ORGANIC,
   OTHERS_IF_ORGANIC_BASELINE_FORMULA,
-  OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE,
+  OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE,
   PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON,
 } from './prevented-emissions.constants';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
@@ -35,7 +35,7 @@ const formatter = new Intl.NumberFormat('en-US', {
 });
 
 export interface OthersIfOrganicAuditDetails {
-  canonicalIbamaCode: string;
+  canonicalLocalWasteClassificationCode: string;
   carbonFraction: number;
   computedFactor: number;
   formulaCoeffs: { intercept: number; slope: number };
@@ -46,14 +46,14 @@ export interface OthersIfOrganicContext {
   normalizedLocalWasteClassificationId?: string;
 }
 
-export interface ResolvedIbamaIds {
+export interface ResolvedLocalWasteClassificationIds {
   localWasteClassificationId?: string;
   normalizedLocalWasteClassificationId?: string;
 }
 
-export const resolveCanonicalIbamaId = (
+export const resolveCanonicalLocalWasteClassificationId = (
   localWasteClassificationIdRaw: NonEmptyString | undefined,
-): ResolvedIbamaIds => {
+): ResolvedLocalWasteClassificationIds => {
   const localWasteClassificationId = isNonEmptyString(
     localWasteClassificationIdRaw,
   )
@@ -138,23 +138,23 @@ export const getPreventedEmissionsFactor = (
 
   if (
     !Object.prototype.hasOwnProperty.call(
-      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE,
+      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE,
       normalizedLocalWasteClassificationId,
     )
   ) {
     throw processorErrors.getKnownError(
-      `The carbon fraction for the "Others (if organic)" IBAMA code "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE.`,
+      `The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.`,
     );
   }
 
   const carbonEntry =
-    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE[
+    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE[
       normalizedLocalWasteClassificationId
     ];
 
   if (!carbonEntry) {
     throw processorErrors.getKnownError(
-      `The carbon fraction for the "Others (if organic)" IBAMA code "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE.`,
+      `The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.`,
     );
   }
 
@@ -165,26 +165,28 @@ export const getPreventedEmissionsFactor = (
 };
 
 export const getOthersIfOrganicAuditDetails = (
-  normalizedIbamaCode: string,
+  normalizedLocalWasteClassificationId: string,
   baseline: MethodologyBaseline,
 ): OthersIfOrganicAuditDetails => {
   if (
     !Object.prototype.hasOwnProperty.call(
-      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE,
-      normalizedIbamaCode,
+      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE,
+      normalizedLocalWasteClassificationId,
     )
   ) {
     throw new Error(
-      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedIbamaCode}"`,
+      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedLocalWasteClassificationId}"`,
     );
   }
 
   const entry =
-    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE[normalizedIbamaCode];
+    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE[
+      normalizedLocalWasteClassificationId
+    ];
 
   if (!entry) {
     throw new Error(
-      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedIbamaCode}"`,
+      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedLocalWasteClassificationId}"`,
     );
   }
 
@@ -199,7 +201,7 @@ export const getOthersIfOrganicAuditDetails = (
   );
 
   return {
-    canonicalIbamaCode: normalizedIbamaCode,
+    canonicalLocalWasteClassificationCode: normalizedLocalWasteClassificationId,
     carbonFraction: entry.carbonFraction,
     computedFactor,
     formulaCoeffs,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -87,7 +87,7 @@ export const calculateOthersIfOrganicFactor = (
   return new BigNumber(slope)
     .multipliedBy(new BigNumber(carbonFraction.toString()))
     .plus(intercept)
-    .decimalPlaces(6, BigNumber.ROUND_HALF_UP)
+    .decimalPlaces(6, BigNumber.ROUND_HALF_DOWN)
     .toNumber();
 };
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -87,7 +87,9 @@ export const getPreventedEmissionsFactor = (
     )
   ) {
     throw processorErrors.getKnownError(
-      `The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.`,
+      processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+        normalizedLocalWasteClassificationId,
+      ),
     );
   }
 
@@ -98,7 +100,9 @@ export const getPreventedEmissionsFactor = (
 
   if (!carbonEntry) {
     throw processorErrors.getKnownError(
-      `The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "${normalizedLocalWasteClassificationId}" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.`,
+      processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+        normalizedLocalWasteClassificationId,
+      ),
     );
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -14,6 +14,7 @@ import {
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type NonEmptyString } from '@carrot-fndn/shared/types';
+import BigNumber from 'bignumber.js';
 
 import {
   CDM_CODE_OTHERS_IF_ORGANIC,
@@ -83,7 +84,11 @@ export const calculateOthersIfOrganicFactor = (
 ): number => {
   const { intercept, slope } = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
 
-  return slope * carbonFraction + intercept;
+  return new BigNumber(slope)
+    .multipliedBy(new BigNumber(carbonFraction.toString()))
+    .plus(intercept)
+    .decimalPlaces(6, BigNumber.ROUND_HALF_UP)
+    .toNumber();
 };
 
 export const getPreventedEmissionsFactor = (
@@ -183,7 +188,11 @@ export const getOthersIfOrganicAuditDetails = (
     );
   }
 
-  const formulaCoeffs = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
+  const formulaCoeffsRaw = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
+  const formulaCoeffs = {
+    intercept: Number.parseFloat(formulaCoeffsRaw.intercept),
+    slope: Number.parseFloat(formulaCoeffsRaw.slope),
+  };
   const computedFactor = calculateOthersIfOrganicFactor(
     baseline,
     entry.carbonFraction,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
@@ -12,6 +12,7 @@ import { faker } from '@faker-js/faker';
 import { preventedEmissionsLambda } from './prevented-emissions.lambda';
 import {
   preventedEmissionsErrorTestCases,
+  type PreventedEmissionsTestCase,
   preventedEmissionsTestCases,
 } from './prevented-emissions.test-cases';
 
@@ -22,11 +23,12 @@ describe('PreventedEmissionsProcessor E2E', () => {
 
   const documentKeyPrefix = faker.string.uuid();
 
-  it.each(preventedEmissionsTestCases)(
+  it.each<PreventedEmissionsTestCase>(preventedEmissionsTestCases)(
     'should return $resultStatus when $scenario',
     async ({
       accreditationDocuments,
       externalCreatedAt,
+      massIDDocumentsParams,
       massIDDocumentValue,
       resultComment,
       resultStatus,
@@ -38,7 +40,9 @@ describe('PreventedEmissionsProcessor E2E', () => {
         participantsAccreditationDocuments,
       } = new BoldStubsBuilder()
         .createMassIDDocuments({
+          ...massIDDocumentsParams,
           partialDocument: {
+            ...massIDDocumentsParams?.partialDocument,
             currentValue: massIDDocumentValue as number,
             externalCreatedAt,
             subtype,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.spec.ts
@@ -206,6 +206,44 @@ describe('PreventedEmissionsOthersOrganicHelpers', () => {
 
       expect(result.toString()).toMatch(/^\d+\.\d{6}$/);
     });
+
+    it('should clamp negative results to zero when carbonFraction is 0', () => {
+      const resultFlaring = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+        '0',
+      );
+      const resultWithoutFlaring = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
+        '0',
+      );
+      const resultDump = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.OPEN_AIR_DUMP,
+        '0',
+      );
+
+      expect(resultFlaring).toBe(0);
+      expect(resultWithoutFlaring).toBe(0);
+      expect(resultDump).toBe(0);
+    });
+
+    it('should clamp negative results to zero when carbonFraction is 1%', () => {
+      const resultFlaring = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+        '0.01',
+      );
+      const resultWithoutFlaring = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
+        '0.01',
+      );
+      const resultDump = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.OPEN_AIR_DUMP,
+        '0.01',
+      );
+
+      expect(resultFlaring).toBe(0);
+      expect(resultWithoutFlaring).toBe(0);
+      expect(resultDump).toBe(0);
+    });
   });
 
   describe('getCarbonFractionForOthersIfOrganic', () => {

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.spec.ts
@@ -1,0 +1,401 @@
+import {
+  stubBoldMassIDPickUpEvent,
+  stubDocument,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  DocumentEventAttributeName,
+  MassIDOrganicSubtype,
+  MethodologyBaseline,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import {
+  OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE,
+  OthersIfOrganicCarbonFractionsByCode,
+} from './prevented-emissions.constants';
+import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
+import {
+  buildOthersIfOrganicContext,
+  calculateOthersIfOrganicFactor,
+  getCarbonFractionForOthersIfOrganic,
+  getOthersIfOrganicAuditDetails,
+  getOthersIfOrganicContextFromMassIdDocument,
+  resolveCanonicalLocalWasteClassificationId,
+} from './prevented-emissions.others-organic.helpers';
+
+const { LOCAL_WASTE_CLASSIFICATION_ID } = DocumentEventAttributeName;
+
+describe('PreventedEmissionsOthersOrganicHelpers', () => {
+  const processorErrors = new PreventedEmissionsProcessorErrors();
+
+  describe('resolveCanonicalLocalWasteClassificationId', () => {
+    it('should return empty ids when localWasteClassificationIdRaw is undefined', () => {
+      expect(
+        resolveCanonicalLocalWasteClassificationId(undefined),
+      ).toStrictEqual({});
+    });
+
+    it('should return normalized id when valid classification id is provided', () => {
+      const result = resolveCanonicalLocalWasteClassificationId('02 01 06');
+
+      expect(result).toEqual({
+        localWasteClassificationId: '02 01 06',
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+    });
+
+    it('should normalize classification id with different spacing', () => {
+      const result = resolveCanonicalLocalWasteClassificationId('02  01  06');
+
+      expect(result).toEqual({
+        localWasteClassificationId: '02  01  06',
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+    });
+
+    it('should return only localWasteClassificationId when id is not found in valid codes', () => {
+      const result = resolveCanonicalLocalWasteClassificationId('99 99 99');
+
+      expect(result).toEqual({
+        localWasteClassificationId: '99 99 99',
+      });
+    });
+  });
+
+  describe('getOthersIfOrganicContextFromMassIdDocument', () => {
+    it('should return empty context when document subtype is not OTHERS_IF_ORGANIC', () => {
+      const document = stubDocument({
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      });
+
+      const result = getOthersIfOrganicContextFromMassIdDocument(document);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty context when pick up event is not found', () => {
+      const document = stubDocument({
+        externalEvents: [],
+        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+      });
+
+      const result = getOthersIfOrganicContextFromMassIdDocument(document);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty context when local waste classification id is missing', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, undefined]],
+          }),
+        ],
+        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+      });
+
+      const result = getOthersIfOrganicContextFromMassIdDocument(document);
+
+      expect(result).toEqual({});
+    });
+
+    it('should return context with normalized id when valid classification id is provided', () => {
+      const document = stubDocument({
+        externalEvents: [
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '02 01 06']],
+          }),
+        ],
+        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+      });
+
+      const result = getOthersIfOrganicContextFromMassIdDocument(document);
+
+      expect(result).toEqual({
+        localWasteClassificationId: '02 01 06',
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+    });
+  });
+
+  describe('buildOthersIfOrganicContext', () => {
+    it('should return undefined when both ids are nil', () => {
+      expect(buildOthersIfOrganicContext({})).toBeUndefined();
+      expect(
+        buildOthersIfOrganicContext({
+          localWasteClassificationId: undefined,
+          normalizedLocalWasteClassificationId: undefined,
+        }),
+      ).toBeUndefined();
+    });
+
+    it('should return context with localWasteClassificationId when provided', () => {
+      const result = buildOthersIfOrganicContext({
+        localWasteClassificationId: '02 01 06',
+      });
+
+      expect(result).toEqual({
+        localWasteClassificationId: '02 01 06',
+      });
+    });
+
+    it('should return context with normalizedLocalWasteClassificationId when provided', () => {
+      const result = buildOthersIfOrganicContext({
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+
+      expect(result).toEqual({
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+    });
+
+    it('should return context with both ids when both are provided', () => {
+      const result = buildOthersIfOrganicContext({
+        localWasteClassificationId: '02  01  06',
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+
+      expect(result).toEqual({
+        localWasteClassificationId: '02  01  06',
+        normalizedLocalWasteClassificationId: '02 01 06',
+      });
+    });
+  });
+
+  describe('calculateOthersIfOrganicFactor', () => {
+    it('should calculate factor for OPEN_AIR_DUMP with 15% carbon', () => {
+      const result = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.OPEN_AIR_DUMP,
+        '0.15',
+      );
+
+      expect(result).toBe(0.698_505);
+    });
+
+    it('should calculate factor for LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS with 22% carbon', () => {
+      const result = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
+        '0.22',
+      );
+
+      expect(result).toBe(1.388_677);
+    });
+
+    it('should calculate factor for LANDFILLS_WITH_FLARING_OF_METHANE_GAS with 37% carbon', () => {
+      const result = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+        '0.37',
+      );
+
+      expect(result).toBe(1.274_799);
+    });
+
+    it('should calculate factor for OPEN_AIR_DUMP with 58% carbon', () => {
+      const result = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.OPEN_AIR_DUMP,
+        '0.58',
+      );
+
+      expect(result).toBe(3.072_695);
+    });
+
+    it('should round to 6 decimal places using ROUND_HALF_DOWN', () => {
+      const result = calculateOthersIfOrganicFactor(
+        MethodologyBaseline.OPEN_AIR_DUMP,
+        '0.15',
+      );
+
+      expect(result.toString()).toMatch(/^\d+\.\d{6}$/);
+    });
+  });
+
+  describe('getCarbonFractionForOthersIfOrganic', () => {
+    it('should throw INVALID_CLASSIFICATION_ID when context is undefined', () => {
+      expect(() =>
+        getCarbonFractionForOthersIfOrganic(undefined, processorErrors),
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID);
+    });
+
+    it('should throw INVALID_CLASSIFICATION_ID when normalizedLocalWasteClassificationId is missing', () => {
+      expect(() =>
+        getCarbonFractionForOthersIfOrganic({}, processorErrors),
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID);
+    });
+
+    it('should throw INVALID_CLASSIFICATION_ID when normalizedLocalWasteClassificationId is empty string', () => {
+      expect(() =>
+        getCarbonFractionForOthersIfOrganic(
+          { normalizedLocalWasteClassificationId: '' },
+          processorErrors,
+        ),
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID);
+    });
+
+    it('should throw INVALID_CLASSIFICATION_ID when classification id is not in WASTE_CLASSIFICATION_CODES', () => {
+      expect(() =>
+        getCarbonFractionForOthersIfOrganic(
+          { normalizedLocalWasteClassificationId: '99 99 99' },
+          processorErrors,
+        ),
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID);
+    });
+
+    it('should throw SUBTYPE_CDM_CODE_MISMATCH when classification code is not 8.7D', () => {
+      expect(() =>
+        getCarbonFractionForOthersIfOrganic(
+          { normalizedLocalWasteClassificationId: '02 01 01' },
+          processorErrors,
+        ),
+      ).toThrow(processorErrors.ERROR_MESSAGE.SUBTYPE_CDM_CODE_MISMATCH);
+    });
+
+    it('should throw MISSING_CARBON_FRACTION when carbon fraction is not configured', () => {
+      expect(() =>
+        getCarbonFractionForOthersIfOrganic(
+          { normalizedLocalWasteClassificationId: '02 02 99' },
+          processorErrors,
+        ),
+      ).toThrow(
+        processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+          '02 02 99',
+        ),
+      );
+    });
+
+    it('should throw MISSING_CARBON_FRACTION when carbon entry exists but is undefined (defensive branch)', () => {
+      const canonicalLocalWasteClassificationCode = '02 01 06';
+      const carbonMap: OthersIfOrganicCarbonFractionsByCode =
+        OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE;
+      const original = carbonMap[canonicalLocalWasteClassificationCode];
+
+      try {
+        // @ts-expect-error - we want to test the defensive branch
+        carbonMap[canonicalLocalWasteClassificationCode] = undefined;
+
+        expect(() =>
+          getCarbonFractionForOthersIfOrganic(
+            {
+              normalizedLocalWasteClassificationId:
+                canonicalLocalWasteClassificationCode,
+            },
+            processorErrors,
+          ),
+        ).toThrow(
+          processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+            canonicalLocalWasteClassificationCode,
+          ),
+        );
+      } finally {
+        // @ts-expect-error - we want to test the defensive branch
+        carbonMap[canonicalLocalWasteClassificationCode] = original;
+      }
+    });
+
+    it('should return carbon fraction when valid classification id is provided', () => {
+      const result = getCarbonFractionForOthersIfOrganic(
+        { normalizedLocalWasteClassificationId: '02 01 06' },
+        processorErrors,
+      );
+
+      expect(result).toBe('0.15');
+    });
+  });
+
+  describe('getOthersIfOrganicAuditDetails', () => {
+    it('should throw when local waste classification code is not configured', () => {
+      expect(() => {
+        getOthersIfOrganicAuditDetails(
+          '00 00 00',
+          MethodologyBaseline.OPEN_AIR_DUMP,
+        );
+      }).toThrow(
+        'getOthersIfOrganicAuditDetails: no carbon entry for "00 00 00"',
+      );
+    });
+
+    it('should throw when local waste classification code exists but entry is undefined (defensive branch)', () => {
+      const canonicalLocalWasteClassificationCode = '02 01 06';
+      const carbonMap = OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE;
+      const original = carbonMap[canonicalLocalWasteClassificationCode];
+
+      try {
+        // @ts-expect-error - we want to test the defensive branch
+        carbonMap[canonicalLocalWasteClassificationCode] = undefined;
+
+        expect(() => {
+          getOthersIfOrganicAuditDetails(
+            canonicalLocalWasteClassificationCode,
+            MethodologyBaseline.OPEN_AIR_DUMP,
+          );
+        }).toThrow(
+          `getOthersIfOrganicAuditDetails: no carbon entry for "${canonicalLocalWasteClassificationCode}"`,
+        );
+      } finally {
+        // @ts-expect-error - we want to test the defensive branch
+        carbonMap[canonicalLocalWasteClassificationCode] = original;
+      }
+    });
+
+    it('should return audit details for OPEN_AIR_DUMP baseline', () => {
+      expect(
+        getOthersIfOrganicAuditDetails(
+          '02 01 06',
+          MethodologyBaseline.OPEN_AIR_DUMP,
+        ),
+      ).toEqual({
+        canonicalLocalWasteClassificationCode: '02 01 06',
+        carbonFraction: '0.15',
+        computedFactor: Number.parseFloat('0.698505'),
+        formulaCoeffs: {
+          intercept: Number.parseFloat('-0.1297013'),
+          slope: Number.parseFloat('5.521373'),
+        },
+      });
+    });
+
+    it('should return audit details for LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS baseline', () => {
+      expect(
+        getOthersIfOrganicAuditDetails(
+          '02 01 06',
+          MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
+        ),
+      ).toEqual({
+        canonicalLocalWasteClassificationCode: '02 01 06',
+        carbonFraction: '0.15',
+        computedFactor: Number.parseFloat('0.905557'),
+        formulaCoeffs: {
+          intercept: Number.parseFloat('-0.1297003'),
+          slope: Number.parseFloat('6.901715'),
+        },
+      });
+    });
+
+    it('should return audit details for LANDFILLS_WITH_FLARING_OF_METHANE_GAS baseline', () => {
+      expect(
+        getOthersIfOrganicAuditDetails(
+          '02 01 06',
+          MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+        ),
+      ).toEqual({
+        canonicalLocalWasteClassificationCode: '02 01 06',
+        carbonFraction: '0.15',
+        computedFactor: Number.parseFloat('0.439691'),
+        formulaCoeffs: {
+          intercept: Number.parseFloat('-0.129701'),
+          slope: Number.parseFloat('3.795947'),
+        },
+      });
+    });
+
+    it('should use BigNumber for formula coefficients', () => {
+      const result = getOthersIfOrganicAuditDetails(
+        '02 01 06',
+        MethodologyBaseline.OPEN_AIR_DUMP,
+      );
+
+      expect(typeof result.formulaCoeffs.intercept).toBe('number');
+      expect(typeof result.formulaCoeffs.slope).toBe('number');
+      expect(result.formulaCoeffs.intercept).toBe(-0.129_701_3);
+      expect(result.formulaCoeffs.slope).toBe(5.521_373);
+    });
+  });
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
@@ -12,7 +12,11 @@ import {
   MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { type NonEmptyString } from '@carrot-fndn/shared/types';
+import {
+  type NonEmptyString,
+  NonNegativeFloat,
+  Percentage,
+} from '@carrot-fndn/shared/types';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -25,17 +29,17 @@ const { LOCAL_WASTE_CLASSIFICATION_ID } = DocumentEventAttributeName;
 const { PICK_UP } = DocumentEventName;
 
 export interface OthersIfOrganicAuditDetails {
-  canonicalLocalWasteClassificationCode: string;
-  carbonFraction: number;
-  computedFactor: number;
+  canonicalLocalWasteClassificationCode: NonEmptyString;
+  carbonFraction: Percentage;
+  computedFactor: NonNegativeFloat;
   formulaCoeffs: { intercept: number; slope: number };
 }
 
 export type OthersIfOrganicContext = OthersIfOrganicRuleSubjectIds;
 
 export interface ResolvedLocalWasteClassificationIds {
-  localWasteClassificationId?: string;
-  normalizedLocalWasteClassificationId?: string;
+  localWasteClassificationId?: NonEmptyString | undefined;
+  normalizedLocalWasteClassificationId?: NonEmptyString | undefined;
 }
 
 export const resolveCanonicalLocalWasteClassificationId = (
@@ -110,8 +114,8 @@ export const buildOthersIfOrganicContext = (
 
 export const calculateOthersIfOrganicFactor = (
   baseline: MethodologyBaseline,
-  carbonFraction: number,
-): number => {
+  carbonFraction: Percentage,
+): NonNegativeFloat => {
   const { intercept, slope } = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
 
   return new BigNumber(slope)
@@ -122,7 +126,7 @@ export const calculateOthersIfOrganicFactor = (
 };
 
 export const getOthersIfOrganicAuditDetails = (
-  normalizedLocalWasteClassificationId: string,
+  normalizedLocalWasteClassificationId: NonEmptyString,
   baseline: MethodologyBaseline,
 ): OthersIfOrganicAuditDetails => {
   if (

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
@@ -15,7 +15,7 @@ import {
 import {
   type NonEmptyString,
   NonNegativeFloat,
-  Percentage,
+  PercentageString,
 } from '@carrot-fndn/shared/types';
 import BigNumber from 'bignumber.js';
 
@@ -30,7 +30,7 @@ const { PICK_UP } = DocumentEventName;
 
 export interface OthersIfOrganicAuditDetails {
   canonicalLocalWasteClassificationCode: NonEmptyString;
-  carbonFraction: Percentage;
+  carbonFraction: PercentageString;
   computedFactor: NonNegativeFloat;
   formulaCoeffs: { intercept: number; slope: number };
 }
@@ -114,12 +114,12 @@ export const buildOthersIfOrganicContext = (
 
 export const calculateOthersIfOrganicFactor = (
   baseline: MethodologyBaseline,
-  carbonFraction: Percentage,
+  carbonFraction: PercentageString,
 ): NonNegativeFloat => {
   const { intercept, slope } = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
 
   return new BigNumber(slope)
-    .multipliedBy(new BigNumber(carbonFraction.toString()))
+    .multipliedBy(new BigNumber(carbonFraction))
     .plus(intercept)
     .decimalPlaces(6, BigNumber.ROUND_HALF_DOWN)
     .toNumber();

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
@@ -149,8 +149,8 @@ export const getOthersIfOrganicAuditDetails = (
 
   const formulaCoeffsRaw = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
   const formulaCoeffs = {
-    intercept: Number.parseFloat(formulaCoeffsRaw.intercept),
-    slope: Number.parseFloat(formulaCoeffsRaw.slope),
+    intercept: new BigNumber(formulaCoeffsRaw.intercept).toNumber(),
+    slope: new BigNumber(formulaCoeffsRaw.slope).toNumber(),
   };
   const computedFactor = calculateOthersIfOrganicFactor(
     baseline,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
@@ -1,0 +1,166 @@
+import {
+  isNil,
+  isNonEmptyString,
+  normalizeString,
+} from '@carrot-fndn/shared/helpers';
+import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
+import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/regional-waste-classification';
+import {
+  type Document,
+  DocumentEventAttributeName,
+  DocumentEventName,
+  MassIDOrganicSubtype,
+  MethodologyBaseline,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+import { type NonEmptyString } from '@carrot-fndn/shared/types';
+import BigNumber from 'bignumber.js';
+
+import {
+  OTHERS_IF_ORGANIC_BASELINE_FORMULA,
+  OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE,
+} from './prevented-emissions.constants';
+import { type OthersIfOrganicRuleSubjectIds } from './prevented-emissions.types';
+
+const { LOCAL_WASTE_CLASSIFICATION_ID } = DocumentEventAttributeName;
+const { PICK_UP } = DocumentEventName;
+
+export interface OthersIfOrganicAuditDetails {
+  canonicalLocalWasteClassificationCode: string;
+  carbonFraction: number;
+  computedFactor: number;
+  formulaCoeffs: { intercept: number; slope: number };
+}
+
+export type OthersIfOrganicContext = OthersIfOrganicRuleSubjectIds;
+
+export interface ResolvedLocalWasteClassificationIds {
+  localWasteClassificationId?: string;
+  normalizedLocalWasteClassificationId?: string;
+}
+
+export const resolveCanonicalLocalWasteClassificationId = (
+  localWasteClassificationIdRaw: NonEmptyString | undefined,
+): ResolvedLocalWasteClassificationIds => {
+  const localWasteClassificationId = isNonEmptyString(
+    localWasteClassificationIdRaw,
+  )
+    ? localWasteClassificationIdRaw
+    : undefined;
+
+  if (isNil(localWasteClassificationId)) {
+    return {};
+  }
+
+  const validClassificationIds = Object.keys(WASTE_CLASSIFICATION_CODES.BR);
+  const normalizedLocalWasteClassificationId = validClassificationIds.find(
+    (validId) =>
+      normalizeString(validId) === normalizeString(localWasteClassificationId),
+  );
+
+  return {
+    ...(!isNil(localWasteClassificationId) && { localWasteClassificationId }),
+    ...(!isNil(normalizedLocalWasteClassificationId) && {
+      normalizedLocalWasteClassificationId,
+    }),
+  };
+};
+
+export const getOthersIfOrganicContextFromMassIdDocument = (
+  massIDDocument: Document,
+): OthersIfOrganicContext => {
+  if (massIDDocument.subtype !== MassIDOrganicSubtype.OTHERS_IF_ORGANIC) {
+    return {};
+  }
+
+  const pickUpEvent = massIDDocument.externalEvents?.find(
+    (event) => event.name === PICK_UP.toString(),
+  );
+  const localWasteClassificationIdRaw = getEventAttributeValue(
+    pickUpEvent,
+    LOCAL_WASTE_CLASSIFICATION_ID,
+  );
+
+  return resolveCanonicalLocalWasteClassificationId(
+    isNonEmptyString(localWasteClassificationIdRaw)
+      ? localWasteClassificationIdRaw
+      : undefined,
+  );
+};
+
+export const buildOthersIfOrganicContext = (
+  ids: OthersIfOrganicRuleSubjectIds,
+): OthersIfOrganicContext | undefined => {
+  if (
+    isNil(ids.localWasteClassificationId) &&
+    isNil(ids.normalizedLocalWasteClassificationId)
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(!isNil(ids.localWasteClassificationId) && {
+      localWasteClassificationId: ids.localWasteClassificationId,
+    }),
+    ...(!isNil(ids.normalizedLocalWasteClassificationId) && {
+      normalizedLocalWasteClassificationId:
+        ids.normalizedLocalWasteClassificationId,
+    }),
+  };
+};
+
+export const calculateOthersIfOrganicFactor = (
+  baseline: MethodologyBaseline,
+  carbonFraction: number,
+): number => {
+  const { intercept, slope } = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
+
+  return new BigNumber(slope)
+    .multipliedBy(new BigNumber(carbonFraction.toString()))
+    .plus(intercept)
+    .decimalPlaces(6, BigNumber.ROUND_HALF_DOWN)
+    .toNumber();
+};
+
+export const getOthersIfOrganicAuditDetails = (
+  normalizedLocalWasteClassificationId: string,
+  baseline: MethodologyBaseline,
+): OthersIfOrganicAuditDetails => {
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE,
+      normalizedLocalWasteClassificationId,
+    )
+  ) {
+    throw new Error(
+      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedLocalWasteClassificationId}"`,
+    );
+  }
+
+  const entry =
+    OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE[
+      normalizedLocalWasteClassificationId
+    ];
+
+  if (!entry) {
+    throw new Error(
+      `getOthersIfOrganicAuditDetails: no carbon entry for "${normalizedLocalWasteClassificationId}"`,
+    );
+  }
+
+  const formulaCoeffsRaw = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
+  const formulaCoeffs = {
+    intercept: Number.parseFloat(formulaCoeffsRaw.intercept),
+    slope: Number.parseFloat(formulaCoeffsRaw.slope),
+  };
+  const computedFactor = calculateOthersIfOrganicFactor(
+    baseline,
+    entry.carbonFraction,
+  );
+
+  return {
+    canonicalLocalWasteClassificationCode: normalizedLocalWasteClassificationId,
+    carbonFraction: entry.carbonFraction,
+    computedFactor,
+    formulaCoeffs,
+  };
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.others-organic.helpers.ts
@@ -120,11 +120,12 @@ export const calculateOthersIfOrganicFactor = (
 ): NonNegativeFloat => {
   const { intercept, slope } = OTHERS_IF_ORGANIC_BASELINE_FORMULA[baseline];
 
-  return new BigNumber(slope)
+  const computed = new BigNumber(slope)
     .multipliedBy(new BigNumber(carbonFraction))
     .plus(intercept)
-    .decimalPlaces(6, BigNumber.ROUND_HALF_DOWN)
-    .toNumber();
+    .decimalPlaces(6, BigNumber.ROUND_HALF_DOWN);
+
+  return BigNumber.max(computed, 0).toNumber();
 };
 
 export const getCarbonFractionForOthersIfOrganic = (

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
@@ -9,6 +9,7 @@ import { random } from 'typia';
 import { PreventedEmissionsProcessor } from './prevented-emissions.processor';
 import {
   preventedEmissionsErrorTestCases,
+  type PreventedEmissionsTestCase,
   preventedEmissionsTestCases,
 } from './prevented-emissions.test-cases';
 
@@ -20,11 +21,12 @@ describe('PreventedEmissionsProcessor', () => {
   });
 
   describe('PreventedEmissionsProcessor', () => {
-    it.each(preventedEmissionsTestCases)(
+    it.each<PreventedEmissionsTestCase>(preventedEmissionsTestCases)(
       'should return $resultStatus when $scenario',
       async ({
         accreditationDocuments,
         externalCreatedAt,
+        massIDDocumentsParams,
         massIDDocumentValue,
         resultComment,
         resultContent,
@@ -34,7 +36,9 @@ describe('PreventedEmissionsProcessor', () => {
         const { ruleInput, ruleOutput } = await createRuleTestFixture({
           accreditationDocuments,
           massIDDocumentsParams: {
+            ...massIDDocumentsParams,
             partialDocument: {
+              ...massIDDocumentsParams?.partialDocument,
               currentValue: massIDDocumentValue as number,
               externalCreatedAt,
               subtype,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -47,7 +47,7 @@ import {
   getPreventedEmissionsFactor,
   getWasteGeneratorBaselineByWasteSubtype,
   type OthersIfOrganicAuditDetails,
-  resolveCanonicalIbamaId,
+  resolveCanonicalLocalWasteClassificationId,
   throwIfMissing,
 } from './prevented-emissions.helpers';
 import { type RuleSubject } from './prevented-emissions.types';
@@ -316,7 +316,9 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       return {};
     }
 
-    return resolveCanonicalIbamaId(localWasteClassificationIdRaw);
+    return resolveCanonicalLocalWasteClassificationId(
+      localWasteClassificationIdRaw,
+    );
   }
 
   private getOthersIfOrganicSubject(

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -1,6 +1,9 @@
 import {
   BoldStubsBuilder,
+  type MetadataAttributeParameter,
+  type StubBoldDocumentParameters,
   stubBoldEmissionAndCompostingMetricsEvent,
+  stubBoldMassIDPickUpEvent,
   stubBoldRecyclingBaselinesEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
@@ -12,16 +15,33 @@ import {
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import { type AnyObject } from '@carrot-fndn/shared/types';
 import { addYears } from 'date-fns';
 
 import { PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON } from './prevented-emissions.constants';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
 import { RESULT_COMMENTS } from './prevented-emissions.processor';
 
-const { BASELINES, EXCEEDING_EMISSION_COEFFICIENT, GREENHOUSE_GAS_TYPE } =
-  DocumentEventAttributeName;
+export interface PreventedEmissionsTestCase {
+  accreditationDocuments: Map<string, StubBoldDocumentParameters>;
+  externalCreatedAt: string;
+  massIDDocumentsParams?: StubBoldDocumentParameters;
+  massIDDocumentValue?: number;
+  resultComment: string;
+  resultContent: AnyObject | undefined;
+  resultStatus: RuleOutputStatus;
+  scenario: string;
+  subtype: MassIDOrganicSubtype;
+}
+
+const {
+  BASELINES,
+  EXCEEDING_EMISSION_COEFFICIENT,
+  GREENHOUSE_GAS_TYPE,
+  LOCAL_WASTE_CLASSIFICATION_ID,
+} = DocumentEventAttributeName;
 const { RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
-const { EMISSION_AND_COMPOSTING_METRICS, RECYCLING_BASELINES } =
+const { EMISSION_AND_COMPOSTING_METRICS, PICK_UP, RECYCLING_BASELINES } =
   DocumentEventName;
 
 const subtype = MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES;
@@ -35,7 +55,104 @@ const expectedPreventedEmissionsValue =
 
 const exceedingEmissionCoefficientExceedingBaseline = baselineValue + 1;
 
+const othersIfOrganicIbamaCode = '02 01 06';
+const othersIfOrganicCarbonFraction = 0.15;
+
+const computeOthersIfOrganicFactor = (
+  baseline_: MethodologyBaseline,
+): number => {
+  if (
+    baseline_ === MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS
+  ) {
+    return (
+      Number.parseFloat('6.901715') * othersIfOrganicCarbonFraction -
+      Number.parseFloat('0.1297012')
+    );
+  }
+
+  if (baseline_ === MethodologyBaseline.OPEN_AIR_DUMP) {
+    return (
+      Number.parseFloat('5.521373') * othersIfOrganicCarbonFraction -
+      Number.parseFloat('0.1297013')
+    );
+  }
+
+  return (
+    Number.parseFloat('3.795947') * othersIfOrganicCarbonFraction -
+    Number.parseFloat('0.129701')
+  );
+};
+
+const getOthersIfOrganicFormulaCoeffs = (
+  baseline_: MethodologyBaseline,
+): { intercept: number; slope: number } => {
+  if (
+    baseline_ === MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS
+  ) {
+    return {
+      intercept: Number.parseFloat('-0.1297012'),
+      slope: Number.parseFloat('6.901715'),
+    };
+  }
+
+  if (baseline_ === MethodologyBaseline.OPEN_AIR_DUMP) {
+    return {
+      intercept: Number.parseFloat('-0.1297013'),
+      slope: Number.parseFloat('5.521373'),
+    };
+  }
+
+  return {
+    intercept: Number.parseFloat('-0.129701'),
+    slope: Number.parseFloat('3.795947'),
+  };
+};
+
 const processorErrors = new PreventedEmissionsProcessorErrors();
+
+const makeRecyclerAccreditationParameters = (
+  metadataAttributes: MetadataAttributeParameter[],
+): StubBoldDocumentParameters => ({
+  externalEventsMap: {
+    [EMISSION_AND_COMPOSTING_METRICS]:
+      stubBoldEmissionAndCompostingMetricsEvent({ metadataAttributes }),
+  },
+});
+
+const makeWasteGeneratorAccreditationParameters = (
+  baselinesValue: Record<string, MethodologyBaseline> | undefined,
+): StubBoldDocumentParameters => ({
+  externalEventsMap: {
+    [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
+      metadataAttributes: [[BASELINES, baselinesValue]],
+    }),
+  },
+});
+
+const makeAccreditationDocuments = ({
+  recyclerMetadataAttributes,
+  wasteGeneratorBaselinesValue,
+}: {
+  recyclerMetadataAttributes: MetadataAttributeParameter[];
+  wasteGeneratorBaselinesValue: Record<string, MethodologyBaseline> | undefined;
+}): Map<string, StubBoldDocumentParameters> =>
+  new Map([
+    [RECYCLER, makeRecyclerAccreditationParameters(recyclerMetadataAttributes)],
+    [
+      WASTE_GENERATOR,
+      makeWasteGeneratorAccreditationParameters(wasteGeneratorBaselinesValue),
+    ],
+  ]);
+
+const makeMassIdPickUpParametersWithIbamaCode = (
+  ibamaCode: string | undefined,
+): StubBoldDocumentParameters => ({
+  externalEventsMap: {
+    [PICK_UP]: stubBoldMassIDPickUpEvent({
+      metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, ibamaCode]],
+    }),
+  },
+});
 
 const {
   massIDAuditDocument,
@@ -54,32 +171,13 @@ const {
 
 export const preventedEmissionsTestCases = [
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, undefined],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [EXCEEDING_EMISSION_COEFFICIENT, undefined],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
@@ -96,35 +194,16 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [
-                    EXCEEDING_EMISSION_COEFFICIENT,
-                    exceedingEmissionCoefficientExceedingBaseline,
-                  ],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [
+          EXCEEDING_EMISSION_COEFFICIENT,
+          exceedingEmissionCoefficientExceedingBaseline,
+        ],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.PASSED(
@@ -151,32 +230,13 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, null],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [EXCEEDING_EMISSION_COEFFICIENT, null],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
@@ -193,35 +253,13 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [
-                    EXCEEDING_EMISSION_COEFFICIENT,
-                    exceedingEmissionCoefficient,
-                  ],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.PASSED(
@@ -245,36 +283,71 @@ export const preventedEmissionsTestCases = [
     scenario: `the calculation is correct with all required attributes`,
     subtype,
   },
+  ...[
+    MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
+    MethodologyBaseline.OPEN_AIR_DUMP,
+    MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+  ].map((othersBaseline) => {
+    const othersFactor = computeOthersIfOrganicFactor(othersBaseline);
+    const expectedOthersPreventedEmissions =
+      massIDDocumentValue * othersFactor -
+      massIDDocumentValue * exceedingEmissionCoefficient;
+
+    const formulaCoeffs = getOthersIfOrganicFormulaCoeffs(othersBaseline);
+
+    return {
+      accreditationDocuments: makeAccreditationDocuments({
+        recyclerMetadataAttributes: [
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ],
+        wasteGeneratorBaselinesValue: {
+          [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: othersBaseline,
+        },
+      }),
+      externalCreatedAt: massIDDocument.externalCreatedAt,
+      massIDDocumentsParams: makeMassIdPickUpParametersWithIbamaCode(
+        othersIfOrganicIbamaCode,
+      ),
+      massIDDocumentValue,
+      resultComment: RESULT_COMMENTS.PASSED(
+        expectedOthersPreventedEmissions,
+        othersFactor,
+        exceedingEmissionCoefficient,
+        massIDDocumentValue,
+      ),
+      resultContent: {
+        gasType: 'Methane (CH4)',
+        othersIfOrganicAudit: {
+          canonicalIbamaCode: othersIfOrganicIbamaCode,
+          carbonFraction: othersIfOrganicCarbonFraction,
+          computedFactor: othersFactor,
+          formulaCoeffs,
+        },
+        preventedCo2e: expectedOthersPreventedEmissions,
+        ruleSubject: {
+          exceedingEmissionCoefficient,
+          gasType: 'Methane (CH4)',
+          localWasteClassificationId: othersIfOrganicIbamaCode,
+          massIDDocumentValue,
+          normalizedLocalWasteClassificationId: othersIfOrganicIbamaCode,
+          wasteGeneratorBaseline: othersBaseline,
+          wasteSubtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+        },
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `Others (if organic) calculates factor dynamically for baseline "${othersBaseline}" and IBAMA "${othersIfOrganicIbamaCode}"`,
+      subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+    };
+  }),
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [
-                    EXCEEDING_EMISSION_COEFFICIENT,
-                    exceedingEmissionCoefficient,
-                  ],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE(
@@ -294,32 +367,13 @@ export const preventedEmissionsTestCases = [
     subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
   },
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, 0],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [EXCEEDING_EMISSION_COEFFICIENT, 0],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
@@ -337,32 +391,13 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [EMISSION_AND_COMPOSTING_METRICS]:
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [EXCEEDING_EMISSION_COEFFICIENT, -0.5],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-          },
-        },
+    accreditationDocuments: makeAccreditationDocuments({
+      recyclerMetadataAttributes: [
+        [EXCEEDING_EMISSION_COEFFICIENT, -0.5],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
       ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-              metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-            }),
-          },
-        },
-      ],
-    ]),
+      wasteGeneratorBaselinesValue: { [subtype]: baseline },
+    }),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
@@ -384,6 +419,76 @@ export const preventedEmissionsTestCases = [
 const wasteGeneratorVerificationDocument =
   participantsAccreditationDocuments.get(WASTE_GENERATOR) as Document;
 
+const mapParticipantAccreditationDocuments = ({
+  excludeActorTypes = [],
+  recyclerExternalEvents,
+  recyclerRemoveEventName,
+  wasteGeneratorExternalEvents,
+  wasteGeneratorRemoveEventName,
+}: {
+  excludeActorTypes?: string[];
+  recyclerExternalEvents?: Document['externalEvents'];
+  recyclerRemoveEventName?: string;
+  wasteGeneratorExternalEvents?: Document['externalEvents'];
+  wasteGeneratorRemoveEventName?: string;
+}): Document[] =>
+  [...participantsAccreditationDocuments.values()]
+    .filter(
+      (document) =>
+        document.subtype === undefined ||
+        !excludeActorTypes.includes(document.subtype),
+    )
+    .map((document) => {
+      if (document.subtype === RECYCLER && recyclerExternalEvents) {
+        return {
+          ...document,
+          externalEvents:
+            recyclerRemoveEventName === undefined
+              ? recyclerExternalEvents
+              : [
+                  ...(document.externalEvents?.filter(
+                    (event) => event.name !== recyclerRemoveEventName,
+                  ) ?? []),
+                  ...recyclerExternalEvents,
+                ],
+        };
+      }
+
+      if (
+        document.subtype === WASTE_GENERATOR &&
+        wasteGeneratorExternalEvents
+      ) {
+        return {
+          ...document,
+          externalEvents:
+            wasteGeneratorRemoveEventName === undefined
+              ? wasteGeneratorExternalEvents
+              : [
+                  ...(document.externalEvents?.filter(
+                    (event) => event.name !== wasteGeneratorRemoveEventName,
+                  ) ?? []),
+                  ...wasteGeneratorExternalEvents,
+                ],
+        };
+      }
+
+      return document;
+    });
+
+const makeRecyclerEmissionAndCompostingMetricsEvents = (
+  metadataAttributes: MetadataAttributeParameter[],
+): Document['externalEvents'] => [
+  stubBoldEmissionAndCompostingMetricsEvent({ metadataAttributes }),
+];
+
+const makeWasteGeneratorRecyclingBaselinesEvents = (
+  baselinesValue: Record<string, MethodologyBaseline> | undefined,
+): Document['externalEvents'] => [
+  stubBoldRecyclingBaselinesEvent({
+    metadataAttributes: [[BASELINES, baselinesValue]],
+  }),
+];
+
 export const preventedEmissionsErrorTestCases = [
   {
     documents: [
@@ -391,39 +496,16 @@ export const preventedEmissionsErrorTestCases = [
         ...massIDDocument,
         subtype: 'INVALID_SUBTYPE' as MassIDOrganicSubtype,
       },
-      ...[...participantsAccreditationDocuments.values()].map((document) => {
-        if (document.subtype === RECYCLER) {
-          return {
-            ...document,
-            externalEvents: [
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [
-                    EXCEEDING_EMISSION_COEFFICIENT,
-                    exceedingEmissionCoefficient,
-                  ],
-                  [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                ],
-              }),
-            ],
-          };
-        }
-
-        if (document.subtype === WASTE_GENERATOR) {
-          return {
-            ...document,
-            externalEvents: [
-              ...(document.externalEvents?.filter(
-                (event) => event.name !== RECYCLING_BASELINES.toString(),
-              ) ?? []),
-              stubBoldRecyclingBaselinesEvent({
-                metadataAttributes: [[BASELINES, { [subtype]: baseline }]],
-              }),
-            ],
-          };
-        }
-
-        return document;
+      ...mapParticipantAccreditationDocuments({
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ]),
+        wasteGeneratorExternalEvents:
+          makeWasteGeneratorRecyclingBaselinesEvents({
+            [subtype]: baseline,
+          }),
+        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
       }),
     ],
     massIDAuditDocument,
@@ -435,28 +517,11 @@ export const preventedEmissionsErrorTestCases = [
   {
     documents: [
       massIDDocument,
-      ...[...participantsAccreditationDocuments.values()].map((document) => {
-        if (document.subtype === RECYCLER) {
-          return {
-            ...document,
-            externalEvents: [
-              ...(document.externalEvents?.filter(
-                (event) =>
-                  event.name !== EMISSION_AND_COMPOSTING_METRICS.toString(),
-              ) ?? []),
-              stubBoldEmissionAndCompostingMetricsEvent({
-                metadataAttributes: [
-                  [
-                    EXCEEDING_EMISSION_COEFFICIENT,
-                    exceedingEmissionCoefficient,
-                  ],
-                ],
-              }),
-            ],
-          };
-        }
-
-        return document;
+      ...mapParticipantAccreditationDocuments({
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+        ]),
+        recyclerRemoveEventName: EMISSION_AND_COMPOSTING_METRICS.toString(),
       }),
     ],
     massIDAuditDocument,
@@ -483,32 +548,14 @@ export const preventedEmissionsErrorTestCases = [
   {
     documents: [
       massIDDocument,
-      ...[...participantsAccreditationDocuments.values()]
-        .filter((document) => document.subtype !== WASTE_GENERATOR)
-        .map((document) => {
-          if (document.subtype === RECYCLER) {
-            return {
-              ...document,
-              externalEvents: [
-                ...(document.externalEvents?.filter(
-                  (event) =>
-                    event.name !== EMISSION_AND_COMPOSTING_METRICS.toString(),
-                ) ?? []),
-                stubBoldEmissionAndCompostingMetricsEvent({
-                  metadataAttributes: [
-                    [
-                      EXCEEDING_EMISSION_COEFFICIENT,
-                      exceedingEmissionCoefficient,
-                    ],
-                    [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                  ],
-                }),
-              ],
-            };
-          }
-
-          return document;
-        }),
+      ...mapParticipantAccreditationDocuments({
+        excludeActorTypes: [WASTE_GENERATOR],
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ]),
+        recyclerRemoveEventName: EMISSION_AND_COMPOSTING_METRICS.toString(),
+      }),
     ],
     massIDAuditDocument,
     resultComment:
@@ -520,28 +567,13 @@ export const preventedEmissionsErrorTestCases = [
   {
     documents: [
       massIDDocument,
-      ...[...participantsAccreditationDocuments.values()]
-        .filter((document) => document.subtype !== WASTE_GENERATOR)
-        .map((document) => {
-          if (document.subtype === RECYCLER) {
-            return {
-              ...document,
-              externalEvents: [
-                stubBoldEmissionAndCompostingMetricsEvent({
-                  metadataAttributes: [
-                    [
-                      EXCEEDING_EMISSION_COEFFICIENT,
-                      exceedingEmissionCoefficient,
-                    ],
-                    [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-                  ],
-                }),
-              ],
-            };
-          }
-
-          return document;
-        }),
+      ...mapParticipantAccreditationDocuments({
+        excludeActorTypes: [WASTE_GENERATOR],
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ]),
+      }),
       {
         ...wasteGeneratorVerificationDocument,
         externalEvents: [
@@ -557,5 +589,102 @@ export const preventedEmissionsErrorTestCases = [
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
       'the Waste Generator Accreditation document has no valid baselines',
+  },
+  {
+    documents: [
+      {
+        ...massIDDocument,
+        externalEvents: [
+          ...(massIDDocument.externalEvents?.filter(
+            (event) => event.name !== PICK_UP.toString(),
+          ) ?? []),
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, undefined]],
+          }),
+        ],
+        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+      },
+      ...mapParticipantAccreditationDocuments({
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ]),
+        wasteGeneratorExternalEvents:
+          makeWasteGeneratorRecyclingBaselinesEvents({
+            [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline,
+          }),
+        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
+      }),
+    ],
+    massIDAuditDocument,
+    resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario:
+      'Others (if organic) does not provide Local Waste Classification ID on PICK_UP',
+  },
+  {
+    documents: [
+      {
+        ...massIDDocument,
+        externalEvents: [
+          ...(massIDDocument.externalEvents?.filter(
+            (event) => event.name !== PICK_UP.toString(),
+          ) ?? []),
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '00 00 00']],
+          }),
+        ],
+        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+      },
+      ...mapParticipantAccreditationDocuments({
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ]),
+        wasteGeneratorExternalEvents:
+          makeWasteGeneratorRecyclingBaselinesEvents({
+            [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline,
+          }),
+        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
+      }),
+    ],
+    massIDAuditDocument,
+    resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario:
+      'Others (if organic) has an unknown Local Waste Classification ID (not an accepted IBAMA code)',
+  },
+  {
+    documents: [
+      {
+        ...massIDDocument,
+        externalEvents: [
+          ...(massIDDocument.externalEvents?.filter(
+            (event) => event.name !== PICK_UP.toString(),
+          ) ?? []),
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '02 02 99']],
+          }),
+        ],
+        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+      },
+      ...mapParticipantAccreditationDocuments({
+        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
+          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        ]),
+        wasteGeneratorExternalEvents:
+          makeWasteGeneratorRecyclingBaselinesEvents({
+            [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline,
+          }),
+        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
+      }),
+    ],
+    massIDAuditDocument,
+    resultComment:
+      'The carbon fraction for the "Others (if organic)" IBAMA code "02 02 99" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE.',
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario:
+      'Others (if organic) has a valid 8.7D IBAMA code but carbon fraction is not configured',
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -680,7 +680,9 @@ export const preventedEmissionsErrorTestCases = [
     ],
     massIDAuditDocument,
     resultComment:
-      'The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "02 02 99" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.',
+      processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+        '02 02 99',
+      ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
       'Others (if organic) has a valid 8.7D local waste classification code (Ibama, Brazil) but carbon fraction is not configured',

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -64,23 +64,15 @@ const computeOthersIfOrganicFactor = (
   if (
     baseline_ === MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS
   ) {
-    return (
-      Number.parseFloat('6.901715') * othersIfOrganicCarbonFraction -
-      Number.parseFloat('0.1297012')
-    );
+    // Coefficients aligned with internal calculator, rounded to 6 decimals.
+    return Number.parseFloat('0.905557');
   }
 
   if (baseline_ === MethodologyBaseline.OPEN_AIR_DUMP) {
-    return (
-      Number.parseFloat('5.521373') * othersIfOrganicCarbonFraction -
-      Number.parseFloat('0.1297013')
-    );
+    return Number.parseFloat('0.698505');
   }
 
-  return (
-    Number.parseFloat('3.795947') * othersIfOrganicCarbonFraction -
-    Number.parseFloat('0.129701')
-  );
+  return Number.parseFloat('0.439691');
 };
 
 const getOthersIfOrganicFormulaCoeffs = (
@@ -90,7 +82,7 @@ const getOthersIfOrganicFormulaCoeffs = (
     baseline_ === MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS
   ) {
     return {
-      intercept: Number.parseFloat('-0.1297012'),
+      intercept: Number.parseFloat('-0.1297003'),
       slope: Number.parseFloat('6.901715'),
     };
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -55,7 +55,7 @@ const expectedPreventedEmissionsValue =
 
 const exceedingEmissionCoefficientExceedingBaseline = baselineValue + 1;
 
-const othersIfOrganicIbamaCode = '02 01 06';
+const othersIfOrganicLocalWasteClassificationCode = '02 01 06';
 const othersIfOrganicCarbonFraction = 0.15;
 
 const computeOthersIfOrganicFactor = (
@@ -136,12 +136,14 @@ const makeAccreditationDocuments = ({
     ],
   ]);
 
-const makeMassIdPickUpParametersWithIbamaCode = (
-  ibamaCode: string | undefined,
+const makeMassIdPickUpParametersWithLocalWasteClassificationCode = (
+  localWasteClassificationCode: string | undefined,
 ): StubBoldDocumentParameters => ({
   externalEventsMap: {
     [PICK_UP]: stubBoldMassIDPickUpEvent({
-      metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, ibamaCode]],
+      metadataAttributes: [
+        [LOCAL_WASTE_CLASSIFICATION_ID, localWasteClassificationCode],
+      ],
     }),
   },
 });
@@ -298,9 +300,10 @@ export const preventedEmissionsTestCases = [
         },
       }),
       externalCreatedAt: massIDDocument.externalCreatedAt,
-      massIDDocumentsParams: makeMassIdPickUpParametersWithIbamaCode(
-        othersIfOrganicIbamaCode,
-      ),
+      massIDDocumentsParams:
+        makeMassIdPickUpParametersWithLocalWasteClassificationCode(
+          othersIfOrganicLocalWasteClassificationCode,
+        ),
       massIDDocumentValue,
       resultComment: RESULT_COMMENTS.PASSED(
         expectedOthersPreventedEmissions,
@@ -311,7 +314,8 @@ export const preventedEmissionsTestCases = [
       resultContent: {
         gasType: 'Methane (CH4)',
         othersIfOrganicAudit: {
-          canonicalIbamaCode: othersIfOrganicIbamaCode,
+          canonicalLocalWasteClassificationCode:
+            othersIfOrganicLocalWasteClassificationCode,
           carbonFraction: othersIfOrganicCarbonFraction,
           computedFactor: othersFactor,
           formulaCoeffs,
@@ -320,15 +324,17 @@ export const preventedEmissionsTestCases = [
         ruleSubject: {
           exceedingEmissionCoefficient,
           gasType: 'Methane (CH4)',
-          localWasteClassificationId: othersIfOrganicIbamaCode,
+          localWasteClassificationId:
+            othersIfOrganicLocalWasteClassificationCode,
           massIDDocumentValue,
-          normalizedLocalWasteClassificationId: othersIfOrganicIbamaCode,
+          normalizedLocalWasteClassificationId:
+            othersIfOrganicLocalWasteClassificationCode,
           wasteGeneratorBaseline: othersBaseline,
           wasteSubtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
         },
       },
       resultStatus: RuleOutputStatus.PASSED,
-      scenario: `Others (if organic) calculates factor dynamically for baseline "${othersBaseline}" and IBAMA "${othersIfOrganicIbamaCode}"`,
+      scenario: `Others (if organic) calculates factor dynamically for baseline "${othersBaseline}" and local waste classification "${othersIfOrganicLocalWasteClassificationCode}"`,
       subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
     };
   }),
@@ -644,7 +650,7 @@ export const preventedEmissionsErrorTestCases = [
     resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
-      'Others (if organic) has an unknown Local Waste Classification ID (not an accepted IBAMA code)',
+      'Others (if organic) has an unknown Local Waste Classification ID (not an accepted local waste classification code (Ibama, Brazil))',
   },
   {
     documents: [
@@ -674,9 +680,9 @@ export const preventedEmissionsErrorTestCases = [
     ],
     massIDAuditDocument,
     resultComment:
-      'The carbon fraction for the "Others (if organic)" IBAMA code "02 02 99" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_IBAMA_CODE.',
+      'The carbon fraction for the "Others (if organic)" local waste classification code (Ibama, Brazil) "02 02 99" is not configured. Add it to OTHERS_IF_ORGANIC_CARBON_FRACTION_BY_LOCAL_CODE.',
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
-      'Others (if organic) has a valid 8.7D IBAMA code but carbon fraction is not configured',
+      'Others (if organic) has a valid 8.7D local waste classification code (Ibama, Brazil) but carbon fraction is not configured',
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -56,7 +56,7 @@ const expectedPreventedEmissionsValue =
 const exceedingEmissionCoefficientExceedingBaseline = baselineValue + 1;
 
 const othersIfOrganicLocalWasteClassificationCode = '02 01 06';
-const othersIfOrganicCarbonFraction = 0.15;
+const othersIfOrganicCarbonFraction = '0.15';
 
 const computeOthersIfOrganicFactor = (
   baseline_: MethodologyBaseline,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -6,11 +6,11 @@ import {
   MethodologyDocumentEventAttributeValue,
   NonEmptyString,
   NonNegativeFloat,
-  Percentage,
+  PercentageString,
 } from '@carrot-fndn/shared/types';
 
 export interface OthersIfOrganicCarbonEntry {
-  carbonFraction: Percentage;
+  carbonFraction: PercentageString;
 }
 
 export type OthersIfOrganicRuleSubjectIds = {

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -7,12 +7,18 @@ import {
   NonEmptyString,
 } from '@carrot-fndn/shared/types';
 
+export interface OthersIfOrganicCarbonEntry {
+  carbonFraction: number;
+}
+
 export interface RuleSubject {
   exceedingEmissionCoefficient:
     | MethodologyDocumentEventAttributeValue
     | undefined;
   gasType: NonEmptyString;
+  localWasteClassificationId?: string;
   massIDDocumentValue: number;
+  normalizedLocalWasteClassificationId?: string;
   wasteGeneratorBaseline: MethodologyBaseline | undefined;
   wasteSubtype: MassIDOrganicSubtype;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -5,15 +5,17 @@ import {
 import {
   MethodologyDocumentEventAttributeValue,
   NonEmptyString,
+  NonNegativeFloat,
+  Percentage,
 } from '@carrot-fndn/shared/types';
 
 export interface OthersIfOrganicCarbonEntry {
-  carbonFraction: number;
+  carbonFraction: Percentage;
 }
 
 export type OthersIfOrganicRuleSubjectIds = {
-  localWasteClassificationId?: string;
-  normalizedLocalWasteClassificationId?: string;
+  localWasteClassificationId?: NonEmptyString | undefined;
+  normalizedLocalWasteClassificationId?: NonEmptyString | undefined;
 };
 
 export interface RuleSubject extends OthersIfOrganicRuleSubjectIds {
@@ -21,7 +23,7 @@ export interface RuleSubject extends OthersIfOrganicRuleSubjectIds {
     | MethodologyDocumentEventAttributeValue
     | undefined;
   gasType: NonEmptyString;
-  massIDDocumentValue: number;
+  massIDDocumentValue: NonNegativeFloat;
   wasteGeneratorBaseline: MethodologyBaseline | undefined;
   wasteSubtype: MassIDOrganicSubtype;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -11,14 +11,17 @@ export interface OthersIfOrganicCarbonEntry {
   carbonFraction: number;
 }
 
-export interface RuleSubject {
+export type OthersIfOrganicRuleSubjectIds = {
+  localWasteClassificationId?: string;
+  normalizedLocalWasteClassificationId?: string;
+};
+
+export interface RuleSubject extends OthersIfOrganicRuleSubjectIds {
   exceedingEmissionCoefficient:
     | MethodologyDocumentEventAttributeValue
     | undefined;
   gasType: NonEmptyString;
-  localWasteClassificationId?: string;
   massIDDocumentValue: number;
-  normalizedLocalWasteClassificationId?: string;
   wasteGeneratorBaseline: MethodologyBaseline | undefined;
   wasteSubtype: MassIDOrganicSubtype;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/README.md
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/README.md
@@ -6,7 +6,7 @@ This directory contains constants related to waste classification used in the BO
 
 The waste classification codes in `local-waste-classification.constants.ts` are populated based on data from:
 
-- [IBAMA - Brazilian List of Solid Waste](https://www.ibama.gov.br/phocadownload/emissoeseresiduos/residuos/ibama-lista-brasileira-de-residuos-solidos.xls)
+- [Ibama - Brazilian List of Solid Waste](https://www.ibama.gov.br/phocadownload/emissoeseresiduos/residuos/ibama-lista-brasileira-de-residuos-solidos.xls)
 
 The CDM_CODE values represent mappings to waste types according to the Clean Development Mechanism (CDM) categorization found in:
 

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/index.ts
@@ -1,1 +1,3 @@
+export * from './regional-waste-classification.constants';
+export * from './regional-waste-classification.helpers';
 export * from './regional-waste-classification.lambda';

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/index.ts
@@ -1,3 +1,2 @@
-export * from './regional-waste-classification.constants';
 export * from './regional-waste-classification.helpers';
 export * from './regional-waste-classification.lambda';

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.constants.ts
@@ -937,6 +937,7 @@ export const SUBTYPE_TO_CDM_CODE_MAP: Map<string, string | undefined> = new Map(
     [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES, '8.3'],
     [MassIDOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE, '8.5'],
     [MassIDOrganicSubtype.INDUSTRIAL_SLUDGE, '8.7B'],
+    [MassIDOrganicSubtype.OTHERS_IF_ORGANIC, '8.7D'],
     [MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS, '8.1'],
   ],
 );

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
@@ -1,4 +1,4 @@
-import { SUBTYPE_TO_CDM_CODE_MAP } from './regional-waste-classification.constants';
+import { SUBTYPE_TO_CDM_CODE_MAP } from '@carrot-fndn/shared/methodologies/bold/utils';
 
 const isAlphaNumericUnicode = (ch: string): boolean => /\p{L}|\p{N}/u.test(ch);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
@@ -5,9 +5,6 @@ const isAlphaNumericUnicode = (ch: string): boolean => /\p{L}|\p{N}/u.test(ch);
 export const getCdmCodeFromSubtype = (subtype: string): string | undefined =>
   SUBTYPE_TO_CDM_CODE_MAP.get(subtype);
 
-export const normalizeClassificationId = (id: string): string =>
-  id.replaceAll(/\s+/g, '');
-
 export const normalizeDescriptionForComparison = (value: string): string => {
   const normalized = value.normalize('NFKC').trim();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -17,6 +17,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
+import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   type AnyObject,
@@ -24,7 +25,6 @@ import {
   MethodologyDocumentEventLabel,
 } from '@carrot-fndn/shared/types';
 
-import { WASTE_CLASSIFICATION_CODES } from './regional-waste-classification.constants';
 import { RegionalWasteClassificationProcessorErrors } from './regional-waste-classification.errors';
 import {
   getCdmCodeFromSubtype,

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -1,6 +1,10 @@
 import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
 
-import { getOrDefault, isNonEmptyString } from '@carrot-fndn/shared/helpers';
+import {
+  getOrDefault,
+  isNonEmptyString,
+  normalizeString,
+} from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
   and,
@@ -24,7 +28,6 @@ import { WASTE_CLASSIFICATION_CODES } from './regional-waste-classification.cons
 import { RegionalWasteClassificationProcessorErrors } from './regional-waste-classification.errors';
 import {
   getCdmCodeFromSubtype,
-  normalizeClassificationId,
   normalizeDescriptionForComparison,
 } from './regional-waste-classification.helpers';
 
@@ -84,8 +87,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
     const validClassificationIds = Object.keys(WASTE_CLASSIFICATION_CODES.BR);
 
     const normalizedId = validClassificationIds.find(
-      (validId) =>
-        normalizeClassificationId(validId) === normalizeClassificationId(id),
+      (validId) => normalizeString(validId) === normalizeString(id),
     );
 
     if (!normalizedId) {

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -41,13 +41,13 @@ const { RECYCLER } = MethodologyDocumentEventLabel;
 export const RESULT_COMMENTS = {
   CLASSIFICATION_DESCRIPTION_MISSING: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" was not provided.`,
   CLASSIFICATION_ID_MISSING: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" was not provided.`,
-  INVALID_CLASSIFICATION_DESCRIPTION: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" does not match the expected IBAMA code description.`,
-  INVALID_CLASSIFICATION_ID: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" does not match an IBAMA code accepted by the methodology.`,
+  INVALID_CLASSIFICATION_DESCRIPTION: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" does not match the expected local waste classification code description.`,
+  INVALID_CLASSIFICATION_ID: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" does not match the local waste classification code accepted by the methodology.`,
   INVALID_SUBTYPE_CDM_CODE_MISMATCH: `The subtype does not match the CDM code for the provided "${LOCAL_WASTE_CLASSIFICATION_ID}".`,
   INVALID_SUBTYPE_MAPPING: `The provided subtype does not map to a valid CDM code.`,
   UNSUPPORTED_COUNTRY: (recyclerCountryCode: string) =>
     `Local waste classification is only validated for recyclers in Brazil, but the recycler country is ${recyclerCountryCode}.`,
-  VALID_CLASSIFICATION: `The local waste classification "${LOCAL_WASTE_CLASSIFICATION_ID}" and "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" match an IBAMA code.`,
+  VALID_CLASSIFICATION: `The local waste classification "${LOCAL_WASTE_CLASSIFICATION_ID}" and "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" match an Ibama code.`,
 } as const;
 
 type Subject = {

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -8,11 +8,11 @@ import {
   DocumentEventName,
   MassIDOrganicSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
+import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
-import { WASTE_CLASSIFICATION_CODES } from './regional-waste-classification.constants';
 import { RESULT_COMMENTS } from './regional-waste-classification.processor';
 
 const {

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -66,7 +66,7 @@ export const regionalWasteClassificationTestCases = [
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
-      'the local waste classification ID and description match an IBAMA code with matching subtype.',
+      'the local waste classification ID and description match a local waste classification code with matching subtype.',
   },
   {
     events: {
@@ -93,7 +93,7 @@ export const regionalWasteClassificationTestCases = [
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
-      'the local waste classification ID and description match the IBAMA code without spaces with matching subtype.',
+      'the local waste classification ID and description match the local waste classification code without spaces with matching subtype.',
   },
   {
     events: {
@@ -193,7 +193,7 @@ export const regionalWasteClassificationTestCases = [
     },
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
-      'the local waste classification description does not match the expected IBAMA code.',
+      'the local waste classification description does not match the expected local waste classification code.',
   },
   {
     events: {

--- a/libs/shared/helpers/src/common.helpers.spec.ts
+++ b/libs/shared/helpers/src/common.helpers.spec.ts
@@ -8,6 +8,7 @@ import {
   isNonEmptyObject,
   isObject,
   isPlainObject,
+  normalizeString,
   pick,
 } from './common.helpers';
 
@@ -116,6 +117,17 @@ describe('common helpers', () => {
       expect(getNonEmptyStringOrDefault('\thello\nworld\r', defaultValue)).toBe(
         'hello\nworld',
       );
+    });
+  });
+
+  describe('normalizeString', () => {
+    it('should remove all whitespace characters', () => {
+      expect(normalizeString('02 01 06')).toBe('020106');
+      expect(normalizeString(' 02\t01\n06\r')).toBe('020106');
+    });
+
+    it('should keep non-whitespace characters unchanged', () => {
+      expect(normalizeString('A-B_C')).toBe('A-B_C');
     });
   });
 

--- a/libs/shared/helpers/src/common.helpers.ts
+++ b/libs/shared/helpers/src/common.helpers.ts
@@ -78,3 +78,6 @@ export const getNonEmptyStringOrDefault = (
 export const getOrUndefined = <T>(
   value: null | T | undefined,
 ): NonNullable<T> | undefined => value ?? undefined;
+
+export const normalizeString = (string: string): string =>
+  string.replaceAll(/\s+/g, '');

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -177,7 +177,7 @@ export enum DocumentSubtype {
   HAULER = MethodologyActorType.HAULER,
   INDUSTRIAL_SLUDGE = MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
   INTEGRATOR = MethodologyActorType.INTEGRATOR,
-  OTHERS_IF_ORGANIC = MassIdOrganicSubtype.OTHERS_IF_ORGANIC,
+  OTHERS_IF_ORGANIC = MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
   PROCESS = 'Process',
   PROCESSOR = MethodologyActorType.PROCESSOR,
   RECYCLER = MethodologyActorType.RECYCLER,

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -159,6 +159,7 @@ export enum MassIdOrganicSubtype {
   FOOD_FOOD_WASTE_AND_BEVERAGES = 'Food, Food Waste and Beverages',
   GARDEN_YARD_AND_PARK_WASTE = 'Garden, Yard and Park Waste',
   INDUSTRIAL_SLUDGE = 'Industrial Sludge',
+  OTHERS_IF_ORGANIC = 'Others (if organic)',
   TOBACCO = 'Tobacco',
   WOOD_AND_WOOD_PRODUCTS = 'Wood and Wood Products',
 }
@@ -172,6 +173,7 @@ export enum DocumentSubtype {
   HAULER = MethodologyActorType.HAULER,
   INDUSTRIAL_SLUDGE = MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
   INTEGRATOR = MethodologyActorType.INTEGRATOR,
+  OTHERS_IF_ORGANIC = MassIdOrganicSubtype.OTHERS_IF_ORGANIC,
   PROCESS = 'Process',
   PROCESSOR = MethodologyActorType.PROCESSOR,
   RECYCLER = MethodologyActorType.RECYCLER,

--- a/libs/shared/methodologies/bold/utils/src/index.ts
+++ b/libs/shared/methodologies/bold/utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './document.mappers';
 export * from './event.helpers';
 export * from './rule-processors.constants';
 export * from './typia.validators';
+export * from './waste-classification.constants';

--- a/libs/shared/methodologies/bold/utils/src/waste-classification.constants.ts
+++ b/libs/shared/methodologies/bold/utils/src/waste-classification.constants.ts
@@ -928,7 +928,8 @@ export const WASTE_CLASSIFICATION_CODES = {
 
 /**
  * Maps MassIDOrganicSubtype values to their corresponding CDM_CODE values.
- * Based on CDM_CODE mapping from README.md
+ * Based on CDM_CODE mapping documented in the Regional Waste Classification rule processor README:
+ * @see {@link ../../../../../methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/README.md | Regional Waste Classification README}
  */
 export const SUBTYPE_TO_CDM_CODE_MAP: Map<string, string | undefined> = new Map(
   [

--- a/libs/shared/types/src/number.types.ts
+++ b/libs/shared/types/src/number.types.ts
@@ -19,5 +19,3 @@ export type NonZeroPositive = number &
 export type NonZeroPositiveInt = number &
   tags.ExclusiveMinimum<0> &
   tags.Type<'int64'>;
-
-export type Percentage = NonNegativeFloat & tags.Maximum<1>;

--- a/libs/shared/types/src/number.types.ts
+++ b/libs/shared/types/src/number.types.ts
@@ -10,6 +10,8 @@ export type Longitude = number &
   tags.Minimum<-180> &
   tags.Type<'float'>;
 
+export type NonNegativeFloat = number & tags.Minimum<0>;
+
 export type NonZeroPositive = number &
   tags.ExclusiveMinimum<0> &
   tags.Type<'float'>;
@@ -17,3 +19,5 @@ export type NonZeroPositive = number &
 export type NonZeroPositiveInt = number &
   tags.ExclusiveMinimum<0> &
   tags.Type<'int64'>;
+
+export type Percentage = NonNegativeFloat & tags.Maximum<1>;

--- a/libs/shared/types/src/string.types.ts
+++ b/libs/shared/types/src/string.types.ts
@@ -2,6 +2,9 @@ import type { tags } from 'typia';
 
 export type NonEmptyString = string & tags.MinLength<1>;
 
+export type PercentageString = NonEmptyString &
+  tags.Pattern<`^(0|1|0\\.\\d+|1\\.0+)$`>;
+
 export type Uri = string & tags.Format<'uri'>;
 
 export type Url = string & tags.Format<'url'>;


### PR DESCRIPTION
### 🧾 Summary

Adds support for the "Others (if organic)" CDM waste subtype (8.7(D)) to the BOLD methodology by adding it to the MassIdOrganicSubtype enum and configuring it to use the same rewards distribution and prevented emissions values as Food Waste.

### 🧩 Context

The CDM (Clean Development Mechanism) methodology includes "Others (if organic)" as waste subtype 8.7(D). This subtype needs to be supported in the BOLD methodology rules to allow processing of organic waste that doesn't fit into the existing specific categories (Food Waste, Tobacco, Sludge, etc.). The new subtype is treated identically to "Food, Food Waste and Beverages" for both rewards distribution (Mixed Organic Waste group) and prevented emissions calculations.

### 🧱 Scope of this PR

**Included:**
- Added `OTHERS_IF_ORGANIC = 'Others (if organic)'` to `MassIdOrganicSubtype` enum
- Added corresponding entry to `DocumentSubtype` enum
- Mapped the new subtype to `MIXED_ORGANIC_WASTE` in rewards distribution
- Added prevented emissions constants with same values as Food Waste for all three baselines

**Not included:**
- No changes to other rule processors (they automatically handle new enum values)
- No changes to regional waste classification (already supports 8.7D codes)

### 🧪 How to test

1. Run tests for affected processors:
   ```bash
   pnpm nx test methodologies-bold-rule-processors-mass-id-mass-id-qualifications
   pnpm nx test methodologies-bold-rule-processors-mass-id-certificate-rewards-distribution
   pnpm nx test methodologies-bold-rule-processors-mass-id-prevented-emissions
   ```

2. Verify the new subtype:
   - Mass ID Qualifications processor accepts `OTHERS_IF_ORGANIC` as a valid subtype
   - Rewards Distribution processor correctly applies Mixed Organic Waste percentages
   - Prevented Emissions processor uses correct emission factors (same as Food Waste)

All tests are passing ✅

### 🧠 Considerations for Review

- **No breaking changes**: The new enum value is additive and doesn't affect existing functionality
- **Automatic handling**: Existing processors automatically handle the new subtype via `Object.values()` and type guards, so no additional code changes were needed
- **Consistent behavior**: The new subtype uses the same values as Food Waste, ensuring consistent treatment for similar organic waste types
- **Type safety**: All mappings use TypeScript `Record` types, ensuring compile-time completeness

### 🔗 Related Links

N/A

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for the "Others (if organic)" waste subtype with region-specific carbon-fraction mappings and computed emission factors.

* **Improvements**
  * Emissions factors computed with baseline-specific linear formulas; results include audit details when available.
  * Improved local classification ID normalization and validation; clearer error messages for classification mismatches.

* **Documentation**
  * Expanded guidance on prevented-emissions calculations, baselines, and the dynamic factor algorithm.

* **Tests**
  * Extensive new and updated tests covering the new subtype, formulas, errors, and helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds full support for `OTHERS_IF_ORGANIC` (CDM 8.7D) across MassID processors with dynamic prevented-emissions factors driven by local waste classification codes.
> 
> - Prevented emissions: new formula-based path for `OTHERS_IF_ORGANIC` using `OTHERS_IF_ORGANIC_BASELINE_FORMULA` and per-code carbon fractions; returns audit details; expanded errors and validations; updated helpers and tests
> - Rewards distribution: maps `OTHERS_IF_ORGANIC` to `MIXED_ORGANIC_WASTE`
> - Regional waste classification: now uses shared `WASTE_CLASSIFICATION_CODES` and normalization; messaging clarified
> - Shared utils/types: added `normalizeString`, `PercentageString`, `NonNegativeFloat`, and exposed waste-classification constants; added enum entries for the new subtype
> - Docs: README updates for methodology and calculations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fe7c3d0d407828f4f204a27e10d478e08cf457f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->