### PR TITLE
refactor(rule): remove waste generator and make integrator dates optional

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
@@ -40,13 +40,12 @@ import { assert } from 'typia';
 import { ParticipantAccreditationsAndVerificationsRequirementsProcessorErrors } from './participant-accreditations-and-verifications-requirements.errors';
 
 const ACTORS_REQUIRING_DATES = new Set([
-  MethodologyDocumentEventLabel.INTEGRATOR,
   MethodologyDocumentEventLabel.PROCESSOR,
   MethodologyDocumentEventLabel.RECYCLER,
 ]);
 
 const ACTORS_WITH_OPTIONAL_DATES = new Set([
-  MethodologyDocumentEventLabel.WASTE_GENERATOR,
+  MethodologyDocumentEventLabel.INTEGRATOR,
 ]);
 
 interface RuleSubject {
@@ -135,7 +134,6 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
             MethodologyDocumentEventLabel.INTEGRATOR,
             MethodologyDocumentEventLabel.PROCESSOR,
             MethodologyDocumentEventLabel.RECYCLER,
-            MethodologyDocumentEventLabel.WASTE_GENERATOR,
           ]),
         )
         .map((event) => [
@@ -297,7 +295,6 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
             MethodologyDocumentEventLabel.INTEGRATOR,
             MethodologyDocumentEventLabel.PROCESSOR,
             MethodologyDocumentEventLabel.RECYCLER,
-            MethodologyDocumentEventLabel.WASTE_GENERATOR,
           ]),
         )
         .map((event) => [


### PR DESCRIPTION
### 🧾 Summary

Removes Waste Generator from participant-accreditations-and-verifications-requirements rule validation and makes INTEGRATOR accreditation dates optional, allowing INTEGRATOR accreditations to be valid without ACCREDITATION_RESULT events.

### 🧩 Context

This change is part of making Waste Generator accreditation documents optional (CRT-232). The rule processor previously required and validated Waste Generator accreditation documents, but they are now being made optional across the system. Additionally, INTEGRATOR accreditations are being updated to allow optional dates, meaning they can be valid without ACCREDITATION_RESULT events.

### 🧱 Scope of this PR

The changes include:

1. **Remove Waste Generator validation**:
   - Removed `WASTE_GENERATOR` from `ACTORS_WITH_OPTIONAL_DATES` constant
   - Removed `WASTE_GENERATOR` from `getActorParticipants()` filter
   - Removed `WASTE_GENERATOR` from `verifyAllParticipantsHaveAccreditationDocuments()` filter
   - Removed unused `ACTORS_WITH_OPTIONAL_DATES` constant (was empty after removing WASTE_GENERATOR)
   - Removed unused `isAccreditationValidWithOptionalDates` import

2. **Make INTEGRATOR dates optional**:
   - Moved `INTEGRATOR` from `ACTORS_REQUIRING_DATES` to `ACTORS_WITH_OPTIONAL_DATES`
   - Restored `ACTORS_WITH_OPTIONAL_DATES` constant with INTEGRATOR
   - Restored `isAccreditationValidWithOptionalDates` import
   - INTEGRATOR now uses `isAccreditationValidWithOptionalDates` validation, allowing accreditations without ACCREDITATION_RESULT events

3. **Test case updates**:
   - Updated test cases for Waste Generator to reflect it being ignored
   - Added test case for Waste Generator with no accreditation document
   - Added test case for PROCESSOR with multiple valid accreditations (to improve coverage)
   - Updated scenario descriptions to clarify behavior

**Not included in this PR**:
- Changes to other rules that may use Waste Generator accreditation documents (e.g., `rewards-distribution`, `geolocation-and-address-precision`)
- Changes to `prevented-emissions` rule (future work)

### 🧪 How to test

Run the test suite for the participant-accreditations-and-verifications-requirements rule:

```bash
pnpm test methodologies-bold-rule-processors-mass-id-participant-accreditations-and-verifications-requirements
```

All 26 tests should pass with 100% code coverage.

To manually verify:
1. Mass ID documents with Waste Generator events should pass validation even without Waste Generator accreditation documents
2. Mass ID documents with INTEGRATOR accreditations without ACCREDITATION_RESULT events should pass validation
3. Mass ID documents with INTEGRATOR accreditations with expired ACCREDITATION_RESULT events should fail validation
4. Mass ID documents with PROCESSOR/RECYCLER accreditations should continue to work as before

### 🧠 Considerations for Review

- **Backward compatibility**: Existing Mass ID documents will continue to work. Documents with Waste Generator accreditation will pass (Waste Generator is ignored), and documents without Waste Generator accreditation will now pass (previously would fail).
- **Validation logic**: The validation logic was simplified by removing the empty `ACTORS_WITH_OPTIONAL_DATES` constant initially, but then restored when INTEGRATOR was moved to optional dates.
- **Test coverage**: Added a test case for multiple valid accreditations scenario to achieve 100% code coverage.

### 🔗 Related Links

- Related task: CRT-232 (Spike: Research eliminating Undisclosed Waste Generator document)
- Implementation plan: `.cursor/plans/remove_waste_generator_from_accreditations_requirements_e4fbc23c.plan.md`

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integrator accreditation dates are now treated as optional instead of mandatory.
  * Waste Generator is removed from specific accreditation validation checks and ignored in those paths.

* **Tests**
  * Expanded coverage for multiple accreditations and participants with multiple roles.
  * Added builder helpers and new scenarios: Waste Generator with no accreditation, multiple valid accreditations via linking, and adjusted expected outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->