### PR TITLE
feat(rule): implement large business verification in rewards distribution

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
@@ -3,6 +3,7 @@ import type { DocumentCriteria } from '@carrot-fndn/shared/methodologies/bold/io
 import {
   MASS_ID,
   METHODOLOGY_DEFINITION,
+  PARTICIPANT_ACCREDITATION_PARTIAL_MATCH,
 } from '@carrot-fndn/shared/methodologies/bold/matchers';
 import {
   MassIdOrganicSubtype,
@@ -94,5 +95,9 @@ export const REWARDS_DISTRIBUTION_BY_WASTE_TYPE: Record<
 };
 
 export const REWARDS_DISTRIBUTION_CRITERIA: DocumentCriteria = {
-  relatedDocuments: [METHODOLOGY_DEFINITION.match, MASS_ID.match],
+  relatedDocuments: [
+    METHODOLOGY_DEFINITION.match,
+    MASS_ID.match,
+    PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.match,
+  ],
 };

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -1,0 +1,230 @@
+import {
+  BoldStubsBuilder,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  DocumentEventAttributeName,
+  DocumentEventAttributeValue,
+  DocumentEventName,
+  DocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import {
+  isLargeBusiness,
+  shouldApplyLargeBusinessDiscount,
+} from './rewards-distribution.helpers';
+
+const { ONBOARDING_DECLARATION } = DocumentEventName;
+const { BUSINESS_SIZE_DECLARATION } = DocumentEventAttributeName;
+const { LARGE_BUSINESS, SMALL_BUSINESS } = DocumentEventAttributeValue;
+const { WASTE_GENERATOR } = DocumentSubtype;
+
+describe('shouldApplyLargeBusinessDiscount', () => {
+  it('should return true when document is undefined (defaults to Large Business)', () => {
+    expect(shouldApplyLargeBusinessDiscount(undefined)).toBe(true);
+  });
+
+  it('should return true when document exists but has no ONBOARDING_DECLARATION event', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([[WASTE_GENERATOR, { externalEventsMap: {} }]]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(shouldApplyLargeBusinessDiscount(document)).toBe(true);
+  });
+
+  it('should return true when document has ONBOARDING_DECLARATION event with Large Business', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [[BUSINESS_SIZE_DECLARATION, LARGE_BUSINESS]],
+                  ),
+              },
+            },
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(shouldApplyLargeBusinessDiscount(document)).toBe(true);
+  });
+
+  it('should return false when document has ONBOARDING_DECLARATION event with Small Business', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [[BUSINESS_SIZE_DECLARATION, SMALL_BUSINESS]],
+                  ),
+              },
+            },
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(shouldApplyLargeBusinessDiscount(document)).toBe(false);
+  });
+
+  it('should return true when document has ONBOARDING_DECLARATION event but BUSINESS_SIZE_DECLARATION is missing', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [],
+                  ),
+              },
+            },
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(shouldApplyLargeBusinessDiscount(document)).toBe(true);
+  });
+});
+
+describe('isLargeBusiness', () => {
+  it('should return true when document has no ONBOARDING_DECLARATION event', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([[WASTE_GENERATOR, { externalEventsMap: {} }]]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(isLargeBusiness(document)).toBe(true);
+  });
+
+  it('should return true when document has ONBOARDING_DECLARATION event with Large Business', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [[BUSINESS_SIZE_DECLARATION, LARGE_BUSINESS]],
+                  ),
+              },
+            },
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(isLargeBusiness(document)).toBe(true);
+  });
+
+  it('should return false when document has ONBOARDING_DECLARATION event with Small Business', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [[BUSINESS_SIZE_DECLARATION, SMALL_BUSINESS]],
+                  ),
+              },
+            },
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(isLargeBusiness(document)).toBe(false);
+  });
+
+  it('should return true when document has ONBOARDING_DECLARATION event but BUSINESS_SIZE_DECLARATION is missing', () => {
+    const document = new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [],
+                  ),
+              },
+            },
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
+
+    expect(isLargeBusiness(document)).toBe(true);
+  });
+});

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -9,10 +9,7 @@ import {
   DocumentSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
-import {
-  isLargeBusiness,
-  shouldApplyLargeBusinessDiscount,
-} from './rewards-distribution.helpers';
+import { shouldApplyLargeBusinessDiscount } from './rewards-distribution.helpers';
 
 const { ONBOARDING_DECLARATION } = DocumentEventName;
 const { BUSINESS_SIZE_DECLARATION } = DocumentEventAttributeName;
@@ -123,108 +120,5 @@ describe('shouldApplyLargeBusinessDiscount', () => {
       .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
 
     expect(shouldApplyLargeBusinessDiscount(document)).toBe(true);
-  });
-});
-
-describe('isLargeBusiness', () => {
-  it('should return true when document has no ONBOARDING_DECLARATION event', () => {
-    const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
-      .createMethodologyDocument()
-      .createParticipantAccreditationDocuments(
-        new Map([[WASTE_GENERATOR, { externalEventsMap: {} }]]),
-      )
-      .build()
-      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
-
-    expect(isLargeBusiness(document)).toBe(true);
-  });
-
-  it('should return true when document has ONBOARDING_DECLARATION event with Large Business', () => {
-    const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
-      .createMethodologyDocument()
-      .createParticipantAccreditationDocuments(
-        new Map([
-          [
-            WASTE_GENERATOR,
-            {
-              externalEventsMap: {
-                [ONBOARDING_DECLARATION]:
-                  stubDocumentEventWithMetadataAttributes(
-                    {
-                      name: ONBOARDING_DECLARATION,
-                    },
-                    [[BUSINESS_SIZE_DECLARATION, LARGE_BUSINESS]],
-                  ),
-              },
-            },
-          ],
-        ]),
-      )
-      .build()
-      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
-
-    expect(isLargeBusiness(document)).toBe(true);
-  });
-
-  it('should return false when document has ONBOARDING_DECLARATION event with Small Business', () => {
-    const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
-      .createMethodologyDocument()
-      .createParticipantAccreditationDocuments(
-        new Map([
-          [
-            WASTE_GENERATOR,
-            {
-              externalEventsMap: {
-                [ONBOARDING_DECLARATION]:
-                  stubDocumentEventWithMetadataAttributes(
-                    {
-                      name: ONBOARDING_DECLARATION,
-                    },
-                    [[BUSINESS_SIZE_DECLARATION, SMALL_BUSINESS]],
-                  ),
-              },
-            },
-          ],
-        ]),
-      )
-      .build()
-      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
-
-    expect(isLargeBusiness(document)).toBe(false);
-  });
-
-  it('should return true when document has ONBOARDING_DECLARATION event but BUSINESS_SIZE_DECLARATION is missing', () => {
-    const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
-      .createMethodologyDocument()
-      .createParticipantAccreditationDocuments(
-        new Map([
-          [
-            WASTE_GENERATOR,
-            {
-              externalEventsMap: {
-                [ONBOARDING_DECLARATION]:
-                  stubDocumentEventWithMetadataAttributes(
-                    {
-                      name: ONBOARDING_DECLARATION,
-                    },
-                    [],
-                  ),
-              },
-            },
-          ],
-        ]),
-      )
-      .build()
-      .participantsAccreditationDocuments.get(WASTE_GENERATOR)!;
-
-    expect(isLargeBusiness(document)).toBe(true);
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -216,9 +216,13 @@ export const getWasteGeneratorAdditionalPercentage = (
   return new BigNumber(0);
 };
 
-export const isLargeBusiness = (
-  wasteGeneratorVerificationDocument: Document,
+export const shouldApplyLargeBusinessDiscount = (
+  wasteGeneratorVerificationDocument: Document | undefined,
 ): boolean => {
+  if (isNil(wasteGeneratorVerificationDocument)) {
+    return true;
+  }
+
   const onboardingDeclarationEvent =
     wasteGeneratorVerificationDocument.externalEvents?.find(
       (event) =>
@@ -241,16 +245,6 @@ export const isLargeBusiness = (
   return (
     String(businessSize) === String(DocumentEventAttributeValue.LARGE_BUSINESS)
   );
-};
-
-export const shouldApplyLargeBusinessDiscount = (
-  wasteGeneratorVerificationDocument: Document | undefined,
-): boolean => {
-  if (isNil(wasteGeneratorVerificationDocument)) {
-    return true;
-  }
-
-  return isLargeBusiness(wasteGeneratorVerificationDocument);
 };
 
 export const applyLargeBusinessDiscount = (

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -32,6 +32,7 @@ describe('RewardsDistributionProcessor', () => {
         expectedRewards,
         massIdDocumentEvents,
         massIdPartialDocument,
+        wasteGeneratorVerificationDocument,
       }) => {
         const {
           massIdAuditDocument,
@@ -55,6 +56,9 @@ describe('RewardsDistributionProcessor', () => {
           massIdDocument,
           massIdCertificateDocument,
           methodologyDocument as Document,
+          ...(wasteGeneratorVerificationDocument
+            ? [wasteGeneratorVerificationDocument]
+            : []),
         ];
 
         spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -40,6 +40,35 @@ const {
   WASTE_GENERATOR,
 } = RewardsDistributionActorType;
 
+const createWasteGeneratorVerificationDocument = (
+  businessSize: DocumentEventAttributeValue,
+): Document => ({
+  ...new BoldStubsBuilder()
+    .createMassIdDocuments()
+    .createMassIdAuditDocuments()
+    .createMethodologyDocument()
+    .createParticipantAccreditationDocuments(
+      new Map([
+        [
+          WASTE_GENERATOR_SUBTYPE,
+          {
+            externalEventsMap: {
+              [ONBOARDING_DECLARATION]:
+                stubDocumentEventWithMetadataAttributes(
+                  {
+                    name: ONBOARDING_DECLARATION,
+                  },
+                  [[BUSINESS_SIZE_DECLARATION, businessSize]],
+                ),
+            },
+          },
+        ],
+      ]),
+    )
+    .build()
+    .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
+} as Document);
+
 const DEFAULT_REWARDS = {
   [COMMUNITY_IMPACT_POOL]: '0',
   [INTEGRATOR]: '8',
@@ -196,32 +225,8 @@ export const rewardsDistributionProcessorTestCases: Array<{
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `Large Business discount is applied when Waste Generator Verification Document indicates Large Business`,
-    wasteGeneratorVerificationDocument: {
-      ...new BoldStubsBuilder()
-        .createMassIdDocuments()
-        .createMassIdAuditDocuments()
-        .createMethodologyDocument()
-        .createParticipantAccreditationDocuments(
-          new Map([
-            [
-              WASTE_GENERATOR_SUBTYPE,
-              {
-                externalEventsMap: {
-                  [ONBOARDING_DECLARATION]:
-                    stubDocumentEventWithMetadataAttributes(
-                      {
-                        name: ONBOARDING_DECLARATION,
-                      },
-                      [[BUSINESS_SIZE_DECLARATION, LARGE_BUSINESS]],
-                    ),
-                },
-              },
-            ],
-          ]),
-        )
-        .build()
-        .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
-    } as Document,
+    wasteGeneratorVerificationDocument:
+      createWasteGeneratorVerificationDocument(LARGE_BUSINESS),
   },
   {
     expectedRewards:
@@ -234,32 +239,8 @@ export const rewardsDistributionProcessorTestCases: Array<{
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `no discount is applied when Waste Generator Verification Document indicates Small Business`,
-    wasteGeneratorVerificationDocument: {
-      ...new BoldStubsBuilder()
-        .createMassIdDocuments()
-        .createMassIdAuditDocuments()
-        .createMethodologyDocument()
-        .createParticipantAccreditationDocuments(
-          new Map([
-            [
-              WASTE_GENERATOR_SUBTYPE,
-              {
-                externalEventsMap: {
-                  [ONBOARDING_DECLARATION]:
-                    stubDocumentEventWithMetadataAttributes(
-                      {
-                        name: ONBOARDING_DECLARATION,
-                      },
-                      [[BUSINESS_SIZE_DECLARATION, SMALL_BUSINESS]],
-                    ),
-                },
-              },
-            ],
-          ]),
-        )
-        .build()
-        .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
-    } as Document,
+    wasteGeneratorVerificationDocument:
+      createWasteGeneratorVerificationDocument(SMALL_BUSINESS),
   },
 ];
 

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -4,6 +4,7 @@ import {
   type BoldExternalEventsObject,
   BoldStubsBuilder,
   stubBoldMassIdPickUpEvent,
+  stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type Document,
@@ -11,6 +12,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventAttributeValue,
   DocumentEventName,
+  DocumentSubtype,
   MassIdOrganicSubtype,
   RewardsDistributionActorType,
   RewardsDistributionWasteType,
@@ -21,9 +23,11 @@ import { REWARDS_DISTRIBUTION_BY_WASTE_TYPE } from './rewards-distribution.const
 import { ERROR_MESSAGES } from './rewards-distribution.errors';
 
 const { MASS_ID, METHODOLOGY } = DocumentCategory;
-const { PICK_UP } = DocumentEventName;
-const { WASTE_ORIGIN } = DocumentEventAttributeName;
-const { UNIDENTIFIED } = DocumentEventAttributeValue;
+const { ONBOARDING_DECLARATION, PICK_UP } = DocumentEventName;
+const { BUSINESS_SIZE_DECLARATION, WASTE_ORIGIN } = DocumentEventAttributeName;
+const { LARGE_BUSINESS, SMALL_BUSINESS, UNIDENTIFIED } =
+  DocumentEventAttributeValue;
+const { WASTE_GENERATOR: WASTE_GENERATOR_SUBTYPE } = DocumentSubtype;
 const {
   COMMUNITY_IMPACT_POOL,
   HAULER,
@@ -71,6 +75,35 @@ const EXPECTED_REWARDS = {
     ...DEFAULT_REWARDS,
     [COMMUNITY_IMPACT_POOL]: '12.5',
   },
+  SMALL_BUSINESS: {
+    [RewardsDistributionWasteType.MIXED_ORGANIC_WASTE]: {
+      [HAULER]: '10',
+      [NETWORK]: '20',
+      [PROCESSOR]: '10',
+      [RECYCLER]: '20',
+      [WASTE_GENERATOR]: '30',
+      ...DEFAULT_REWARDS,
+      [COMMUNITY_IMPACT_POOL]: '0',
+    },
+    [RewardsDistributionWasteType.SLUDGE_FROM_WASTE_TREATMENT]: {
+      [HAULER]: '5',
+      [NETWORK]: '20',
+      [PROCESSOR]: '10',
+      [RECYCLER]: '30',
+      [WASTE_GENERATOR]: '25',
+      ...DEFAULT_REWARDS,
+      [COMMUNITY_IMPACT_POOL]: '0',
+    },
+    [RewardsDistributionWasteType.TOBACCO_INDUSTRY_RESIDUES]: {
+      [HAULER]: '5',
+      [NETWORK]: '20',
+      [PROCESSOR]: '10',
+      [RECYCLER]: '30',
+      [WASTE_GENERATOR]: '25',
+      ...DEFAULT_REWARDS,
+      [COMMUNITY_IMPACT_POOL]: '0',
+    },
+  },
   WITHOUT_WASTE_GENERATOR: {
     WITH_HAULER: {
       [HAULER]: '7.5',
@@ -94,6 +127,7 @@ export const rewardsDistributionProcessorTestCases: Array<{
   massIdPartialDocument: PartialDeep<Document>;
   resultStatus: RuleOutputStatus;
   scenario: string;
+  wasteGeneratorVerificationDocument?: Document | undefined;
 }> = [
   ...Object.entries(REWARDS_DISTRIBUTION_BY_WASTE_TYPE).map(
     ([wasteType, expectedRewards]) => ({
@@ -144,6 +178,88 @@ export const rewardsDistributionProcessorTestCases: Array<{
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `all rewards are applied for the ${REWARDS_DISTRIBUTION_BY_WASTE_TYPE['Food, Food Waste and Beverages']}`,
+  },
+  {
+    expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
+    massIdDocumentEvents: {},
+    massIdPartialDocument: {
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `Large Business discount is applied when Waste Generator Verification Document is missing (defaults to Large Business)`,
+  },
+  {
+    expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
+    massIdDocumentEvents: {},
+    massIdPartialDocument: {
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `Large Business discount is applied when Waste Generator Verification Document indicates Large Business`,
+    wasteGeneratorVerificationDocument: {
+      ...new BoldStubsBuilder()
+        .createMassIdDocuments()
+        .createMassIdAuditDocuments()
+        .createMethodologyDocument()
+        .createParticipantAccreditationDocuments(
+          new Map([
+            [
+              WASTE_GENERATOR_SUBTYPE,
+              {
+                externalEventsMap: {
+                  [ONBOARDING_DECLARATION]:
+                    stubDocumentEventWithMetadataAttributes(
+                      {
+                        name: ONBOARDING_DECLARATION,
+                      },
+                      [[BUSINESS_SIZE_DECLARATION, LARGE_BUSINESS]],
+                    ),
+                },
+              },
+            ],
+          ]),
+        )
+        .build()
+        .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
+    } as Document,
+  },
+  {
+    expectedRewards:
+      EXPECTED_REWARDS.SMALL_BUSINESS[
+        RewardsDistributionWasteType.MIXED_ORGANIC_WASTE
+      ],
+    massIdDocumentEvents: {},
+    massIdPartialDocument: {
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `no discount is applied when Waste Generator Verification Document indicates Small Business`,
+    wasteGeneratorVerificationDocument: {
+      ...new BoldStubsBuilder()
+        .createMassIdDocuments()
+        .createMassIdAuditDocuments()
+        .createMethodologyDocument()
+        .createParticipantAccreditationDocuments(
+          new Map([
+            [
+              WASTE_GENERATOR_SUBTYPE,
+              {
+                externalEventsMap: {
+                  [ONBOARDING_DECLARATION]:
+                    stubDocumentEventWithMetadataAttributes(
+                      {
+                        name: ONBOARDING_DECLARATION,
+                      },
+                      [[BUSINESS_SIZE_DECLARATION, SMALL_BUSINESS]],
+                    ),
+                },
+              },
+            ],
+          ]),
+        )
+        .build()
+        .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
+    } as Document,
   },
 ];
 

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -42,32 +42,33 @@ const {
 
 const createWasteGeneratorVerificationDocument = (
   businessSize: DocumentEventAttributeValue,
-): Document => ({
-  ...new BoldStubsBuilder()
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
-    .createMethodologyDocument()
-    .createParticipantAccreditationDocuments(
-      new Map([
-        [
-          WASTE_GENERATOR_SUBTYPE,
-          {
-            externalEventsMap: {
-              [ONBOARDING_DECLARATION]:
-                stubDocumentEventWithMetadataAttributes(
-                  {
-                    name: ONBOARDING_DECLARATION,
-                  },
-                  [[BUSINESS_SIZE_DECLARATION, businessSize]],
-                ),
+): Document =>
+  ({
+    ...new BoldStubsBuilder()
+      .createMassIdDocuments()
+      .createMassIdAuditDocuments()
+      .createMethodologyDocument()
+      .createParticipantAccreditationDocuments(
+        new Map([
+          [
+            WASTE_GENERATOR_SUBTYPE,
+            {
+              externalEventsMap: {
+                [ONBOARDING_DECLARATION]:
+                  stubDocumentEventWithMetadataAttributes(
+                    {
+                      name: ONBOARDING_DECLARATION,
+                    },
+                    [[BUSINESS_SIZE_DECLARATION, businessSize]],
+                  ),
+              },
             },
-          },
-        ],
-      ]),
-    )
-    .build()
-    .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
-} as Document);
+          ],
+        ]),
+      )
+      .build()
+      .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
+  }) as Document;
 
 const DEFAULT_REWARDS = {
   [COMMUNITY_IMPACT_POOL]: '0',

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.types.ts
@@ -13,6 +13,7 @@ export interface ActorMassIdPercentageInputDto {
   actorType: RewardsDistributionActorType;
   massIdDocument: Document;
   rewardDistribution: BigNumber;
+  wasteGeneratorVerificationDocument: Document | undefined;
 }
 
 export interface ActorReward {

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -105,7 +105,7 @@ export enum DocumentEventName {
   MONITORING_SYSTEMS_AND_EQUIPMENT = MethodologyDocumentEventName.MONITORING_SYSTEMS_AND_EQUIPMENT,
   MOVE = 'MOVE',
   NOTICE = MethodologyDocumentEventName.NOTICE,
-  ONBOARDING_DECLARATION = 'Onboarding Declaration',
+  ONBOARDING_DECLARATION = MethodologyDocumentEventName.ONBOARDING_DECLARATION,
   OUTPUT = MethodologyDocumentEventName.OUTPUT,
   PICK_UP = MethodologyDocumentEventName.PICK_UP,
   RECYCLED = MethodologyDocumentEventName.RECYCLED,

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -33,6 +33,7 @@ export enum DocumentEventAttributeName {
   ACCREDITATION_STATUS = 'Accreditation Status',
   APPROVED_EXCEPTIONS = 'Approved Exceptions',
   BASELINES = 'Baselines',
+  BUSINESS_SIZE_DECLARATION = 'Business Size Declaration',
   CAPTURED_GPS_LATITUDE = 'Captured GPS Latitude',
   CAPTURED_GPS_LONGITUDE = 'Captured GPS Longitude',
   CONTAINER_CAPACITY = 'Container Capacity',
@@ -75,6 +76,8 @@ export enum DocumentEventAttributeName {
 }
 
 export enum DocumentEventAttributeValue {
+  LARGE_BUSINESS = 'Large Business',
+  SMALL_BUSINESS = 'Small Business',
   UNIDENTIFIED = 'Unidentified',
 }
 
@@ -102,6 +105,7 @@ export enum DocumentEventName {
   MONITORING_SYSTEMS_AND_EQUIPMENT = MethodologyDocumentEventName.MONITORING_SYSTEMS_AND_EQUIPMENT,
   MOVE = 'MOVE',
   NOTICE = MethodologyDocumentEventName.NOTICE,
+  ONBOARDING_DECLARATION = 'Onboarding Declaration',
   OUTPUT = MethodologyDocumentEventName.OUTPUT,
   PICK_UP = MethodologyDocumentEventName.PICK_UP,
   RECYCLED = MethodologyDocumentEventName.RECYCLED,

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -61,6 +61,7 @@ export enum MethodologyDocumentEventName {
   LINK = 'LINK',
   MONITORING_SYSTEMS_AND_EQUIPMENT = 'Monitoring Systems & Equipment',
   NOTICE = 'NOTICE',
+  ONBOARDING_DECLARATION = 'Onboarding Declaration',
   OUTPUT = 'OUTPUT',
   PICK_UP = 'Pick-up',
   RECYCLED = 'Recycled',


### PR DESCRIPTION
### 🧾 Summary

Implements Large Business verification logic in the rewards distribution rule processor. Applies a 50% discount to Waste Generators without onboarding (defaulting to Large Business) and to Waste Generators with onboarding that are verified as Large Business. Extracts shared discount calculation helpers for better code reusability and maintainability.

### 🧩 Context

This change implements the business requirement to apply a 50% discount to Large Business waste generators in the rewards distribution calculation. The discount is determined by checking Waste Generator Verification Documents for the business size declaration. If no verification document exists or the business size is not specified, the system defaults to treating the waste generator as a Large Business.

### 🧱 Scope of this PR

**Included:**
- Large Business verification logic using Waste Generator Verification Documents
- Discount application to Waste Generators (50% when Large Business)
- Community Impact Pool share calculation (only when discount is applied)
- Shared helper functions for discount calculations
- Comprehensive test coverage for all verification scenarios
- Enum extensions for new document events and attributes

**Not included:**
- Changes to other rule processors
- UI or API changes
- Documentation updates (will be addressed separately if needed)

### 🧪 How to test

1. Run the test suite:
   ```bash
   pnpm test methodologies-bold-rule-processors-mass-id-certificate-rewards-distribution
   ```

2. Test scenarios covered:
   - Waste Generator Verification Document missing (should apply discount)
   - Waste Generator Verification Document indicates "Large Business" (should apply discount)
   - Waste Generator Verification Document indicates "Small Business" (should NOT apply discount)
   - Waste Generator Verification Document exists but ONBOARDING_DECLARATION event is missing (should apply discount)
   - Waste Generator Verification Document exists, ONBOARDING_DECLARATION event exists, but BUSINESS_SIZE_DECLARATION attribute is missing (should apply discount)

3. Verify expected rewards:
   - Large Business: Waste Generator gets 15% (50% discount from 30%), Community Impact Pool gets 15%
   - Small Business: Waste Generator gets 30% (no discount), Community Impact Pool gets 0%

### 🧠 Considerations for Review

- **Helper Function Separation**: The logic is separated into `isLargeBusiness` (for existing documents) and `shouldApplyLargeBusinessDiscount` (handles nil check). This separation ensures `isLargeBusiness` is only called when a document exists.

- **Shared Discount Helpers**: The discount calculation logic is extracted into shared helpers (`applyLargeBusinessDiscount` and `calculateCommunityImpactPoolShare`) to ensure consistency and reusability.

- **Default Behavior**: The system defaults to Large Business when verification documents or attributes are missing. This is an intentional business decision.

- **Community Impact Pool**: The Community Impact Pool share is only calculated when a discount is applied (Large Business). For Small Business, it receives 0%.

- **Enum Extensions**: New enum values were added to support the ONBOARDING_DECLARATION event and BUSINESS_SIZE_DECLARATION attribute.

### 🔗 Related Links

- ClickUp Task: https://app.clickup.com/t/3005225/CRT-240
- Implementation Plan: `.cursor/plans/implement_large_business_verification_in_rewards_distribution_15767b9e.plan.md`

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rewards distribution now conditionally applies a large-business discount using an optional waste-generator verification document; when verification or onboarding data is missing, previous permissive behavior is preserved.
  * Added business-size classifications (Large, Small, Unidentified) and an onboarding declaration event to drive discount decisions.

* **Tests**
  * Added comprehensive tests and scenarios covering discount gating, size detection, and expected reward outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces large-business gating for Waste Generator rewards using an optional verification document and applies a 50% discount when applicable, allocating the difference to `Community Impact Pool`.
> 
> - Expands `REWARDS_DISTRIBUTION_CRITERIA` to include `PARTICIPANT_ACCREDITATION_PARTIAL_MATCH`
> - Loads Waste Generator verification doc in `RewardsDistributionProcessor` and threads it through calculations
> - Adds helpers: `shouldApplyLargeBusinessDiscount`, `applyLargeBusinessDiscount`, `calculateCommunityImpactPoolShare`
> - Applies discount in Waste Generator calculation and derives Community Impact Pool share via `getNgoActorMassIdPercentage`
> - Updates types to carry `wasteGeneratorVerificationDocument`
> - Adds comprehensive tests for helper logic and processor scenarios (Large/Small/missing onboarding)
> - Extends enums with `ONBOARDING_DECLARATION`, `BUSINESS_SIZE_DECLARATION`, and business-size values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd2823f7903ee7c296fdbdce925191975bf2ca76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->