### PR TITLE
feat(rule): add subtype CDM_CODE verification to regional waste classification

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.constants.ts
@@ -1,3 +1,5 @@
+import { MassIdOrganicSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
+
 // Common descriptions
 const OTHER_WASTE = 'Outros resíduos não anteriormente especificados';
 const EFFLUENT_TREATMENT_SLUDGE = 'Lodos do tratamento local de efluentes';
@@ -923,3 +925,18 @@ export const WASTE_CLASSIFICATION_CODES = {
     },
   },
 } as const;
+
+/**
+ * Maps MassIdOrganicSubtype values to their corresponding CDM_CODE values.
+ * Based on CDM_CODE mapping from README.md
+ */
+export const SUBTYPE_TO_CDM_CODE_MAP: Map<string, string | undefined> = new Map(
+  [
+    [MassIdOrganicSubtype.DOMESTIC_SLUDGE, '8.7C'],
+    [MassIdOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE, '8.7A'],
+    [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES, '8.3'],
+    [MassIdOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE, '8.5'],
+    [MassIdOrganicSubtype.INDUSTRIAL_SLUDGE, '8.7B'],
+    [MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS, '8.1'],
+  ],
+);

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
@@ -1,0 +1,26 @@
+import { SUBTYPE_TO_CDM_CODE_MAP } from './regional-waste-classification.constants';
+
+const isAlphaNumericUnicode = (ch: string): boolean => /\p{L}|\p{N}/u.test(ch);
+
+export const getCdmCodeFromSubtype = (subtype: string): string | undefined =>
+  SUBTYPE_TO_CDM_CODE_MAP.get(subtype);
+
+export const normalizeClassificationId = (id: string): string =>
+  id.replaceAll(/\s+/g, '');
+
+export const normalizeDescriptionForComparison = (value: string): string => {
+  const normalized = value.normalize('NFKC').trim();
+
+  let start = 0;
+  let end = normalized.length - 1;
+
+  while (start <= end && !isAlphaNumericUnicode(normalized.charAt(start))) {
+    start += 1;
+  }
+
+  while (end >= start && !isAlphaNumericUnicode(normalized.charAt(end))) {
+    end -= 1;
+  }
+
+  return normalized.slice(start, end + 1);
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.lambda.e2e.spec.ts
@@ -17,10 +17,11 @@ describe('RegionalWasteClassificationLambda E2E', () => {
 
   it.each(regionalWasteClassificationTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ events, resultComment, resultStatus }) => {
+    async ({ events, partialDocument, resultComment, resultStatus }) => {
       const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
         .createMassIdDocuments({
           externalEventsMap: events,
+          partialDocument,
         })
         .createMassIdAuditDocuments()
         .build();

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.spec.ts
@@ -18,12 +18,19 @@ describe('RegionalWasteClassificationProcessor', () => {
 
   it.each(regionalWasteClassificationTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ events, resultComment, resultContent, resultStatus }) => {
+    async ({
+      events,
+      partialDocument,
+      resultComment,
+      resultContent,
+      resultStatus,
+    }) => {
       const ruleInput = random<Required<RuleInput>>();
 
       const { massIdDocument } = new BoldStubsBuilder()
         .createMassIdDocuments({
           externalEventsMap: events,
+          partialDocument,
         })
         .build();
 

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -40,12 +40,11 @@ export const RESULT_COMMENTS = {
   CLASSIFICATION_ID_MISSING: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" was not provided.`,
   INVALID_CLASSIFICATION_DESCRIPTION: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" does not match the expected IBAMA code description.`,
   INVALID_CLASSIFICATION_ID: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" does not match an IBAMA code accepted by the methodology.`,
-  INVALID_SUBTYPE_CDM_CODE_MISMATCH: `The subtype does not match the CDM_CODE for the provided Local Waste Classification ID.`,
-  INVALID_SUBTYPE_MAPPING: `The provided subtype does not map to a valid CDM_CODE.`,
+  INVALID_SUBTYPE_CDM_CODE_MISMATCH: `The subtype does not match the CDM code for the provided "${LOCAL_WASTE_CLASSIFICATION_ID}".`,
+  INVALID_SUBTYPE_MAPPING: `The provided subtype does not map to a valid CDM code.`,
   UNSUPPORTED_COUNTRY: (recyclerCountryCode: string) =>
     `Local waste classification is only validated for recyclers in Brazil, but the recycler country is ${recyclerCountryCode}.`,
-  VALID_CLASSIFICATION:
-    'The local waste classification ID and description match an IBAMA code.',
+  VALID_CLASSIFICATION: `The local waste classification "${LOCAL_WASTE_CLASSIFICATION_ID}" and "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" match an IBAMA code.`,
 } as const;
 
 type Subject = {

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -22,8 +22,11 @@ import {
 
 import { WASTE_CLASSIFICATION_CODES } from './regional-waste-classification.constants';
 import { RegionalWasteClassificationProcessorErrors } from './regional-waste-classification.errors';
-
-const isAlphaNumericUnicode = (ch: string): boolean => /\p{L}|\p{N}/u.test(ch);
+import {
+  getCdmCodeFromSubtype,
+  normalizeClassificationId,
+  normalizeDescriptionForComparison,
+} from './regional-waste-classification.helpers';
 
 const {
   LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
@@ -37,6 +40,8 @@ export const RESULT_COMMENTS = {
   CLASSIFICATION_ID_MISSING: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" was not provided.`,
   INVALID_CLASSIFICATION_DESCRIPTION: `The "${LOCAL_WASTE_CLASSIFICATION_DESCRIPTION}" does not match the expected IBAMA code description.`,
   INVALID_CLASSIFICATION_ID: `The "${LOCAL_WASTE_CLASSIFICATION_ID}" does not match an IBAMA code accepted by the methodology.`,
+  INVALID_SUBTYPE_CDM_CODE_MISMATCH: `The subtype does not match the CDM_CODE for the provided Local Waste Classification ID.`,
+  INVALID_SUBTYPE_MAPPING: `The provided subtype does not map to a valid CDM_CODE.`,
   UNSUPPORTED_COUNTRY: (recyclerCountryCode: string) =>
     `Local waste classification is only validated for recyclers in Brazil, but the recycler country is ${recyclerCountryCode}.`,
   VALID_CLASSIFICATION:
@@ -47,6 +52,7 @@ type Subject = {
   description: MethodologyDocumentEventAttributeValue | string | undefined;
   id: MethodologyDocumentEventAttributeValue | string | undefined;
   recyclerCountryCode: string;
+  subtype: string;
 };
 
 export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProcessor<Subject> {
@@ -56,7 +62,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
   protected override evaluateResult(
     subject: Subject,
   ): EvaluateResultOutput | Promise<EvaluateResultOutput> {
-    const { description, id, recyclerCountryCode } = subject;
+    const { description, id, recyclerCountryCode, subtype } = subject;
 
     if (recyclerCountryCode !== 'BR') {
       return this.isFailed(
@@ -79,22 +85,38 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
     const validClassificationIds = Object.keys(WASTE_CLASSIFICATION_CODES.BR);
 
     const normalizedId = validClassificationIds.find(
-      (validId) => validId.replaceAll(/\s+/g, '') === id.replaceAll(/\s+/g, ''),
+      (validId) =>
+        normalizeClassificationId(validId) === normalizeClassificationId(id),
     );
 
     if (!normalizedId) {
       return this.isFailed(RESULT_COMMENTS.INVALID_CLASSIFICATION_ID, subject);
     }
 
-    const expectedDescription =
+    const expectedCdmCode = getCdmCodeFromSubtype(subtype);
+
+    if (!expectedCdmCode) {
+      return this.isFailed(RESULT_COMMENTS.INVALID_SUBTYPE_MAPPING, subject);
+    }
+
+    const classificationEntry =
       WASTE_CLASSIFICATION_CODES.BR[
         normalizedId as keyof typeof WASTE_CLASSIFICATION_CODES.BR
-      ].description;
+      ];
+
+    if (classificationEntry.CDM_CODE !== expectedCdmCode) {
+      return this.isFailed(
+        RESULT_COMMENTS.INVALID_SUBTYPE_CDM_CODE_MISMATCH,
+        subject,
+      );
+    }
+
+    const expectedDescription = classificationEntry.description;
 
     const normalizedProvidedDescription =
-      this.normalizeDescriptionForComparison(description);
+      normalizeDescriptionForComparison(description);
     const normalizedExpectedDescription =
-      this.normalizeDescriptionForComparison(expectedDescription);
+      normalizeDescriptionForComparison(expectedDescription);
 
     if (normalizedProvidedDescription !== normalizedExpectedDescription) {
       return this.isFailed(
@@ -118,6 +140,10 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
       and(eventNameIsAnyOf([ACTOR]), eventLabelIsAnyOf([RECYCLER])),
     );
 
+    if (!document.subtype) {
+      return undefined;
+    }
+
     return {
       description: getEventAttributeValue(
         pickUpEvent,
@@ -125,6 +151,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
       ),
       id: getEventAttributeValue(pickUpEvent, LOCAL_WASTE_CLASSIFICATION_ID),
       recyclerCountryCode: getOrDefault(recyclerEvent?.address.countryCode, ''),
+      subtype: document.subtype,
     };
   }
 
@@ -137,22 +164,5 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
       ...(resultContent && { resultContent }),
       resultStatus: RuleOutputStatus.FAILED,
     };
-  }
-
-  private normalizeDescriptionForComparison(value: string): string {
-    const normalized = value.normalize('NFKC').trim();
-
-    let start = 0;
-    let end = normalized.length - 1;
-
-    while (start <= end && !isAlphaNumericUnicode(normalized.charAt(start))) {
-      start += 1;
-    }
-
-    while (end >= start && !isAlphaNumericUnicode(normalized.charAt(end))) {
-      end -= 1;
-    }
-
-    return normalized.slice(start, end + 1);
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -6,6 +6,7 @@ import {
 import {
   DocumentEventAttributeName,
   DocumentEventName,
+  MassIdOrganicSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
@@ -53,15 +54,19 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
     resultContent: {
       description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
       id: '02 01 01',
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
-      'the local waste classification ID and description match an IBAMA code.',
+      'the local waste classification ID and description match an IBAMA code with matching subtype.',
   },
   {
     events: {
@@ -76,15 +81,19 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
     resultContent: {
       description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
       id: '020101',
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
-      'the local waste classification ID and description match the IBAMA code without spaces.',
+      'the local waste classification ID and description match the IBAMA code without spaces with matching subtype.',
   },
   {
     events: {
@@ -99,15 +108,19 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
     resultContent: {
       description: `***${WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description} - (*)`,
       id: '02 01 01',
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
-      'the local waste classification description has leading/trailing special characters but matches after normalization.',
+      'the local waste classification description has leading/trailing special characters but matches after normalization with matching subtype.',
   },
   {
     events: {
@@ -122,11 +135,15 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.CLASSIFICATION_ID_MISSING,
     resultContent: {
       description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
       id: undefined,
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the local waste classification ID is missing.',
@@ -141,11 +158,15 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.CLASSIFICATION_DESCRIPTION_MISSING,
     resultContent: {
       description: undefined,
       id: '02 01 01',
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the local waste classification description is missing.',
@@ -160,11 +181,15 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.INVALID_CLASSIFICATION_DESCRIPTION,
     resultContent: {
       description: randomDescription,
       id: '02 01 01',
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
@@ -180,11 +205,15 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.UNSUPPORTED_COUNTRY('US'),
     resultContent: {
       description: randomDescription,
       id: '02 01 01',
       recyclerCountryCode: 'US',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the recycler is not from Brazil.',
@@ -199,13 +228,172 @@ export const regionalWasteClassificationTestCases = [
         ],
       }),
     },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+    },
     resultComment: RESULT_COMMENTS.INVALID_CLASSIFICATION_ID,
     resultContent: {
       description: randomDescription,
       id: randomId,
       recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
     },
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the local waste classification ID is not valid.',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultComment: RESULT_COMMENTS.INVALID_SUBTYPE_CDM_CODE_MISMATCH,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+      id: '02 01 01',
+      recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario:
+      'the subtype does not match the CDM_CODE for the provided classification ID.',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 02'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 02'].description,
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 02'].description,
+      id: '02 01 02',
+      recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario:
+      'the subtype matches the CDM_CODE for the provided classification ID.',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 07'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 07'].description,
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
+    },
+    resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 07'].description,
+      id: '02 01 07',
+      recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario:
+      'the subtype matches the CDM_CODE 8.1 for Wood and Wood Products.',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 02 04'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 02 04'].description,
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+    },
+    resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 02 04'].description,
+      id: '02 02 04',
+      recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: 'the subtype matches the CDM_CODE 8.7C for Domestic Sludge.',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: MassIdOrganicSubtype.TOBACCO,
+    },
+    resultComment: RESULT_COMMENTS.INVALID_SUBTYPE_MAPPING,
+    resultContent: {
+      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+      id: '02 01 01',
+      recyclerCountryCode: 'BR',
+      subtype: MassIdOrganicSubtype.TOBACCO,
+    },
+    resultStatus: RuleOutputStatus.FAILED,
+    scenario:
+      'the subtype does not map to a valid CDM_CODE (TOBACCO has no mapping).',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIdPickUpEvent({
+        metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: undefined,
+    },
+    resultComment: 'Rule not applicable',
+    resultContent: undefined,
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: 'the document does not have a subtype (rule not applicable).',
   },
 ];


### PR DESCRIPTION
### 🧾 Summary

Adds subtype CDM_CODE verification to the regional waste classification rule and refactors test cases to reduce code duplication.

### 🧩 Context

The regional waste classification rule needs to verify that the provided subtype matches the CDM_CODE for the given Local Waste Classification ID. This ensures data consistency and prevents mismatched waste classification data. Additionally, the test cases file had significant code duplication that was reduced through helper functions.

### 🧱 Scope of this PR

**Included:**
- Added subtype-to-CDM_CODE mapping verification in the regional waste classification processor
- Extracted helper functions (`getCdmCodeFromSubtype`, `normalizeClassificationId`, `normalizeDescriptionForComparison`) to a new helpers file
- Moved `SUBTYPE_TO_CDM_CODE_MAP` to the constants file
- Updated `EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE` mapping to '8.7A'
- Temporarily removed `TOBACCO` subtype from the mapping
- Refactored test cases to use helper functions, significantly reducing duplication
- Added test cases for missing subtype and invalid subtype mapping scenarios

**Not included:**
- Other waste classification rules
- Additional subtype mappings beyond what's specified

### 🧪 How to test

Run the test suite for the regional waste classification rule:

```bash
pnpm test methodologies-bold-rule-processors-mass-id-regional-waste-classification
```

All 28 tests should pass with 100% code coverage. The tests verify:
- Valid classifications with matching subtypes
- Invalid subtype mappings
- Missing subtype handling
- CDM_CODE mismatches
- Edge cases with normalized IDs and descriptions

### 🧠 Considerations for Review

- **Type Safety**: The code uses TypeScript's `exactOptionalPropertyTypes`, which requires careful handling of `undefined` values in test cases
- **Helper Functions**: Helper functions were extracted to improve code organization and reusability
- **Test Refactoring**: Test cases were significantly refactored to use helper functions, reducing duplication from ~400 lines to a more maintainable structure
- **Subtype Requirement**: The `subtype` field is now required (validated by another rule), so the processor assumes it's always present
- **Map Lookup**: Changed from multiple `if` statements to a `Map` lookup for better performance and maintainability

### 🔗 Related Links

N/A

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for waste subtypes with automated CDM code lookup and stricter validation.
  * Improved normalization of classification IDs and descriptions for reliable comparisons.

* **Bug Fixes**
  * New error states for missing subtype mappings and CDM-code mismatches; clearer validation flow.

* **Tests**
  * Expanded E2E/unit tests to cover subtype scenarios, partial-document injection, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds subtype-based CDM_CODE validation to the regional waste classification rule and refactors utilities/tests for clarity.
> 
> - Validates `document.subtype` via `SUBTYPE_TO_CDM_CODE_MAP` and ensures its CDM code matches the IBAMA entry for the provided `LOCAL_WASTE_CLASSIFICATION_ID` and description; returns specific failures for ID/description mismatch, subtype mismatch, unmapped subtype, and non-BR recycler
> - Extracts helpers (`getCdmCodeFromSubtype`, `normalizeClassificationId`, `normalizeDescriptionForComparison`) and moves subtype map to constants (incl. `EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE` → `8.7A`)
> - Updates processor to use helpers; subject now includes `subtype` and rule is not applicable when absent
> - Expands unit/E2E tests to pass `partialDocument.subtype`, adding cases for CDM_CODE mismatches, unmapped/missing subtype, and normalized IDs/descriptions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4bae3ae850c7cb0c69abddedf514e050efb6ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->