### PR TITLE
refactor(shared): standardize MassID nomenclature across codebase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,12 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": "always"
   },
-  "conventionalCommits.scopes": ["nx", "rule", "shared", "script"],
+  "conventionalCommits.scopes": [
+    "nx",
+    "rule",
+    "shared",
+    "script"
+  ],
   "cSpell.words": [
     "airbnb",
     "commitlint",

--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/mass-id-qualifications/src/lambda.ts
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/mass-id-qualifications/src/lambda.ts
@@ -1,1 +1,1 @@
-export { massIdQualificationsLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-qualifications';
+export { massIDQualificationsLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-qualifications';

--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/mass-id-sorting/src/lambda.ts
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/mass-id-sorting/src/lambda.ts
@@ -1,1 +1,1 @@
-export { massIdSortingLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-sorting';
+export { massIDSortingLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-sorting';

--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/mass-id-qualifications/src/lambda.ts
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/mass-id-qualifications/src/lambda.ts
@@ -1,1 +1,1 @@
-export { massIdQualificationsLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-qualifications';
+export { massIDQualificationsLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-qualifications';

--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/mass-id-sorting/src/lambda.ts
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/mass-id-sorting/src/lambda.ts
@@ -1,1 +1,1 @@
-export { massIdSortingLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-sorting';
+export { massIDSortingLambda as handler } from '@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/mass-id-sorting';

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -7,14 +7,14 @@ import { random } from 'typia';
 
 import type {
   ActorsByType,
-  ResultContentsWithMassIdCertificateValue,
+  ResultContentsWithMassIDCertificateValue,
   RewardsDistributionActor,
 } from './rewards-distribution.types';
 
 import {
   addAmount,
   addParticipantRemainder,
-  aggregateMassIdCertificatesRewards,
+  aggregateMassIDCertificatesRewards,
   calculateAbsoluteValue,
   calculateAmount,
   calculateCreditPercentage,
@@ -66,7 +66,7 @@ describe('Rewards Distribution Helpers', () => {
   describe('calculateAbsoluteValue', () => {
     it('should calculate absolute value correctly', () => {
       const result = calculateAbsoluteValue({
-        massIdCertificateValue: new BigNumber(2000),
+        massIDCertificateValue: new BigNumber(2000),
         percentage: new BigNumber(10),
       });
 
@@ -75,14 +75,14 @@ describe('Rewards Distribution Helpers', () => {
 
     it('should handle zero values correctly', () => {
       const resultZeroPercentage = calculateAbsoluteValue({
-        massIdCertificateValue: new BigNumber(1000),
+        massIDCertificateValue: new BigNumber(1000),
         percentage: new BigNumber(0),
       });
 
       expect(resultZeroPercentage).toBe('0');
 
       const resultZeroCertificateValue = calculateAbsoluteValue({
-        massIdCertificateValue: new BigNumber(0),
+        massIDCertificateValue: new BigNumber(0),
         percentage: new BigNumber(50),
       });
 
@@ -175,8 +175,8 @@ describe('Rewards Distribution Helpers', () => {
     it('should return the correct amount of the participant', () => {
       const amount = calculateAmount({
         creditUnitPrice,
-        massIdCertificateValue: new BigNumber(1500),
-        massIdPercentage: new BigNumber('30.1234567892'),
+        massIDCertificateValue: new BigNumber(1500),
+        massIDPercentage: new BigNumber('30.1234567892'),
         previousParticipantAmount: new BigNumber(0),
       });
 
@@ -186,8 +186,8 @@ describe('Rewards Distribution Helpers', () => {
     it('should return the correct amount of the participant when the same participant already exists', () => {
       const amount = calculateAmount({
         creditUnitPrice,
-        massIdCertificateValue: new BigNumber(1500),
-        massIdPercentage: new BigNumber('30.1234567892'),
+        massIDCertificateValue: new BigNumber(1500),
+        massIDPercentage: new BigNumber('30.1234567892'),
         previousParticipantAmount: new BigNumber('3.223669'),
       });
 
@@ -197,8 +197,8 @@ describe('Rewards Distribution Helpers', () => {
     it('should handle undefined participantAmount', () => {
       const amount = calculateAmount({
         creditUnitPrice,
-        massIdCertificateValue: new BigNumber(100),
-        massIdPercentage: new BigNumber('10'),
+        massIDCertificateValue: new BigNumber(100),
+        massIDPercentage: new BigNumber('10'),
         previousParticipantAmount: new BigNumber(0),
       });
 
@@ -208,7 +208,7 @@ describe('Rewards Distribution Helpers', () => {
 
   describe('calculateRemainder', () => {
     it('should return the correct remainder of the credit', () => {
-      const massIdCertificateTotalValue = new BigNumber(2500);
+      const massIDCertificateTotalValue = new BigNumber(2500);
 
       const actors = new Map(
         Array.from({ length: 3 }).map(() => [
@@ -224,7 +224,7 @@ describe('Rewards Distribution Helpers', () => {
       const { amount, percentage } = calculateRemainder({
         actors,
         creditUnitPrice,
-        massIdCertificateTotalValue,
+        massIDCertificateTotalValue,
       });
 
       expect(amount.toString()).toEqual('13037.488054');
@@ -305,24 +305,24 @@ describe('Rewards Distribution Helpers', () => {
           actorsData[index]?.participant.id,
         );
 
-      const resultContentsWithMassIdCertificateValue: ResultContentsWithMassIdCertificateValue[] =
+      const resultContentsWithMassIDCertificateValue: ResultContentsWithMassIDCertificateValue[] =
         [
           {
-            massIdCertificateValue: new BigNumber(900),
+            massIDCertificateValue: new BigNumber(900),
             resultContent: {
-              massIdDocumentId: faker.string.uuid(),
-              massIdRewards: [
+              massIDDocumentId: faker.string.uuid(),
+              massIDRewards: [
                 {
                   actorType: actorsData[0]!.actorType,
                   address: actorsData[0]!.address,
-                  massIdPercentage: '20.1234567892',
+                  massIDPercentage: '20.1234567892',
                   participant: actorsData[0]!.participant,
                   preserveSensitiveData: actorsData[0]!.preserveSensitiveData,
                 },
                 {
                   actorType: actorsData[1]!.actorType,
                   address: actorsData[1]!.address,
-                  massIdPercentage: '79.8765432108',
+                  massIDPercentage: '79.8765432108',
                   participant: actorsData[1]!.participant,
                   preserveSensitiveData: actorsData[1]!.preserveSensitiveData,
                 },
@@ -330,21 +330,21 @@ describe('Rewards Distribution Helpers', () => {
             },
           },
           {
-            massIdCertificateValue: new BigNumber(900),
+            massIDCertificateValue: new BigNumber(900),
             resultContent: {
-              massIdDocumentId: faker.string.uuid(),
-              massIdRewards: [
+              massIDDocumentId: faker.string.uuid(),
+              massIDRewards: [
                 {
                   actorType: actorsData[2]!.actorType,
                   address: actorsData[2]!.address,
-                  massIdPercentage: '32.1238731924',
+                  massIDPercentage: '32.1238731924',
                   participant: actorsData[2]!.participant,
                   preserveSensitiveData: actorsData[2]!.preserveSensitiveData,
                 },
                 {
                   actorType: actorsData[3]!.actorType,
                   address: actorsData[3]!.address,
-                  massIdPercentage: '67.8761268076',
+                  massIDPercentage: '67.8761268076',
                   participant: actorsData[3]!.participant,
                   preserveSensitiveData: actorsData[3]!.preserveSensitiveData,
                 },
@@ -353,13 +353,13 @@ describe('Rewards Distribution Helpers', () => {
           },
         ];
 
-      const { actors, massIdCertificateTotalValue } =
-        aggregateMassIdCertificatesRewards(
+      const { actors, massIDCertificateTotalValue } =
+        aggregateMassIDCertificatesRewards(
           creditUnitPrice,
-          resultContentsWithMassIdCertificateValue,
+          resultContentsWithMassIDCertificateValue,
         );
 
-      expect(massIdCertificateTotalValue.toString()).toEqual('1800');
+      expect(massIDCertificateTotalValue.toString()).toEqual('1800');
 
       expect(actors.get(getActorKeyByIndex(0))).toMatchObject({
         amount: '947.211111',
@@ -394,24 +394,24 @@ describe('Rewards Distribution Helpers', () => {
       const actorType1 = RewardsDistributionActorType.WASTE_GENERATOR;
       const actorType2 = RewardsDistributionActorType.HAULER;
 
-      const resultContentsWithMassIdCertificateValue: ResultContentsWithMassIdCertificateValue[] =
+      const resultContentsWithMassIDCertificateValue: ResultContentsWithMassIDCertificateValue[] =
         [
           {
-            massIdCertificateValue: new BigNumber(1000),
+            massIDCertificateValue: new BigNumber(1000),
             resultContent: {
-              massIdDocumentId: faker.string.uuid(),
-              massIdRewards: [
+              massIDDocumentId: faker.string.uuid(),
+              massIDRewards: [
                 {
                   actorType: actorType1,
                   address: address1,
-                  massIdPercentage: '40',
+                  massIDPercentage: '40',
                   participant: participant1,
                   preserveSensitiveData: false,
                 },
                 {
                   actorType: actorType2,
                   address: address2,
-                  massIdPercentage: '60',
+                  massIDPercentage: '60',
                   participant: participant2,
                   preserveSensitiveData: false,
                 },
@@ -419,21 +419,21 @@ describe('Rewards Distribution Helpers', () => {
             },
           },
           {
-            massIdCertificateValue: new BigNumber(500),
+            massIDCertificateValue: new BigNumber(500),
             resultContent: {
-              massIdDocumentId: faker.string.uuid(),
-              massIdRewards: [
+              massIDDocumentId: faker.string.uuid(),
+              massIDRewards: [
                 {
                   actorType: actorType1,
                   address: address1,
-                  massIdPercentage: '30',
+                  massIDPercentage: '30',
                   participant: participant1,
                   preserveSensitiveData: false,
                 },
                 {
                   actorType: actorType2,
                   address: address2,
-                  massIdPercentage: '70',
+                  massIDPercentage: '70',
                   participant: participant2,
                   preserveSensitiveData: false,
                 },
@@ -442,10 +442,10 @@ describe('Rewards Distribution Helpers', () => {
           },
         ];
 
-      const { actors, massIdCertificateTotalValue } =
-        aggregateMassIdCertificatesRewards(
+      const { actors, massIDCertificateTotalValue } =
+        aggregateMassIDCertificatesRewards(
           creditUnitPrice,
-          resultContentsWithMassIdCertificateValue,
+          resultContentsWithMassIDCertificateValue,
         );
 
       const expectedAmount1 = formatDecimalPlaces(
@@ -488,7 +488,7 @@ describe('Rewards Distribution Helpers', () => {
         totalAmount: new BigNumber('7845'),
       });
 
-      expect(massIdCertificateTotalValue.toString()).toEqual('1500');
+      expect(massIDCertificateTotalValue.toString()).toEqual('1500');
 
       expect(actors.get(participantType1)?.amount).toEqual(expectedAmount1);
       expect(actors.get(participantType2)?.amount).toEqual(expectedAmount2);

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -6,9 +6,9 @@ import BigNumber from 'bignumber.js';
 
 import type {
   ActorsByType,
-  AggregateMassIdCertificateRewards,
+  AggregateMassIDCertificateRewards,
   Remainder,
-  ResultContentsWithMassIdCertificateValue,
+  ResultContentsWithMassIDCertificateValue,
   RewardsDistribution,
   RuleSubject,
 } from './rewards-distribution.types';
@@ -32,11 +32,11 @@ export const calculateCreditPercentage = ({
   ).toString();
 
 export const calculateAbsoluteValue = (options: {
-  massIdCertificateValue: BigNumber;
+  massIDCertificateValue: BigNumber;
   percentage: BigNumber;
 }): NonEmptyString =>
   formatPercentage(options.percentage)
-    .multipliedBy(options.massIdCertificateValue)
+    .multipliedBy(options.massIDCertificateValue)
     .toString();
 
 export const addAmount = (options: {
@@ -53,14 +53,14 @@ export const addAmount = (options: {
 
 export const calculateAmount = (options: {
   creditUnitPrice: BigNumber;
-  massIdCertificateValue: BigNumber;
-  massIdPercentage: BigNumber;
+  massIDCertificateValue: BigNumber;
+  massIDPercentage: BigNumber;
   previousParticipantAmount: BigNumber;
 }): NonEmptyString => {
   const value = new BigNumber(
     calculateAbsoluteValue({
-      massIdCertificateValue: options.massIdCertificateValue,
-      percentage: options.massIdPercentage,
+      massIDCertificateValue: options.massIDCertificateValue,
+      percentage: options.massIDPercentage,
     }),
   );
 
@@ -74,9 +74,9 @@ export const calculateAmount = (options: {
 export const calculateRemainder = (options: {
   actors: ActorsByType;
   creditUnitPrice: BigNumber;
-  massIdCertificateTotalValue: BigNumber;
+  massIDCertificateTotalValue: BigNumber;
 }): Remainder => {
-  const { actors, creditUnitPrice, massIdCertificateTotalValue } = options;
+  const { actors, creditUnitPrice, massIDCertificateTotalValue } = options;
 
   let participantsAmount = new BigNumber(0);
   let participantsPercentage = new BigNumber(0);
@@ -85,7 +85,7 @@ export const calculateRemainder = (options: {
     participantsAmount = participantsAmount.plus(actor.amount);
     participantsPercentage = participantsPercentage.plus(actor.percentage);
   }
-  const rawAmount = massIdCertificateTotalValue
+  const rawAmount = massIDCertificateTotalValue
     .multipliedBy(creditUnitPrice)
     .minus(participantsAmount);
   const rawPercentage = new BigNumber(100).minus(participantsPercentage);
@@ -129,34 +129,34 @@ export const getAggregateParticipantKey = (
   return `${actorType}-${participantId}`;
 };
 
-export const aggregateMassIdCertificatesRewards = (
+export const aggregateMassIDCertificatesRewards = (
   creditUnitPrice: BigNumber,
-  resultContentsWithMassIdCertificateValue: ResultContentsWithMassIdCertificateValue[],
-): AggregateMassIdCertificateRewards => {
+  resultContentsWithMassIDCertificateValue: ResultContentsWithMassIDCertificateValue[],
+): AggregateMassIDCertificateRewards => {
   const actors: ActorsByType = new Map();
 
-  const massIdCertificateTotalValue = calculateCertificateTotalValue(
-    resultContentsWithMassIdCertificateValue.map(
-      ({ massIdCertificateValue }) => massIdCertificateValue,
+  const massIDCertificateTotalValue = calculateCertificateTotalValue(
+    resultContentsWithMassIDCertificateValue.map(
+      ({ massIDCertificateValue }) => massIDCertificateValue,
     ),
   );
 
   const creditTotal = formatDecimalPlaces(
-    massIdCertificateTotalValue.multipliedBy(creditUnitPrice),
+    massIDCertificateTotalValue.multipliedBy(creditUnitPrice),
   );
 
   for (const {
-    massIdCertificateValue,
-    resultContent: { massIdRewards },
-  } of resultContentsWithMassIdCertificateValue) {
-    for (const massIdReward of massIdRewards) {
+    massIDCertificateValue,
+    resultContent: { massIDRewards },
+  } of resultContentsWithMassIDCertificateValue) {
+    for (const massIDReward of massIDRewards) {
       const {
         actorType,
         address,
-        massIdPercentage,
+        massIDPercentage,
         participant,
         preserveSensitiveData,
-      } = massIdReward;
+      } = massIDReward;
       const participantKey = getAggregateParticipantKey(
         actorType,
         participant.id,
@@ -165,8 +165,8 @@ export const aggregateMassIdCertificatesRewards = (
 
       const amount = calculateAmount({
         creditUnitPrice,
-        massIdCertificateValue,
-        massIdPercentage: new BigNumber(massIdPercentage),
+        massIDCertificateValue,
+        massIDPercentage: new BigNumber(massIDPercentage),
         previousParticipantAmount: actor?.amount
           ? new BigNumber(actor.amount)
           : new BigNumber(0),
@@ -188,7 +188,7 @@ export const aggregateMassIdCertificatesRewards = (
 
   return {
     actors,
-    massIdCertificateTotalValue,
+    massIDCertificateTotalValue,
   };
 };
 
@@ -197,24 +197,24 @@ export const calculateRewardsDistribution = (
 ): RewardsDistribution => {
   const { creditUnitPrice } = ruleSubject;
 
-  const resultContentsWithMassIdCertificateValue =
-    ruleSubject.resultContentsWithMassIdCertificateValue.map(
-      ({ massIdCertificateValue, resultContent }) => ({
-        massIdCertificateValue,
+  const resultContentsWithMassIDCertificateValue =
+    ruleSubject.resultContentsWithMassIDCertificateValue.map(
+      ({ massIDCertificateValue, resultContent }) => ({
+        massIDCertificateValue,
         resultContent,
       }),
     );
 
-  const { actors, massIdCertificateTotalValue } =
-    aggregateMassIdCertificatesRewards(
+  const { actors, massIDCertificateTotalValue } =
+    aggregateMassIDCertificatesRewards(
       creditUnitPrice,
-      resultContentsWithMassIdCertificateValue,
+      resultContentsWithMassIDCertificateValue,
     );
 
   const remainder = calculateRemainder({
     actors,
     creditUnitPrice,
-    massIdCertificateTotalValue,
+    massIDCertificateTotalValue,
   });
 
   addParticipantRemainder({
@@ -225,7 +225,7 @@ export const calculateRewardsDistribution = (
   return {
     actors: [...actors.values()],
     creditUnitPrice: creditUnitPrice.toString(),
-    massIdCertificateTotalValue: massIdCertificateTotalValue.toString(),
+    massIDCertificateTotalValue: massIDCertificateTotalValue.toString(),
     remainder: {
       amount: remainder.amount.toString(),
       percentage: remainder.percentage.toString(),

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.lambda.e2e.spec.ts
@@ -36,10 +36,10 @@ describe('RewardsDistributionProcessor E2E', () => {
       async ({
         creditOrderDocument,
         expectedActorsResult,
-        massIdCertificateDocuments,
+        massIDCertificateDocuments,
       }) => {
         prepareEnvironmentTestE2E(
-          [...massIdCertificateDocuments, creditOrderDocument].map(
+          [...massIDCertificateDocuments, creditOrderDocument].map(
             (document) => ({
               document,
               documentKey: toDocumentKey({
@@ -98,11 +98,11 @@ describe('RewardsDistributionProcessor E2E', () => {
       'should return $resultStatus when $scenario',
       async ({
         creditOrderDocument,
-        massIdCertificateDocuments,
+        massIDCertificateDocuments,
         resultStatus,
       }) => {
         prepareEnvironmentTestE2E(
-          [...massIdCertificateDocuments, creditOrderDocument].map(
+          [...massIDCertificateDocuments, creditOrderDocument].map(
             (document) => ({
               document,
               documentKey: toDocumentKey({

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -36,13 +36,13 @@ describe('RewardsDistributionProcessor', () => {
         creditOrderDocument,
         expectedActorsResult,
         expectedCertificateTotalValue,
-        massIdCertificateDocuments,
+        massIDCertificateDocuments,
         unitPrice,
       }) => {
         spyOnLoadDocument(creditOrderDocument);
         spyOnDocumentQueryServiceLoad(
           creditOrderDocument,
-          massIdCertificateDocuments,
+          massIDCertificateDocuments,
         );
 
         const ruleInput = stubRuleInput({
@@ -54,7 +54,7 @@ describe('RewardsDistributionProcessor', () => {
         const {
           actors,
           creditUnitPrice,
-          massIdCertificateTotalValue,
+          massIDCertificateTotalValue,
           remainder,
         } = ruleOutput.resultContent as RewardsDistribution;
 
@@ -77,7 +77,7 @@ describe('RewardsDistributionProcessor', () => {
           actorsResult.map((actor) => BigNumber(actor.amount)),
         );
         const totalCreditPrice = BigNumber(creditUnitPrice).multipliedBy(
-          massIdCertificateTotalValue,
+          massIDCertificateTotalValue,
         );
 
         expect(
@@ -87,7 +87,7 @@ describe('RewardsDistributionProcessor', () => {
           Math.abs(totalAmount.minus(totalCreditPrice).toNumber()) < 0.000_005,
         ).toBeTruthy();
         expect(creditUnitPrice).toBe(String(unitPrice));
-        expect(massIdCertificateTotalValue).toBe(
+        expect(massIDCertificateTotalValue).toBe(
           String(expectedCertificateTotalValue),
         );
 
@@ -117,7 +117,7 @@ describe('RewardsDistributionProcessor', () => {
       'should return $resultStatus when $scenario',
       async ({
         creditOrderDocument,
-        massIdCertificateDocuments,
+        massIDCertificateDocuments,
         resultComment,
         resultStatus,
       }) => {
@@ -127,7 +127,7 @@ describe('RewardsDistributionProcessor', () => {
 
         spyOnDocumentQueryServiceLoad(
           stubDocument(),
-          massIdCertificateDocuments,
+          massIDCertificateDocuments,
         );
 
         const ruleInput = {

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.ts
@@ -30,7 +30,7 @@ import BigNumber from 'bignumber.js';
 import { is } from 'typia';
 
 import type {
-  ResultContentsWithMassIdCertificateValue,
+  ResultContentsWithMassIDCertificateValue,
   RuleSubject,
 } from './rewards-distribution.types';
 
@@ -98,10 +98,10 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
   }
 
   getRewardsDistributionRuleValue(
-    massIdCertificateDocument: Document,
+    massIDCertificateDocument: Document,
   ): CertificateRewardDistributionOutput {
     const rewardsDistributionRuleEvent =
-      massIdCertificateDocument.externalEvents?.find((event) =>
+      massIDCertificateDocument.externalEvents?.find((event) =>
         eventHasMetadataAttribute({
           event,
           metadataName: DocumentEventAttributeName.SLUG,
@@ -120,7 +120,7 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     ) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.REWARDS_DISTRIBUTION_RULE_RESULT_CONTENT_NOT_FOUND(
-          massIdCertificateDocument.id,
+          massIDCertificateDocument.id,
         ),
       );
     }
@@ -132,15 +132,15 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     const certificateDocumentsQuery =
       await this.generateCertificateDocumentsQuery(ruleInput);
 
-    const resultContentsWithMassIdCertificateValue =
+    const resultContentsWithMassIDCertificateValue =
       await certificateDocumentsQuery?.iterator().map(
-        ({ document }): ResultContentsWithMassIdCertificateValue => ({
-          massIdCertificateValue: new BigNumber(document.currentValue),
+        ({ document }): ResultContentsWithMassIDCertificateValue => ({
+          massIDCertificateValue: new BigNumber(document.currentValue),
           resultContent: this.getRewardsDistributionRuleValue(document),
         }),
       );
 
-    if (!isNonEmptyArray(resultContentsWithMassIdCertificateValue)) {
+    if (!isNonEmptyArray(resultContentsWithMassIDCertificateValue)) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.CERTIFICATE_DOCUMENT_NOT_FOUND(
           this.certificateMatch.match.type,
@@ -150,7 +150,7 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
 
     return {
       creditUnitPrice: new BigNumber(await this.getCreditUnitPrice(ruleInput)),
-      resultContentsWithMassIdCertificateValue,
+      resultContentsWithMassIDCertificateValue,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -19,8 +19,8 @@ import {
   DocumentEventName,
   DocumentSubtype,
   DocumentType,
-  MassIdDocumentActorType,
-  type MassIdReward,
+  MassIDDocumentActorType,
+  type MassIDReward,
   MethodologyDocumentActorType,
   RewardsDistributionActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -42,7 +42,7 @@ type CreditOrderDocument = Document;
 
 type ErrorTestCase = {
   creditOrderDocument: CreditOrderDocument | undefined;
-  massIdCertificateDocuments: CertificateDocument[];
+  massIDCertificateDocuments: CertificateDocument[];
   resultComment: string;
   resultStatus: RuleOutputStatus;
   scenario: string;
@@ -52,7 +52,7 @@ type TestCase = {
   creditOrderDocument: CreditOrderDocument;
   expectedActorsResult: ActorResult[];
   expectedCertificateTotalValue: number;
-  massIdCertificateDocuments: CertificateDocument[];
+  massIDCertificateDocuments: CertificateDocument[];
   resultStatus: RuleOutputStatus;
   scenario: string;
   unitPrice: number;
@@ -106,7 +106,7 @@ const MULTI_HAULER_REWARDS_DISTRIBUTION = {
 };
 
 const generateParticipants = () => {
-  const massIdActorParticipants = new Map(
+  const massIDActorParticipants = new Map(
     MASS_ID_ACTOR_PARTICIPANTS.map((subtype) => [
       subtype,
       stubParticipant({ id: faker.string.uuid(), type: subtype }),
@@ -120,30 +120,30 @@ const generateParticipants = () => {
     ]),
   );
 
-  return { massIdActorParticipants, methodologyActorParticipants };
+  return { massIDActorParticipants, methodologyActorParticipants };
 };
 
-const { massIdActorParticipants, methodologyActorParticipants } =
+const { massIDActorParticipants, methodologyActorParticipants } =
   generateParticipants();
 
 const createStandardRewardsDistribution = (
   documentId: string,
 ): CertificateRewardDistributionOutput => ({
-  massIdDocumentId: documentId,
-  massIdRewards: [
-    ...massIdActorParticipants.entries(),
+  massIDDocumentId: documentId,
+  massIDRewards: [
+    ...massIDActorParticipants.entries(),
     ...methodologyActorParticipants.entries(),
   ].map(([actorType, participant]) => ({
     actorType,
     address: {
       id: faker.string.uuid(),
     },
-    massIdPercentage: STANDARD_REWARDS_DISTRIBUTION[actorType],
+    massIDPercentage: STANDARD_REWARDS_DISTRIBUTION[actorType],
     participant: {
       id: participant.id,
       name: participant.name,
     },
-  })) as unknown as NonEmptyArray<MassIdReward>,
+  })) as unknown as NonEmptyArray<MassIDReward>,
 });
 
 const createMethodologyActorReward = (
@@ -165,7 +165,7 @@ const createMethodologyActorReward = (
     address: {
       id: faker.string.uuid(),
     },
-    massIdPercentage: percentage,
+    massIDPercentage: percentage,
     participant: {
       id,
       name,
@@ -173,16 +173,16 @@ const createMethodologyActorReward = (
   };
 };
 
-const createMassIdActorReward = (
+const createMassIDActorReward = (
   actorType: RewardsDistributionActorType,
   percentage: string,
 ) => {
   const id =
-    massIdActorParticipants.get(actorType as unknown as MassIdDocumentActorType)
+    massIDActorParticipants.get(actorType as unknown as MassIDDocumentActorType)
       ?.id || faker.string.uuid();
 
   const name =
-    massIdActorParticipants.get(actorType as unknown as MassIdDocumentActorType)
+    massIDActorParticipants.get(actorType as unknown as MassIDDocumentActorType)
       ?.name || `${actorType} Participant`;
 
   return {
@@ -190,7 +190,7 @@ const createMassIdActorReward = (
     address: {
       id: faker.string.uuid(),
     },
-    massIdPercentage: percentage,
+    massIDPercentage: percentage,
     participant: {
       id,
       name,
@@ -204,8 +204,8 @@ const createMultiHaulerRewardsDistribution = (
   const haulerParticipants = [
     {
       id:
-        massIdActorParticipants.get(
-          HAULER as unknown as MassIdDocumentActorType,
+        massIDActorParticipants.get(
+          HAULER as unknown as MassIDDocumentActorType,
         )?.id ?? '',
       name: 'Tera',
       percentage: MULTI_HAULER_REWARDS_DISTRIBUTION[HAULER][0],
@@ -228,29 +228,29 @@ const createMultiHaulerRewardsDistribution = (
       address: {
         id: faker.string.uuid(),
       },
-      massIdPercentage: percentage,
+      massIDPercentage: percentage,
       participant: { id, name },
     }));
 
-  const massIdRewards = [
+  const massIDRewards = [
     ...createHaulerRewards(),
-    createMassIdActorReward(
+    createMassIDActorReward(
       WASTE_GENERATOR,
       MULTI_HAULER_REWARDS_DISTRIBUTION[WASTE_GENERATOR],
     ),
-    createMassIdActorReward(
+    createMassIDActorReward(
       PROCESSOR,
       MULTI_HAULER_REWARDS_DISTRIBUTION[PROCESSOR],
     ),
-    createMassIdActorReward(
+    createMassIDActorReward(
       RECYCLER,
       MULTI_HAULER_REWARDS_DISTRIBUTION[RECYCLER],
     ),
-    createMassIdActorReward(
+    createMassIDActorReward(
       INTEGRATOR,
       MULTI_HAULER_REWARDS_DISTRIBUTION[INTEGRATOR],
     ),
-    createMassIdActorReward(
+    createMassIDActorReward(
       COMMUNITY_IMPACT_POOL,
       MULTI_HAULER_REWARDS_DISTRIBUTION[COMMUNITY_IMPACT_POOL],
     ),
@@ -266,33 +266,33 @@ const createMultiHaulerRewardsDistribution = (
       NETWORK,
       MULTI_HAULER_REWARDS_DISTRIBUTION[NETWORK],
     ),
-  ] as unknown as NonEmptyArray<MassIdReward>;
+  ] as unknown as NonEmptyArray<MassIDReward>;
 
   return {
-    massIdDocumentId: documentId,
-    massIdRewards,
+    massIDDocumentId: documentId,
+    massIDRewards,
   };
 };
 
 const buildCertificateDocuments = (options: {
-  massIdDocumentId: string;
+  massIDDocumentId: string;
   rewardsDistribution: CertificateRewardDistributionOutput;
   value: number;
 }) => {
-  const { massIdDocumentId, rewardsDistribution, value } = options;
+  const { massIDDocumentId, rewardsDistribution, value } = options;
 
   return new BoldStubsBuilder({
-    massIdActorParticipants,
-    massIdDocumentIds: [massIdDocumentId],
+    massIDActorParticipants,
+    massIDDocumentIds: [massIDDocumentId],
     methodologyName: BoldMethodologyName.RECYCLING,
   })
-    .createMassIdDocuments({
+    .createMassIDDocuments({
       partialDocument: {
         subtype: FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
     })
-    .createMassIdAuditDocuments()
-    .createMassIdCertificateDocuments({
+    .createMassIDAuditDocuments()
+    .createMassIDCertificateDocuments({
       externalEventsMap: {
         [REWARDS_DISTRIBUTION_RULE_SLUG]:
           stubBoldCertificateRewardsDistributionMetadataEvent({
@@ -317,35 +317,35 @@ const buildCertificateDocuments = (options: {
 };
 
 const createTestDocuments = () => {
-  const massId1Value = 1000;
-  const massId1DocumentId = faker.string.uuid();
+  const massID1Value = 1000;
+  const massID1DocumentId = faker.string.uuid();
 
   const standardDocuments = buildCertificateDocuments({
-    massIdDocumentId: massId1DocumentId,
-    rewardsDistribution: createStandardRewardsDistribution(massId1DocumentId),
-    value: massId1Value,
+    massIDDocumentId: massID1DocumentId,
+    rewardsDistribution: createStandardRewardsDistribution(massID1DocumentId),
+    value: massID1Value,
   });
 
   const multiHaulerDocuments = buildCertificateDocuments({
-    massIdDocumentId: massId1DocumentId,
+    massIDDocumentId: massID1DocumentId,
     rewardsDistribution:
-      createMultiHaulerRewardsDistribution(massId1DocumentId),
-    value: massId1Value,
+      createMultiHaulerRewardsDistribution(massID1DocumentId),
+    value: massID1Value,
   });
 
-  const massId2Value = 500;
-  const massId2DocumentId = faker.string.uuid();
+  const massID2Value = 500;
+  const massID2DocumentId = faker.string.uuid();
   const secondDocuments = buildCertificateDocuments({
-    massIdDocumentId: massId2DocumentId,
-    rewardsDistribution: createStandardRewardsDistribution(massId2DocumentId),
-    value: massId2Value,
+    massIDDocumentId: massID2DocumentId,
+    rewardsDistribution: createStandardRewardsDistribution(massID2DocumentId),
+    value: massID2Value,
   });
 
-  const combinedValue = massId1Value + massId2Value;
+  const combinedValue = massID1Value + massID2Value;
 
   const multipleCertificateDocuments = [
-    ...standardDocuments.massIdCertificateDocuments,
-    ...secondDocuments.massIdCertificateDocuments,
+    ...standardDocuments.massIDCertificateDocuments,
+    ...secondDocuments.massIDCertificateDocuments,
   ];
 
   const multipleCertificatesCreditOrderDocument = {
@@ -355,19 +355,19 @@ const createTestDocuments = () => {
       stubDocumentEvent({
         name: RELATED,
         relatedDocument: mapDocumentRelation(
-          secondDocuments.massIdCertificateDocuments[0]!,
+          secondDocuments.massIDCertificateDocuments[0]!,
         ),
       }),
     ],
   };
 
   return {
-    massId1Value,
-    massId2Value,
+    massID1Value,
+    massID2Value,
     multiHauler: multiHaulerDocuments,
     multipleCertificates: {
       creditOrderDocument: multipleCertificatesCreditOrderDocument,
-      massIdCertificateDocuments: multipleCertificateDocuments,
+      massIDCertificateDocuments: multipleCertificateDocuments,
       totalValue: combinedValue,
     },
     secondDocument: secondDocuments,
@@ -552,8 +552,8 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
   {
     creditOrderDocument: documents.standard.creditOrderDocument,
     expectedActorsResult: expectedResults.singleCertificateStandard,
-    expectedCertificateTotalValue: documents.massId1Value,
-    massIdCertificateDocuments: documents.standard.massIdCertificateDocuments,
+    expectedCertificateTotalValue: documents.massID1Value,
+    massIDCertificateDocuments: documents.standard.massIDCertificateDocuments,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'single certificate with equal distribution',
     unitPrice: UNIT_PRICE_VALUE,
@@ -561,9 +561,9 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
   {
     creditOrderDocument: documents.multiHauler.creditOrderDocument,
     expectedActorsResult: expectedResults.multipleHaulers,
-    expectedCertificateTotalValue: documents.massId1Value,
-    massIdCertificateDocuments:
-      documents.multiHauler.massIdCertificateDocuments,
+    expectedCertificateTotalValue: documents.massID1Value,
+    massIDCertificateDocuments:
+      documents.multiHauler.massIDCertificateDocuments,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'single certificate with multiple HAULER participants',
     unitPrice: UNIT_PRICE_VALUE,
@@ -572,8 +572,8 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     creditOrderDocument: documents.multipleCertificates.creditOrderDocument,
     expectedActorsResult: expectedResults.multipleCertificates,
     expectedCertificateTotalValue: documents.multipleCertificates.totalValue,
-    massIdCertificateDocuments:
-      documents.multipleCertificates.massIdCertificateDocuments,
+    massIDCertificateDocuments:
+      documents.multipleCertificates.massIDCertificateDocuments,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'multiple certificates with the same participants',
     unitPrice: UNIT_PRICE_VALUE,
@@ -582,9 +582,9 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
 
 const createErrorTestCases = () => {
   const errorStubs = new BoldStubsBuilder()
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
-    .createMassIdCertificateDocuments({
+    .createMassIDDocuments()
+    .createMassIDAuditDocuments()
+    .createMassIDCertificateDocuments({
       partialDocument: {
         type: RECYCLED_ID,
       },
@@ -600,9 +600,9 @@ const createErrorTestCases = () => {
   };
 
   const certificateDocumentWithoutRuleEvent = {
-    ...errorStubs.massIdCertificateDocuments[0]!,
+    ...errorStubs.massIDCertificateDocuments[0]!,
     externalEvents:
-      errorStubs.massIdCertificateDocuments[0]!.externalEvents?.filter(
+      errorStubs.massIDCertificateDocuments[0]!.externalEvents?.filter(
         (event) => event.name !== REWARDS_DISTRIBUTION_RULE_SLUG,
       ),
   };
@@ -621,15 +621,15 @@ const errorTestData = createErrorTestCases();
 export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
   {
     creditOrderDocument: errorTestData.errorStubs.creditOrderDocument,
-    massIdCertificateDocuments: [],
+    massIDCertificateDocuments: [],
     resultComment: ERROR_MESSAGES.CERTIFICATE_DOCUMENT_NOT_FOUND(RECYCLED_ID),
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the ${RECYCLED_ID} documents is not found`,
   },
   {
     creditOrderDocument: undefined,
-    massIdCertificateDocuments: [
-      ...errorTestData.errorStubs.massIdCertificateDocuments,
+    massIDCertificateDocuments: [
+      ...errorTestData.errorStubs.massIDCertificateDocuments,
     ],
     resultComment: ERROR_MESSAGES.CREDIT_ORDER_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
@@ -637,8 +637,8 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
   },
   {
     creditOrderDocument: errorTestData.creditOrderDocumentWithoutRulesMetadata,
-    massIdCertificateDocuments: [
-      ...errorTestData.errorStubs.massIdCertificateDocuments,
+    massIDCertificateDocuments: [
+      ...errorTestData.errorStubs.massIDCertificateDocuments,
     ],
     resultComment: ERROR_MESSAGES.INVALID_CREDIT_UNIT_PRICE,
     resultStatus: RuleOutputStatus.FAILED,
@@ -646,12 +646,12 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
   },
   {
     creditOrderDocument: errorTestData.errorStubs.creditOrderDocument,
-    massIdCertificateDocuments: [
+    massIDCertificateDocuments: [
       errorTestData.certificateDocumentWithoutRulesMetadata,
     ],
     resultComment:
       ERROR_MESSAGES.REWARDS_DISTRIBUTION_RULE_RESULT_CONTENT_NOT_FOUND(
-        errorTestData.errorStubs.massIdCertificateDocuments[0]!.id,
+        errorTestData.errorStubs.massIDCertificateDocuments[0]!.id,
       ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `a certificate document has no "${RULE_RESULT_DETAILS}" attribute`,

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.types.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.types.ts
@@ -11,9 +11,9 @@ import type BigNumber from 'bignumber.js';
 
 export type ActorsByType = Map<string, RewardsDistributionActor>;
 
-export interface AggregateMassIdCertificateRewards {
+export interface AggregateMassIDCertificateRewards {
   actors: ActorsByType;
-  massIdCertificateTotalValue: BigNumber;
+  massIDCertificateTotalValue: BigNumber;
 }
 
 export interface Participant {
@@ -26,15 +26,15 @@ export interface Remainder<T = BigNumber> {
   percentage: T;
 }
 
-export interface ResultContentsWithMassIdCertificateValue {
-  massIdCertificateValue: BigNumber;
+export interface ResultContentsWithMassIDCertificateValue {
+  massIDCertificateValue: BigNumber;
   resultContent: CertificateRewardDistributionOutput;
 }
 
 export interface RewardsDistribution {
   actors: RewardsDistributionActor[];
   creditUnitPrice: NonEmptyString;
-  massIdCertificateTotalValue: NonEmptyString;
+  massIDCertificateTotalValue: NonEmptyString;
   remainder: Remainder<string>;
 }
 
@@ -49,5 +49,5 @@ export interface RewardsDistributionActor {
 
 export interface RuleSubject {
   creditUnitPrice: BigNumber;
-  resultContentsWithMassIdCertificateValue: ResultContentsWithMassIdCertificateValue[];
+  resultContentsWithMassIDCertificateValue: ResultContentsWithMassIDCertificateValue[];
 }

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
@@ -5,7 +5,7 @@ import {
   METHODOLOGY_DEFINITION,
 } from '@carrot-fndn/shared/methodologies/bold/matchers';
 import {
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   RewardsDistributionActorType,
   RewardsDistributionWasteType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -74,22 +74,22 @@ export const REWARDS_DISTRIBUTION: RewardsDistribution = {
 };
 
 export const REWARDS_DISTRIBUTION_BY_WASTE_TYPE: Record<
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   RewardsDistributionWasteType
 > = {
-  [MassIdOrganicSubtype.DOMESTIC_SLUDGE]:
+  [MassIDOrganicSubtype.DOMESTIC_SLUDGE]:
     RewardsDistributionWasteType.SLUDGE_FROM_WASTE_TREATMENT,
-  [MassIdOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE]:
+  [MassIDOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE]:
     RewardsDistributionWasteType.MIXED_ORGANIC_WASTE,
-  [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+  [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
     RewardsDistributionWasteType.MIXED_ORGANIC_WASTE,
-  [MassIdOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE]:
+  [MassIDOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE]:
     RewardsDistributionWasteType.MIXED_ORGANIC_WASTE,
-  [MassIdOrganicSubtype.INDUSTRIAL_SLUDGE]:
+  [MassIDOrganicSubtype.INDUSTRIAL_SLUDGE]:
     RewardsDistributionWasteType.SLUDGE_FROM_WASTE_TREATMENT,
-  [MassIdOrganicSubtype.TOBACCO]:
+  [MassIDOrganicSubtype.TOBACCO]:
     RewardsDistributionWasteType.TOBACCO_INDUSTRY_RESIDUES,
-  [MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS]:
+  [MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS]:
     RewardsDistributionWasteType.MIXED_ORGANIC_WASTE,
 };
 

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -23,8 +23,8 @@ describe('shouldApplyLargeBusinessDiscount', () => {
 
   it('should return true when document exists but has no ONBOARDING_DECLARATION event', () => {
     const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
+      .createMassIDDocuments()
+      .createMassIDAuditDocuments()
       .createMethodologyDocument()
       .createParticipantAccreditationDocuments(
         new Map([[WASTE_GENERATOR, { externalEventsMap: {} }]]),
@@ -37,8 +37,8 @@ describe('shouldApplyLargeBusinessDiscount', () => {
 
   it('should return true when document has ONBOARDING_DECLARATION event with Large Business', () => {
     const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
+      .createMassIDDocuments()
+      .createMassIDAuditDocuments()
       .createMethodologyDocument()
       .createParticipantAccreditationDocuments(
         new Map([
@@ -66,8 +66,8 @@ describe('shouldApplyLargeBusinessDiscount', () => {
 
   it('should return false when document has ONBOARDING_DECLARATION event with Small Business', () => {
     const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
+      .createMassIDDocuments()
+      .createMassIDAuditDocuments()
       .createMethodologyDocument()
       .createParticipantAccreditationDocuments(
         new Map([
@@ -95,8 +95,8 @@ describe('shouldApplyLargeBusinessDiscount', () => {
 
   it('should return true when document has ONBOARDING_DECLARATION event but BUSINESS_SIZE_DECLARATION is missing', () => {
     const document = new BoldStubsBuilder()
-      .createMassIdDocuments()
-      .createMassIdAuditDocuments()
+      .createMassIDDocuments()
+      .createMassIDAuditDocuments()
       .createMethodologyDocument()
       .createParticipantAccreditationDocuments(
         new Map([

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -15,7 +15,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventAttributeValue,
   DocumentEventName,
-  type MassIdReward,
+  type MassIDReward,
   RewardActorAddress,
   type RewardActorParticipant,
   RewardsDistributionActorType,
@@ -46,18 +46,18 @@ export const isHaulerActorDefined = (
 export const formatPercentage = (percentage: BigNumber): string =>
   percentage.multipliedBy(100).toString();
 
-export const mapMassIdRewards = (participants: ActorReward[]): MassIdReward[] =>
+export const mapMassIDRewards = (participants: ActorReward[]): MassIDReward[] =>
   participants.map(
     ({
       actorType,
       address,
-      massIdPercentage,
+      massIDPercentage,
       participant,
       preserveSensitiveData,
     }) => ({
       actorType,
       address,
-      massIdPercentage: formatPercentage(massIdPercentage),
+      massIDPercentage: formatPercentage(massIDPercentage),
       participant,
       preserveSensitiveData,
     }),
@@ -66,22 +66,22 @@ export const mapMassIdRewards = (participants: ActorReward[]): MassIdReward[] =>
 export const mapActorReward = ({
   actorType,
   address,
-  massIdDocument,
-  massIdPercentage,
+  massIDDocument,
+  massIDPercentage,
   participant,
   preserveSensitiveData,
 }: {
   actorType: RewardsDistributionActorType;
   address: RewardActorAddress;
-  massIdDocument: Document;
-  massIdPercentage: BigNumber;
+  massIDDocument: Document;
+  massIDPercentage: BigNumber;
   participant: RewardActorParticipant;
   preserveSensitiveData: boolean | undefined;
 }): ActorReward => ({
   actorType,
   address,
-  massIdDocument,
-  massIdPercentage,
+  massIDDocument,
+  massIDPercentage,
   participant,
   preserveSensitiveData,
 });
@@ -216,21 +216,21 @@ export const getWasteGeneratorAdditionalPercentage = (
   return new BigNumber(0);
 };
 
-export const getNgoActorMassIdPercentage = (
-  massIdDocument: Document,
-  actorMassIdPercentage: BigNumber,
+export const getNgoActorMassIDPercentage = (
+  massIDDocument: Document,
+  actorMassIDPercentage: BigNumber,
   actors: RewardsDistributionActor[],
   rewardDistributions: RewardsDistributionActorTypePercentage,
   getWasteGeneratorFullPercentage: (
     targetDocument: Document,
-    targetActorMassIdPercentage: BigNumber,
+    targetActorMassIDPercentage: BigNumber,
     targetActors: RewardsDistributionActor[],
     targetRewardDistributions: RewardsDistributionActorTypePercentage,
   ) => BigNumber,
 ): BigNumber =>
   getWasteGeneratorFullPercentage(
-    massIdDocument,
-    actorMassIdPercentage,
+    massIDDocument,
+    actorMassIDPercentage,
     actors,
     rewardDistributions,
   ).multipliedBy(LARGE_REVENUE_BUSINESS_DISCOUNT);

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.lambda.e2e.spec.ts
@@ -26,27 +26,27 @@ describe('RewardsDistributionProcessor E2E', () => {
 
   it.each(rewardsDistributionProcessorTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ massIdDocumentEvents, massIdPartialDocument, resultStatus }) => {
+    async ({ massIDDocumentEvents, massIDPartialDocument, resultStatus }) => {
       const {
-        massIdAuditDocument,
-        massIdCertificateDocument,
-        massIdDocument,
+        massIDAuditDocument,
+        massIDCertificateDocument,
+        massIDDocument,
         methodologyDocument,
       } = new BoldStubsBuilder()
-        .createMassIdDocuments({
-          externalEventsMap: massIdDocumentEvents,
-          partialDocument: massIdPartialDocument,
+        .createMassIDDocuments({
+          externalEventsMap: massIDDocumentEvents,
+          partialDocument: massIDPartialDocument,
         })
-        .createMassIdAuditDocuments()
-        .createMassIdCertificateDocuments()
+        .createMassIDAuditDocuments()
+        .createMassIDCertificateDocuments()
         .createMethodologyDocument()
         .build();
 
       prepareEnvironmentTestE2E(
         [
-          massIdDocument,
-          massIdAuditDocument,
-          massIdCertificateDocument,
+          massIDDocument,
+          massIDAuditDocument,
+          massIDCertificateDocument,
           methodologyDocument as Document,
         ].map((document) => ({
           document,
@@ -59,7 +59,7 @@ describe('RewardsDistributionProcessor E2E', () => {
 
       const response = (await rewardsDistributionLambda(
         stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),
@@ -75,9 +75,9 @@ describe('RewardsDistributionProcessor E2E', () => {
   describe('RewardsDistributionProcessorErrors', () => {
     it.each(rewardsDistributionProcessorErrors)(
       'should return $resultStatus when $scenario',
-      async ({ documents, massIdAuditDocument, resultStatus }) => {
+      async ({ documents, massIDAuditDocument, resultStatus }) => {
         prepareEnvironmentTestE2E(
-          [...documents, massIdAuditDocument].map((document) => ({
+          [...documents, massIDAuditDocument].map((document) => ({
             document,
             documentKey: toDocumentKey({
               documentId: document.id,
@@ -88,7 +88,7 @@ describe('RewardsDistributionProcessor E2E', () => {
 
         const response = (await rewardsDistributionLambda(
           stubRuleInput({
-            documentId: massIdAuditDocument.id,
+            documentId: massIDAuditDocument.id,
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -30,63 +30,63 @@ describe('RewardsDistributionProcessor', () => {
       'should return $resultStatus when $scenario',
       async ({
         expectedRewards,
-        massIdDocumentEvents,
-        massIdPartialDocument,
+        massIDDocumentEvents,
+        massIDPartialDocument,
       }) => {
         const {
-          massIdAuditDocument,
-          massIdCertificateDocument,
-          massIdDocument,
+          massIDAuditDocument,
+          massIDCertificateDocument,
+          massIDDocument,
           methodologyDocument,
         } = new BoldStubsBuilder({
           methodologyName: BoldMethodologyName.RECYCLING,
         })
-          .createMassIdDocuments({
-            externalEventsMap: massIdDocumentEvents,
-            partialDocument: massIdPartialDocument,
+          .createMassIDDocuments({
+            externalEventsMap: massIDDocumentEvents,
+            partialDocument: massIDPartialDocument,
           })
-          .createMassIdAuditDocuments()
-          .createMassIdCertificateDocuments()
+          .createMassIDAuditDocuments()
+          .createMassIDCertificateDocuments()
           .createMethodologyDocument()
           .build();
 
         const allDocuments = [
-          massIdAuditDocument,
-          massIdDocument,
-          massIdCertificateDocument,
+          massIDAuditDocument,
+          massIDDocument,
+          massIDCertificateDocument,
           methodologyDocument as Document,
         ];
 
-        spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+        spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
         const ruleInput = stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
         });
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
-        const { massIdRewards } =
+        const { massIDRewards } =
           ruleOutput.resultContent as RewardDistributionResultContent;
 
         const totalPercentage = sumBigNumbers(
-          massIdRewards.map(
-            ({ massIdPercentage }) => new BigNumber(massIdPercentage),
+          massIDRewards.map(
+            ({ massIDPercentage }) => new BigNumber(massIDPercentage),
           ),
         );
 
         expect(ruleOutput.resultContent).toMatchObject({
-          massIdDocumentId: massIdDocument.id,
+          massIDDocumentId: massIDDocument.id,
         });
 
         for (const actorType of Object.keys(expectedRewards)) {
-          const reward = massIdRewards.find(
-            (massIdReward) =>
-              massIdReward.actorType ===
+          const reward = massIDRewards.find(
+            (massIDReward) =>
+              massIDReward.actorType ===
               (actorType as RewardsDistributionActorType),
           );
 
           expect(reward).toBeDefined();
-          expect(reward?.massIdPercentage).toBe(expectedRewards[actorType]);
+          expect(reward?.massIDPercentage).toBe(expectedRewards[actorType]);
         }
 
         expect(totalPercentage.eq(BigNumber(100))).toBeTruthy();
@@ -99,17 +99,17 @@ describe('RewardsDistributionProcessor', () => {
       'should return $resultStatus when $scenario',
       async ({
         documents,
-        massIdAuditDocument,
+        massIDAuditDocument,
         resultComment,
         resultStatus,
       }) => {
-        const allDocuments = [massIdAuditDocument, ...documents];
+        const allDocuments = [massIDAuditDocument, ...documents];
 
-        spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+        spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
         const ruleInput = {
           ...random<Required<RuleInput>>(),
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
         };
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.ts
@@ -12,7 +12,7 @@ import {
 import { isActorEvent } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import {
   type Document,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   RewardsDistributionActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
@@ -37,14 +37,14 @@ import {
   calculatePercentageForUnidentifiedWasteOrigin,
   checkIfHasRequiredActorTypes,
   getActorsByType,
-  getNgoActorMassIdPercentage,
+  getNgoActorMassIDPercentage,
   getWasteGeneratorAdditionalPercentage,
   isWasteOriginIdentified,
   mapActorReward,
-  mapMassIdRewards,
+  mapMassIDRewards,
 } from './rewards-distribution.helpers';
 import {
-  type ActorMassIdPercentageInputDto,
+  type ActorMassIDPercentageInputDto,
   type ActorReward,
   type RewardsDistributionActor,
   type RewardsDistributionActorTypePercentage,
@@ -56,17 +56,17 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
   readonly errorProcessor = new RewardsDistributionProcessorErrors();
 
   async getRuleDocuments(documentQuery: DocumentQuery<Document>): Promise<{
-    massIdDocument: Document | undefined;
+    massIDDocument: Document | undefined;
     methodologyDocument: Document | undefined;
   }> {
-    let massIdDocument: Document | undefined;
+    let massIDDocument: Document | undefined;
     let methodologyDocument: Document | undefined;
 
     await documentQuery.iterator().each(({ document }) => {
       const documentRelation = mapDocumentRelation(document);
 
       if (MASS_ID.matches(documentRelation)) {
-        massIdDocument = document;
+        massIDDocument = document;
       }
 
       if (METHODOLOGY_DEFINITION.matches(documentRelation)) {
@@ -75,7 +75,7 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     });
 
     return {
-      massIdDocument,
+      massIDDocument,
       methodologyDocument,
     };
   }
@@ -92,10 +92,10 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
         documentId: String(ruleInput.documentId),
       });
 
-      const { massIdDocument, methodologyDocument } =
+      const { massIDDocument, methodologyDocument } =
         await this.getRuleDocuments(documentLoader);
 
-      if (isNil(massIdDocument)) {
+      if (isNil(massIDDocument)) {
         throw this.errorProcessor.getKnownError(
           this.errorProcessor.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
         );
@@ -108,14 +108,14 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
       }
 
       const actorRewards = this.getActorRewards({
-        massIdDocument,
+        massIDDocument,
         methodologyDocument,
       });
 
       return mapToRuleOutput(ruleInput, RuleOutputStatus.PASSED, {
         resultContent: {
-          massIdDocumentId: massIdDocument.id,
-          massIdRewards: mapMassIdRewards(actorRewards),
+          massIDDocumentId: massIDDocument.id,
+          massIDRewards: mapMassIDRewards(actorRewards),
         },
       });
     } catch (error: unknown) {
@@ -125,8 +125,8 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     }
   }
 
-  private extractMassIdSubtype(document: Document): MassIdOrganicSubtype {
-    if (!is<MassIdOrganicSubtype>(document.subtype)) {
+  private extractMassIDSubtype(document: Document): MassIDOrganicSubtype {
+    if (!is<MassIDOrganicSubtype>(document.subtype)) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.UNEXPECTED_DOCUMENT_SUBTYPE(
           String(document.subtype),
@@ -137,20 +137,20 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     return document.subtype;
   }
 
-  private getActorMassIdPercentage(
-    dto: ActorMassIdPercentageInputDto,
+  private getActorMassIDPercentage(
+    dto: ActorMassIDPercentageInputDto,
   ): BigNumber {
-    const { actors, actorType, massIdDocument, rewardDistribution } = dto;
+    const { actors, actorType, massIDDocument, rewardDistribution } = dto;
 
-    let actorMassIdPercentage = rewardDistribution;
+    let actorMassIDPercentage = rewardDistribution;
     const rewardDistributions =
-      this.getRewardsDistributionActorTypePercentages(massIdDocument);
+      this.getRewardsDistributionActorTypePercentages(massIDDocument);
     const wasteGeneratorRewardDistribution =
       rewardDistributions['Waste Generator'];
 
     if (actorType === RewardsDistributionActorType.WASTE_GENERATOR) {
-      actorMassIdPercentage = this.getWasteGeneratorActorMassIdPercentage(
-        massIdDocument,
+      actorMassIDPercentage = this.getWasteGeneratorActorMassIDPercentage(
+        massIDDocument,
         wasteGeneratorRewardDistribution,
         actors,
         rewardDistributions,
@@ -158,47 +158,47 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     }
 
     if (actorType === RewardsDistributionActorType.COMMUNITY_IMPACT_POOL) {
-      const sourcePercentage = getNgoActorMassIdPercentage(
-        massIdDocument,
+      const sourcePercentage = getNgoActorMassIDPercentage(
+        massIDDocument,
         wasteGeneratorRewardDistribution,
         actors,
         rewardDistributions,
-        this.getWasteGeneratorActorMassIdFullPercentage.bind(this),
+        this.getWasteGeneratorActorMassIDFullPercentage.bind(this),
       );
 
-      actorMassIdPercentage = actorMassIdPercentage.plus(sourcePercentage);
+      actorMassIDPercentage = actorMassIDPercentage.plus(sourcePercentage);
     }
 
-    if (!isWasteOriginIdentified(massIdDocument)) {
+    if (!isWasteOriginIdentified(massIDDocument)) {
       const additionalPercentage = getWasteGeneratorAdditionalPercentage(
         actors,
         rewardDistributions,
       );
 
-      actorMassIdPercentage = calculatePercentageForUnidentifiedWasteOrigin({
+      actorMassIDPercentage = calculatePercentageForUnidentifiedWasteOrigin({
         actors,
         actorType,
         additionalPercentage,
-        basePercentage: actorMassIdPercentage,
+        basePercentage: actorMassIDPercentage,
         rewardDistributions,
         wasteGeneratorPercentage: wasteGeneratorRewardDistribution,
       });
     }
 
-    return actorMassIdPercentage;
+    return actorMassIDPercentage;
   }
 
   private getActorRewards({
-    massIdDocument,
+    massIDDocument,
     methodologyDocument,
   }: {
-    massIdDocument: Document;
+    massIDDocument: Document;
     methodologyDocument: Document;
   }): ActorReward[] {
     const result: ActorReward[] = [];
-    const actors = this.getRewardsDistributionActors(massIdDocument);
+    const actors = this.getRewardsDistributionActors(massIDDocument);
     const distributions =
-      this.getRewardsDistributionActorTypePercentages(massIdDocument);
+      this.getRewardsDistributionActorTypePercentages(massIDDocument);
 
     for (const [actorType, rewardDistribution] of Object.entries(
       distributions,
@@ -214,10 +214,10 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
         });
 
         if (isNonEmptyArray(actorsByType)) {
-          const massIdPercentage = this.getActorMassIdPercentage({
+          const massIDPercentage = this.getActorMassIDPercentage({
             actors,
             actorType,
-            massIdDocument,
+            massIDDocument,
             rewardDistribution,
           }).div(actorsByType.length);
 
@@ -227,8 +227,8 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
                 mapActorReward({
                   actorType: type,
                   address,
-                  massIdDocument,
-                  massIdPercentage,
+                  massIDDocument,
+                  massIDPercentage,
                   participant,
                   preserveSensitiveData,
                 }),
@@ -300,20 +300,20 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
   private getRewardsDistributionActorTypePercentages(
     document: Document,
   ): RewardsDistributionActorTypePercentage {
-    const documentSubtype = this.extractMassIdSubtype(document);
+    const documentSubtype = this.extractMassIDSubtype(document);
     const wasteType = REWARDS_DISTRIBUTION_BY_WASTE_TYPE[documentSubtype];
 
     return REWARDS_DISTRIBUTION[wasteType];
   }
 
-  private getWasteGeneratorActorMassIdFullPercentage(
+  private getWasteGeneratorActorMassIDFullPercentage(
     document: Document,
-    actorMassIdPercentage: BigNumber,
+    actorMassIDPercentage: BigNumber,
     actors: RewardsDistributionActor[],
     rewardDistributions: RewardsDistributionActorTypePercentage,
   ): BigNumber {
     if (isWasteOriginIdentified(document)) {
-      return actorMassIdPercentage.plus(
+      return actorMassIDPercentage.plus(
         getWasteGeneratorAdditionalPercentage(actors, rewardDistributions),
       );
     }
@@ -321,15 +321,15 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
     return new BigNumber(0);
   }
 
-  private getWasteGeneratorActorMassIdPercentage(
+  private getWasteGeneratorActorMassIDPercentage(
     document: Document,
-    actorMassIdPercentage: BigNumber,
+    actorMassIDPercentage: BigNumber,
     actors: RewardsDistributionActor[],
     rewardDistributions: RewardsDistributionActorTypePercentage,
   ): BigNumber {
-    const fullPercentage = this.getWasteGeneratorActorMassIdFullPercentage(
+    const fullPercentage = this.getWasteGeneratorActorMassIDFullPercentage(
       document,
-      actorMassIdPercentage,
+      actorMassIDPercentage,
       actors,
       rewardDistributions,
     );

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -3,7 +3,7 @@ import type { PartialDeep } from 'type-fest';
 import {
   type BoldExternalEventsObject,
   BoldStubsBuilder,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type Document,
@@ -11,7 +11,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventAttributeValue,
   DocumentEventName,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   RewardsDistributionActorType,
   RewardsDistributionWasteType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -90,8 +90,8 @@ const EXPECTED_REWARDS = {
 
 export const rewardsDistributionProcessorTestCases: Array<{
   expectedRewards: Record<string, string>;
-  massIdDocumentEvents?: BoldExternalEventsObject | undefined;
-  massIdPartialDocument: PartialDeep<Document>;
+  massIDDocumentEvents?: BoldExternalEventsObject | undefined;
+  massIDPartialDocument: PartialDeep<Document>;
   resultStatus: RuleOutputStatus;
   scenario: string;
 }> = [
@@ -99,8 +99,8 @@ export const rewardsDistributionProcessorTestCases: Array<{
     ([wasteType, expectedRewards]) => ({
       // eslint-disable-next-line security/detect-object-injection
       expectedRewards: EXPECTED_REWARDS[expectedRewards],
-      massIdDocumentEvents: {},
-      massIdPartialDocument: {
+      massIDDocumentEvents: {},
+      massIDPartialDocument: {
         subtype: wasteType,
       },
       resultStatus: RuleOutputStatus.PASSED,
@@ -109,62 +109,62 @@ export const rewardsDistributionProcessorTestCases: Array<{
   ),
   {
     expectedRewards: EXPECTED_REWARDS.WITHOUT_WASTE_GENERATOR.WITHOUT_HAULER,
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [`ACTOR-${HAULER}`]: undefined,
       [`ACTOR-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
       }),
     },
-    massIdPartialDocument: {
-      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    massIDPartialDocument: {
+      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is not present`,
   },
   {
     expectedRewards: EXPECTED_REWARDS.WITHOUT_WASTE_GENERATOR.WITH_HAULER,
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [`ACTOR-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
       }),
     },
-    massIdPartialDocument: {
-      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    massIDPartialDocument: {
+      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is present`,
   },
   {
     expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
-    massIdDocumentEvents: {},
-    massIdPartialDocument: {
-      subtype: MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    massIDDocumentEvents: {},
+    massIDPartialDocument: {
+      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
     },
     resultStatus: RuleOutputStatus.PASSED,
     scenario: `all rewards are applied for the ${REWARDS_DISTRIBUTION_BY_WASTE_TYPE['Food, Food Waste and Beverages']}`,
   },
 ];
 
-const { massIdAuditDocument, massIdDocument, methodologyDocument } =
+const { massIDAuditDocument, massIDDocument, methodologyDocument } =
   new BoldStubsBuilder()
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
+    .createMassIDDocuments()
+    .createMassIDAuditDocuments()
     .createMethodologyDocument()
     .build();
 
 export const rewardsDistributionProcessorErrors = [
   {
     documents: [],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: ERROR_MESSAGES.MASS_ID_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `${MASS_ID} document is not found`,
   },
   {
-    documents: [massIdDocument],
-    massIdAuditDocument,
+    documents: [massIDDocument],
+    massIDAuditDocument,
     resultComment: ERROR_MESSAGES.METHODOLOGY_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `${METHODOLOGY} document is not found`,
@@ -172,15 +172,15 @@ export const rewardsDistributionProcessorErrors = [
   {
     documents: [
       {
-        ...massIdDocument,
-        externalEvents: massIdDocument.externalEvents?.filter(
+        ...massIDDocument,
+        externalEvents: massIDDocument.externalEvents?.filter(
           ({ label }) => label !== RewardsDistributionActorType.INTEGRATOR,
         ),
       },
       methodologyDocument as Document,
     ],
-    massIdAuditDocument,
-    resultComment: ERROR_MESSAGES.MISSING_REQUIRED_ACTORS(massIdDocument.id, [
+    massIDAuditDocument,
+    resultComment: ERROR_MESSAGES.MISSING_REQUIRED_ACTORS(massIDDocument.id, [
       RewardsDistributionActorType.INTEGRATOR,
     ]),
     resultStatus: RuleOutputStatus.FAILED,
@@ -192,9 +192,9 @@ export const rewardsDistributionProcessorErrors = [
         ...methodologyDocument,
         externalEvents: [],
       } as Document,
-      massIdDocument,
+      massIDDocument,
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the ${METHODOLOGY} document does not have the required actors`,
@@ -202,32 +202,32 @@ export const rewardsDistributionProcessorErrors = [
   {
     documents: [
       {
-        ...massIdDocument,
+        ...massIDDocument,
         externalEvents: [],
       } as Document,
       methodologyDocument as Document,
     ],
-    massIdAuditDocument,
-    resultComment: ERROR_MESSAGES.EXTERNAL_EVENTS_NOT_FOUND(massIdDocument.id),
+    massIDAuditDocument,
+    resultComment: ERROR_MESSAGES.EXTERNAL_EVENTS_NOT_FOUND(massIDDocument.id),
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the ${MASS_ID} document does not have external events`,
   },
   {
     documents: [
       {
-        ...massIdDocument,
+        ...massIDDocument,
         subtype: 'unknown',
       } as Document,
       methodologyDocument as Document,
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: ERROR_MESSAGES.UNEXPECTED_DOCUMENT_SUBTYPE('unknown'),
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the ${MASS_ID} document has an unexpected subtype`,
   },
   {
     documents: [
-      massIdDocument,
+      massIDDocument,
       {
         ...methodologyDocument,
         externalEvents: methodologyDocument?.externalEvents?.map((event) =>
@@ -237,7 +237,7 @@ export const rewardsDistributionProcessorErrors = [
         ),
       } as Document,
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the ${METHODOLOGY} document does not have the required address in actors`,

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.types.ts
@@ -8,18 +8,18 @@ import {
   RewardsDistributionWasteType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
-export interface ActorMassIdPercentageInputDto {
+export interface ActorMassIDPercentageInputDto {
   actors: RewardsDistributionActor[];
   actorType: RewardsDistributionActorType;
-  massIdDocument: Document;
+  massIDDocument: Document;
   rewardDistribution: BigNumber;
 }
 
 export interface ActorReward {
   actorType: RewardsDistributionActorType;
   address: RewardActorAddress;
-  massIdDocument: Document;
-  massIdPercentage: BigNumber;
+  massIDDocument: Document;
+  massIDPercentage: BigNumber;
   participant: RewardActorParticipant;
   preserveSensitiveData: boolean | undefined;
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.lambda.e2e.spec.ts
@@ -1,8 +1,8 @@
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
 import {
   BoldStubsBuilder,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdRecycledEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDRecycledEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type DocumentEvent,
@@ -33,7 +33,7 @@ describe('CompostingCycleTimeframeProcessor E2E', () => {
       if (dropOffEventDate) {
         externalEvents.set(
           DROP_OFF,
-          stubBoldMassIdDropOffEvent({
+          stubBoldMassIDDropOffEvent({
             partialDocumentEvent: {
               externalCreatedAt: dropOffEventDate,
             },
@@ -44,7 +44,7 @@ describe('CompostingCycleTimeframeProcessor E2E', () => {
       if (recycledEventDate) {
         externalEvents.set(
           RECYCLED,
-          stubBoldMassIdRecycledEvent({
+          stubBoldMassIDRecycledEvent({
             partialDocumentEvent: {
               externalCreatedAt: recycledEventDate,
             },
@@ -52,15 +52,15 @@ describe('CompostingCycleTimeframeProcessor E2E', () => {
         );
       }
 
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: externalEvents,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -72,7 +72,7 @@ describe('CompostingCycleTimeframeProcessor E2E', () => {
       const response = (await compostingCycleTimeframeLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.spec.ts
@@ -1,8 +1,8 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
-  stubBoldMassIdDocument,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdRecycledEvent,
+  stubBoldMassIDDocument,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDRecycledEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type DocumentEvent,
@@ -64,11 +64,11 @@ describe('CompostingCycleTimeframeProcessor', () => {
       resultStatus,
     }) => {
       const ruleInput = random<Required<RuleInput>>();
-      const document = stubBoldMassIdDocument({
+      const document = stubBoldMassIDDocument({
         externalEventsMap: new Map([
           [
             DROP_OFF,
-            stubBoldMassIdDropOffEvent({
+            stubBoldMassIDDropOffEvent({
               partialDocumentEvent: {
                 externalCreatedAt:
                   dropOffEventDate as DocumentEvent['externalCreatedAt'],
@@ -77,7 +77,7 @@ describe('CompostingCycleTimeframeProcessor', () => {
           ],
           [
             RECYCLED,
-            stubBoldMassIdRecycledEvent({
+            stubBoldMassIDRecycledEvent({
               partialDocumentEvent: {
                 externalCreatedAt:
                   recycledEventDate as DocumentEvent['externalCreatedAt'],

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.lambda.e2e.spec.ts
@@ -34,15 +34,15 @@ describe('DocumentManifestDataLambda E2E', () => {
         documentManifestType,
       });
 
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -54,7 +54,7 @@ describe('DocumentManifestDataLambda E2E', () => {
       const response = (await lambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
@@ -50,13 +50,13 @@ describe('DocumentManifestDataProcessor', () => {
 
       const ruleInput = random<Required<RuleInput>>();
 
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
@@ -81,13 +81,13 @@ describe('DocumentManifestDataProcessor', () => {
         documentManifestType: DocumentEventName.TRANSPORT_MANIFEST,
       });
       const ruleInput = random<Required<RuleInput>>();
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {},
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       await expect(ruleDataProcessor.process(ruleInput)).rejects.toThrow(
         'DOCUMENT_ATTACHMENT_BUCKET_NAME environment variable is required',
@@ -106,13 +106,13 @@ describe('DocumentManifestDataProcessor', () => {
         documentManifestType: DocumentEventName.TRANSPORT_MANIFEST,
       });
       const ruleInput = random<Required<RuleInput>>();
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {},
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
       await ruleDataProcessor.process(ruleInput);
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
@@ -138,13 +138,13 @@ describe('DocumentManifestDataProcessor', () => {
         documentManifestType: DocumentEventName.TRANSPORT_MANIFEST,
       });
       const ruleInput = random<Required<RuleInput>>();
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {},
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
       await ruleDataProcessor.process(ruleInput);
 
       expect(cloudWatchMock).toHaveReceivedCommandWith(PutMetricDataCommand, {
@@ -186,13 +186,13 @@ describe('DocumentManifestDataProcessor', () => {
         documentManifestType: DocumentEventName.TRANSPORT_MANIFEST,
       });
       const ruleInput = random<Required<RuleInput>>();
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {},
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
       await ruleDataProcessor.process(ruleInput);
 
       expect(loggerErrorSpy).toHaveBeenCalledWith(

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
@@ -1,7 +1,7 @@
 import {
   stubAddress,
-  stubBoldMassIdRecyclingManifestEvent,
-  stubBoldMassIdTransportManifestEvent,
+  stubBoldMassIDRecyclingManifestEvent,
+  stubBoldMassIDTransportManifestEvent,
   stubDocumentEvent,
   stubDocumentEventAttachment,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
@@ -35,8 +35,8 @@ const attributeErrorMessages: Record<string, string> = {
 const documentManifestType = random<DocumentManifestType>();
 
 const documentManifestTypeStub = {
-  [RECYCLING_MANIFEST]: stubBoldMassIdRecyclingManifestEvent,
-  [TRANSPORT_MANIFEST]: stubBoldMassIdTransportManifestEvent,
+  [RECYCLING_MANIFEST]: stubBoldMassIDRecyclingManifestEvent,
+  [TRANSPORT_MANIFEST]: stubBoldMassIDTransportManifestEvent,
 };
 
 const sameAddress = stubAddress();

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.lambda.e2e.spec.ts
@@ -21,17 +21,17 @@ describe('DriverIdentificationLambda E2E', () => {
   it.each(driverIdentificationTestCases)(
     'should return $resultStatus when $scenario',
     async ({ pickUpEvent, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {
             [PICK_UP]: pickUpEvent,
           },
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -43,7 +43,7 @@ describe('DriverIdentificationLambda E2E', () => {
       const response = (await driverIdentificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.spec.ts
@@ -24,15 +24,15 @@ describe('DriverIdentificationProcessor', () => {
     async ({ pickUpEvent, resultComment, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
 
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {
             [PICK_UP]: pickUpEvent,
           },
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
@@ -1,4 +1,4 @@
-import { stubBoldMassIdPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
   DocumentEventVehicleType,
@@ -19,7 +19,7 @@ const someJustification = faker.lorem.sentence();
 
 export const driverIdentificationTestCases = [
   {
-    pickUpEvent: stubBoldMassIdPickUpEvent({
+    pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [
         [DRIVER_IDENTIFIER, faker.lorem.sentence()],
         [DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION, undefined],
@@ -31,7 +31,7 @@ export const driverIdentificationTestCases = [
     scenario: `the ${DRIVER_IDENTIFIER} is provided`,
   },
   {
-    pickUpEvent: stubBoldMassIdPickUpEvent({
+    pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [
         [DRIVER_IDENTIFIER, undefined],
         [DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION, someJustification],
@@ -43,7 +43,7 @@ export const driverIdentificationTestCases = [
     scenario: `the ${DRIVER_IDENTIFIER} is not provided, but the ${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION} is provided`,
   },
   {
-    pickUpEvent: stubBoldMassIdPickUpEvent({
+    pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [
         [DRIVER_IDENTIFIER, undefined],
         [DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION, undefined],
@@ -55,7 +55,7 @@ export const driverIdentificationTestCases = [
     scenario: `the ${DRIVER_IDENTIFIER} is not provided and the ${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION} is not provided`,
   },
   {
-    pickUpEvent: stubBoldMassIdPickUpEvent({
+    pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [
         [DRIVER_IDENTIFIER, undefined],
         [DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION, undefined],
@@ -67,7 +67,7 @@ export const driverIdentificationTestCases = [
     scenario: `the vehicle type is ${SLUDGE_PIPES}`,
   },
   {
-    pickUpEvent: stubBoldMassIdPickUpEvent({
+    pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [
         [DRIVER_IDENTIFIER, faker.lorem.sentence()],
         [DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION, someJustification],

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('DropOffAtRecyclerLambda E2E', () => {
   it.each(dropOffAtRecyclerTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdAuditDocument, massIdDocument].map((document) => ({
+        [massIDAuditDocument, massIDDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('DropOffAtRecyclerLambda E2E', () => {
       const response = (await dropOffAtRecyclerLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.processor.spec.ts
@@ -19,15 +19,15 @@ describe('DropOffAtRecyclerProcessor', () => {
   it.each(dropOffAtRecyclerTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
         .build();
 
       const ruleInput = random<Required<RuleInput>>();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
@@ -1,6 +1,6 @@
 import {
   stubAddress,
-  stubBoldMassIdDropOffEvent,
+  stubBoldMassIDDropOffEvent,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
@@ -27,7 +27,7 @@ export const dropOffAtRecyclerTestCases = [
   },
   {
     events: {
-      [DROP_OFF]: stubBoldMassIdDropOffEvent({
+      [DROP_OFF]: stubBoldMassIDDropOffEvent({
         metadataAttributes: [[RECEIVING_OPERATOR_IDENTIFIER, undefined]],
       }),
     },
@@ -37,7 +37,7 @@ export const dropOffAtRecyclerTestCases = [
   },
   {
     events: {
-      [DROP_OFF]: stubBoldMassIdDropOffEvent(),
+      [DROP_OFF]: stubBoldMassIDDropOffEvent(),
     },
     resultComment: RESULT_COMMENTS.ADDRESS_MISMATCH,
     resultStatus: RuleOutputStatus.FAILED,
@@ -50,7 +50,7 @@ export const dropOffAtRecyclerTestCases = [
         label: RECYCLER,
         name: ACTOR,
       }),
-      [DROP_OFF]: stubBoldMassIdDropOffEvent({
+      [DROP_OFF]: stubBoldMassIDDropOffEvent({
         partialDocumentEvent: {
           address: sameRecyclerAndDropOffAddress,
         },

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
@@ -254,6 +254,11 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         externalEventsMap: new Map(),
       });
 
+      const massIDAuditDocument = createMassIDAuditDocumentWithActor(
+        actorType,
+        participantId,
+        accreditationDocument.id,
+      );
 
       const result = getAccreditedAddressByParticipantIdAndActorType(
         massIDAuditDocument,

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.spec.ts
@@ -1,15 +1,15 @@
 import {
   stubAddress,
   stubBoldAccreditationDocument,
-  stubBoldMassIdAuditDocument,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDAuditDocument,
+  stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
@@ -27,7 +27,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
   describe('getAccreditedAddressByParticipantIdAndActorType', () => {
     it('should return the accredited address by participant id and actor type', () => {
       const participantId = faker.string.uuid();
-      const actorType = MassIdDocumentActorType.RECYCLER;
+      const actorType = MassIDDocumentActorType.RECYCLER;
       const addressId = faker.string.uuid();
 
       const accreditationDocument = stubBoldAccreditationDocument({
@@ -42,7 +42,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
         ]),
       });
 
-      const massIdAuditDocument = stubBoldMassIdAuditDocument({
+      const massIDAuditDocument = stubBoldMassIDAuditDocument({
         externalEventsMap: new Map([
           [
             'ACTOR',
@@ -57,7 +57,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
       });
 
       const result = getAccreditedAddressByParticipantIdAndActorType(
-        massIdAuditDocument,
+        massIDAuditDocument,
         participantId,
         actorType,
         [
@@ -71,16 +71,16 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
 
     it('should return undefined when actor event is not found', () => {
       const participantId = faker.string.uuid();
-      const actorType = MassIdDocumentActorType.HAULER;
+      const actorType = MassIDDocumentActorType.HAULER;
 
       const accreditationDocument = stubBoldAccreditationDocument();
 
-      const massIdAuditDocument = stubBoldMassIdAuditDocument({
+      const massIDAuditDocument = stubBoldMassIDAuditDocument({
         externalEventsMap: new Map(),
       });
 
       const result = getAccreditedAddressByParticipantIdAndActorType(
-        massIdAuditDocument,
+        massIDAuditDocument,
         participantId,
         actorType,
         [accreditationDocument],
@@ -91,11 +91,11 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
 
     it('should return undefined when accreditation document id is missing in actor event', () => {
       const participantId = faker.string.uuid();
-      const actorType = MassIdDocumentActorType.PROCESSOR;
+      const actorType = MassIDDocumentActorType.PROCESSOR;
 
       const accreditationDocument = stubBoldAccreditationDocument();
 
-      const massIdAuditDocument = stubBoldMassIdAuditDocument({
+      const massIDAuditDocument = stubBoldMassIDAuditDocument({
         externalEventsMap: new Map([
           [
             'ACTOR',
@@ -110,7 +110,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
       });
 
       const result = getAccreditedAddressByParticipantIdAndActorType(
-        massIdAuditDocument,
+        massIDAuditDocument,
         participantId,
         actorType,
         [accreditationDocument],
@@ -121,11 +121,11 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
 
     it('should return undefined when accreditation document is not found', () => {
       const participantId = faker.string.uuid();
-      const actorType = MassIdDocumentActorType.WASTE_GENERATOR;
+      const actorType = MassIDDocumentActorType.WASTE_GENERATOR;
 
       const unrelatedAccreditationDocument = stubBoldAccreditationDocument();
 
-      const massIdAuditDocument = stubBoldMassIdAuditDocument({
+      const massIDAuditDocument = stubBoldMassIDAuditDocument({
         externalEventsMap: new Map([
           [
             'ACTOR',
@@ -140,7 +140,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
       });
 
       const result = getAccreditedAddressByParticipantIdAndActorType(
-        massIdAuditDocument,
+        massIDAuditDocument,
         participantId,
         actorType,
         [unrelatedAccreditationDocument],
@@ -151,13 +151,13 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
 
     it('should return undefined when facility address event is not found in accreditation document', () => {
       const participantId = faker.string.uuid();
-      const actorType = MassIdDocumentActorType.INTEGRATOR;
+      const actorType = MassIDDocumentActorType.INTEGRATOR;
 
       const accreditationDocument = stubBoldAccreditationDocument({
         externalEventsMap: new Map(),
       });
 
-      const massIdAuditDocument = stubBoldMassIdAuditDocument({
+      const massIDAuditDocument = stubBoldMassIDAuditDocument({
         externalEventsMap: new Map([
           [
             'ACTOR',
@@ -172,7 +172,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
       });
 
       const result = getAccreditedAddressByParticipantIdAndActorType(
-        massIdAuditDocument,
+        massIDAuditDocument,
         participantId,
         actorType,
         [accreditationDocument],
@@ -186,7 +186,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
     it('should return the gps geolocation of the event', () => {
       const latitude = faker.location.latitude();
       const longitude = faker.location.longitude();
-      const event = stubBoldMassIdPickUpEvent({
+      const event = stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [CAPTURED_GPS_LATITUDE, latitude],
           [CAPTURED_GPS_LONGITUDE, longitude],
@@ -200,7 +200,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
     });
 
     it('should return undefined if the event has no gps geolocation metadata', () => {
-      const event = stubBoldMassIdPickUpEvent({
+      const event = stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [CAPTURED_GPS_LATITUDE, undefined],
           [CAPTURED_GPS_LONGITUDE, undefined],
@@ -213,7 +213,7 @@ describe('GeolocationAndAddressPrecisionHelpers', () => {
     });
 
     it('should return undefined if the latitude and longitude are not valid', () => {
-      const event = stubBoldMassIdPickUpEvent({
+      const event = stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [CAPTURED_GPS_LATITUDE, 'invalid'],
           [CAPTURED_GPS_LONGITUDE, 'invalid'],

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.helpers.ts
@@ -10,7 +10,7 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type Geolocation,
@@ -21,12 +21,12 @@ import {
 import { is } from 'typia';
 
 export const getAccreditedAddressByParticipantIdAndActorType = (
-  massIdAuditDocument: Document,
+  massIDAuditDocument: Document,
   participantId: string,
-  actorType: MassIdDocumentActorType,
+  actorType: MassIDDocumentActorType,
   accreditationDocuments: Document[],
 ): MethodologyAddress | undefined => {
-  const actorEvent = massIdAuditDocument.externalEvents?.find(
+  const actorEvent = massIDAuditDocument.externalEvents?.find(
     (event) =>
       isActorEvent(event) &&
       eventHasLabel(event, actorType) &&
@@ -35,7 +35,7 @@ export const getAccreditedAddressByParticipantIdAndActorType = (
 
   if (isNil(actorEvent)) {
     logger.debug(
-      `[MassID Audit Document ${massIdAuditDocument.id}] Actor event not found for participant ${participantId} and actor type ${actorType}`,
+      `[MassID Audit Document ${massIDAuditDocument.id}] Actor event not found for participant ${participantId} and actor type ${actorType}`,
     );
 
     return undefined;
@@ -45,7 +45,7 @@ export const getAccreditedAddressByParticipantIdAndActorType = (
 
   if (isNil(accreditationDocumentId)) {
     logger.debug(
-      `[MassID Audit Document ${massIdAuditDocument.id}] Accreditation document ID not found for actor event ${actorEvent.id}`,
+      `[MassID Audit Document ${massIDAuditDocument.id}] Accreditation document ID not found for actor event ${actorEvent.id}`,
     );
 
     return undefined;
@@ -57,7 +57,7 @@ export const getAccreditedAddressByParticipantIdAndActorType = (
 
   if (isNil(participantAccreditationDocument)) {
     logger.debug(
-      `[MassID Audit Document ${massIdAuditDocument.id}] Participant accreditation document not found for accreditation document ID ${accreditationDocumentId}`,
+      `[MassID Audit Document ${massIDAuditDocument.id}] Participant accreditation document not found for accreditation document ID ${accreditationDocumentId}`,
     );
 
     return undefined;
@@ -70,7 +70,7 @@ export const getAccreditedAddressByParticipantIdAndActorType = (
 
   if (!facilityAddressEvent) {
     logger.debug(
-      `[MassID Audit Document ${massIdAuditDocument.id}] Facility address event not found for participant ${participantId} and actor type ${actorType}`,
+      `[MassID Audit Document ${massIDAuditDocument.id}] Facility address event not found for participant ${participantId} and actor type ${actorType}`,
     );
 
     return undefined;

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.lambda.e2e.spec.ts
@@ -34,17 +34,17 @@ describe('GeolocationAndAddressPrecisionProcessor E2E', () => {
     async ({
       accreditationDocuments,
       actorParticipants,
-      massIdDocumentParameters,
+      massIDDocumentParameters,
       resultComment,
       resultStatus,
     }) => {
       const {
-        massIdAuditDocument,
-        massIdDocument,
+        massIDAuditDocument,
+        massIDDocument,
         participantsAccreditationDocuments,
-      } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-        .createMassIdDocuments(massIdDocumentParameters)
-        .createMassIdAuditDocuments()
+      } = new BoldStubsBuilder({ massIDActorParticipants: actorParticipants })
+        .createMassIDDocuments(massIDDocumentParameters)
+        .createMassIDAuditDocuments()
         .createMethodologyDocument()
         .createParticipantAccreditationDocuments(accreditationDocuments)
         .build();
@@ -63,15 +63,15 @@ describe('GeolocationAndAddressPrecisionProcessor E2E', () => {
           }),
       );
 
-      massIdAuditDocument.externalEvents = [
-        ...(massIdAuditDocument.externalEvents ?? []),
+      massIDAuditDocument.externalEvents = [
+        ...(massIDAuditDocument.externalEvents ?? []),
         ...auditActorEvents,
       ];
 
       prepareEnvironmentTestE2E(
         [
-          massIdDocument,
-          massIdAuditDocument,
+          massIDDocument,
+          massIDAuditDocument,
           ...participantsAccreditationDocuments.values(),
         ].map((document) => ({
           document,
@@ -84,7 +84,7 @@ describe('GeolocationAndAddressPrecisionProcessor E2E', () => {
 
       const response = (await geolocationAndAddressPrecisionLambda(
         stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),
@@ -101,9 +101,9 @@ describe('GeolocationAndAddressPrecisionProcessor E2E', () => {
   describe('GeolocationAndAddressPrecisionProcessorErrors', () => {
     it.each(geolocationAndAddressPrecisionErrorTestCases)(
       'should return $resultStatus when $scenario',
-      async ({ documents, massIdAuditDocument, resultStatus }) => {
+      async ({ documents, massIDAuditDocument, resultStatus }) => {
         const documentEntries = (
-          [...documents, massIdAuditDocument].filter(Boolean) as Document[]
+          [...documents, massIDAuditDocument].filter(Boolean) as Document[]
         ).map((document) => ({
           document,
           documentKey: toDocumentKey({
@@ -118,7 +118,7 @@ describe('GeolocationAndAddressPrecisionProcessor E2E', () => {
 
         const response = (await geolocationAndAddressPrecisionLambda(
           stubRuleInput({
-            documentId: massIdAuditDocument?.id ?? faker.string.uuid(),
+            documentId: massIDAuditDocument?.id ?? faker.string.uuid(),
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
@@ -32,19 +32,19 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
     async ({
       accreditationDocuments,
       actorParticipants,
-      massIdDocumentParameters,
+      massIDDocumentParameters,
       resultComment,
       resultStatus,
     }) => {
       const {
-        massIdAuditDocument,
-        massIdDocument,
+        massIDAuditDocument,
+        massIDDocument,
         participantsAccreditationDocuments,
       } = new BoldStubsBuilder({
-        massIdActorParticipants: actorParticipants,
+        massIDActorParticipants: actorParticipants,
       })
-        .createMassIdDocuments(massIdDocumentParameters)
-        .createMassIdAuditDocuments()
+        .createMassIDDocuments(massIDDocumentParameters)
+        .createMassIDAuditDocuments()
         .createMethodologyDocument()
         .createParticipantAccreditationDocuments(accreditationDocuments)
         .build();
@@ -63,23 +63,23 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
           }),
       );
 
-      massIdAuditDocument.externalEvents = [
-        ...(massIdAuditDocument.externalEvents ?? []),
+      massIDAuditDocument.externalEvents = [
+        ...(massIDAuditDocument.externalEvents ?? []),
         ...auditActorEvents,
       ];
 
       const allDocuments = [
-        massIdDocument,
-        massIdAuditDocument,
+        massIDDocument,
+        massIDAuditDocument,
         ...participantsAccreditationDocuments.values(),
       ];
 
-      spyOnLoadDocument(massIdAuditDocument);
-      spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+      spyOnLoadDocument(massIDAuditDocument);
+      spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
       const ruleInput = {
         ...random<Required<RuleInput>>(),
-        documentId: massIdAuditDocument.id,
+        documentId: massIDAuditDocument.id,
       };
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
@@ -98,7 +98,7 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
       (testCase) => ({
         ...testCase,
         hasDocuments: Boolean(
-          testCase.massIdAuditDocument && testCase.documents,
+          testCase.massIDAuditDocument && testCase.documents,
         ),
       }),
     );
@@ -107,20 +107,20 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
       'should return $resultStatus when $scenario',
       async (testCase) => {
         if (testCase.hasDocuments) {
-          const { documents, massIdAuditDocument } = testCase as unknown as {
+          const { documents, massIDAuditDocument } = testCase as unknown as {
             documents: Document[];
-            massIdAuditDocument: Document;
+            massIDAuditDocument: Document;
           };
 
-          spyOnLoadDocument(massIdAuditDocument);
-          spyOnDocumentQueryServiceLoad(massIdAuditDocument, [
-            massIdAuditDocument,
+          spyOnLoadDocument(massIDAuditDocument);
+          spyOnDocumentQueryServiceLoad(massIDAuditDocument, [
+            massIDAuditDocument,
             ...documents,
           ]);
 
           const ruleInput: Required<RuleInput> = {
             ...random<Required<RuleInput>>(),
-            documentId: massIdAuditDocument.id,
+            documentId: massIDAuditDocument.id,
           };
 
           const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -5,15 +5,15 @@ import {
   MASS_ID_ACTOR_PARTICIPANTS,
   stubAddress,
   type StubBoldDocumentParameters,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { type MethodologyParticipant } from '@carrot-fndn/shared/types';
@@ -22,7 +22,7 @@ import { faker } from '@faker-js/faker';
 import { GeolocationAndAddressPrecisionProcessorErrors } from './geolocation-and-address-precision.errors';
 import { RESULT_COMMENTS } from './geolocation-and-address-precision.processor';
 
-const { RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
+const { RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
 const {
   ACCREDITATION_CONTEXT,
   ACTOR,
@@ -145,7 +145,7 @@ const wasteGeneratorActorEvent = stubDocumentEvent({
 export const geolocationAndAddressPrecisionTestCases: Array<{
   accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
   actorParticipants: Map<string, MethodologyParticipant>;
-  massIdDocumentParameters?: StubBoldDocumentParameters | undefined;
+  massIDDocumentParameters?: StubBoldDocumentParameters | undefined;
   resultComment: string;
   resultStatus: RuleOutputStatus;
   scenario: string;
@@ -177,11 +177,11 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
   {
     accreditationDocuments: validAccreditationDocuments,
     actorParticipants,
-    massIdDocumentParameters: {
+    massIDDocumentParameters: {
       externalEventsMap: {
         [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
         [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: stubBoldMassIdDropOffEvent({
+        [DROP_OFF]: stubBoldMassIDDropOffEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, nearbyRecyclerAddress.latitude],
             [CAPTURED_GPS_LONGITUDE, nearbyRecyclerAddress.longitude],
@@ -191,7 +191,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
             participant: recyclerParticipant,
           },
         }),
-        [PICK_UP]: stubBoldMassIdPickUpEvent({
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, nearbyWasteGeneratorAddress.latitude],
             [CAPTURED_GPS_LONGITUDE, nearbyWasteGeneratorAddress.longitude],
@@ -211,11 +211,11 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
   {
     accreditationDocuments: validAccreditationDocuments,
     actorParticipants,
-    massIdDocumentParameters: {
+    massIDDocumentParameters: {
       externalEventsMap: {
         [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
         [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: stubBoldMassIdDropOffEvent({
+        [DROP_OFF]: stubBoldMassIDDropOffEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, invalidRecyclerAddress.latitude],
             [CAPTURED_GPS_LONGITUDE, invalidRecyclerAddress.longitude],
@@ -225,7 +225,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
             participant: recyclerParticipant,
           },
         }),
-        [PICK_UP]: stubBoldMassIdPickUpEvent({
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, invalidWasteGeneratorAddress.latitude],
             [CAPTURED_GPS_LONGITUDE, invalidWasteGeneratorAddress.longitude],
@@ -244,11 +244,11 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
   {
     accreditationDocuments: validAccreditationDocuments,
     actorParticipants,
-    massIdDocumentParameters: {
+    massIDDocumentParameters: {
       externalEventsMap: {
         [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
         [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: stubBoldMassIdDropOffEvent({
+        [DROP_OFF]: stubBoldMassIDDropOffEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, invalidRecyclerAddress.latitude],
             [CAPTURED_GPS_LONGITUDE, invalidRecyclerAddress.longitude],
@@ -268,11 +268,11 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
   {
     accreditationDocuments: validAccreditationDocuments,
     actorParticipants,
-    massIdDocumentParameters: {
+    massIDDocumentParameters: {
       externalEventsMap: {
         [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
         [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: stubBoldMassIdDropOffEvent({
+        [DROP_OFF]: stubBoldMassIDDropOffEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, undefined],
             [CAPTURED_GPS_LONGITUDE, undefined],
@@ -282,7 +282,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
             participant: recyclerParticipant,
           },
         }),
-        [PICK_UP]: stubBoldMassIdPickUpEvent({
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, undefined],
             [CAPTURED_GPS_LONGITUDE, undefined],
@@ -302,11 +302,11 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
   {
     accreditationDocuments: validAccreditationDocuments,
     actorParticipants,
-    massIdDocumentParameters: {
+    massIDDocumentParameters: {
       externalEventsMap: {
         [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
         [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: stubBoldMassIdDropOffEvent({
+        [DROP_OFF]: stubBoldMassIDDropOffEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, undefined],
             [CAPTURED_GPS_LONGITUDE, undefined],
@@ -316,7 +316,7 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
             participant: recyclerParticipant,
           },
         }),
-        [PICK_UP]: stubBoldMassIdPickUpEvent({
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [CAPTURED_GPS_LATITUDE, undefined],
             [CAPTURED_GPS_LONGITUDE, undefined],
@@ -338,17 +338,17 @@ export const geolocationAndAddressPrecisionTestCases: Array<{
 const errorMessage = new GeolocationAndAddressPrecisionProcessorErrors();
 
 const {
-  massIdAuditDocument,
-  massIdDocument,
+  massIDAuditDocument,
+  massIDDocument,
   participantsAccreditationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocuments({
+  .createMassIDDocuments({
     externalEventsMap: {
       [DROP_OFF]: undefined,
       [PICK_UP]: undefined,
     },
   })
-  .createMassIdAuditDocuments()
+  .createMassIDAuditDocuments()
   .createMethodologyDocument()
   .createParticipantAccreditationDocuments()
   .build();
@@ -356,32 +356,32 @@ const {
 export const geolocationAndAddressPrecisionErrorTestCases = [
   {
     documents: [
-      massIdAuditDocument,
+      massIDAuditDocument,
       ...participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the MassID document does not exist',
   },
   {
     documents: [
-      massIdDocument,
-      massIdAuditDocument,
+      massIDDocument,
+      massIDAuditDocument,
       ...participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment:
       errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_REQUIRED_EVENTS(
-        massIdDocument.id,
+        massIDDocument.id,
       ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
-      'the MassId document does not contain a DROP_OFF or PICK_UP event',
+      'the MassID document does not contain a DROP_OFF or PICK_UP event',
   },
   {
-    documents: [massIdDocument, massIdAuditDocument],
-    massIdAuditDocument,
+    documents: [massIDDocument, massIDAuditDocument],
+    massIDAuditDocument,
     resultComment:
       errorMessage.ERROR_MESSAGE.PARTICIPANT_ACCREDITATION_DOCUMENTS_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
@@ -389,7 +389,7 @@ export const geolocationAndAddressPrecisionErrorTestCases = [
   },
   {
     documents: [],
-    massIdAuditDocument: undefined,
+    massIDAuditDocument: undefined,
     resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_AUDIT_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the MassID Audit document does not exist',

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.lambda.e2e.spec.ts
@@ -22,15 +22,15 @@ describe('HaulerIdentificationProcessor E2E', () => {
   it.each(haulerIdentificationTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const massId = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const massID = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massId.massIdDocument, massId.massIdAuditDocument].map((document) => ({
+        [massID.massIDDocument, massID.massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -42,7 +42,7 @@ describe('HaulerIdentificationProcessor E2E', () => {
       const response = (await haulerIdentificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massId.massIdDocument.id,
+          parentDocumentId: massID.massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.processor.spec.ts
@@ -1,5 +1,5 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
   type RuleOutput,
@@ -18,13 +18,13 @@ describe('HaulerIdentificationProcessor', () => {
   it.each(haulerIdentificationTestCases)(
     `should return $resultStatus when $scenario`,
     async ({ events, resultComment, resultStatus }) => {
-      const massIdDocumentStub = stubBoldMassIdDocument({
+      const massIDDocumentStub = stubBoldMassIDDocument({
         externalEventsMap: events,
       });
 
       const ruleInput = random<Required<RuleInput>>();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocumentStub);
+      documentLoaderService.mockResolvedValueOnce(massIDDocumentStub);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
@@ -1,5 +1,5 @@
 import {
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
@@ -32,7 +32,7 @@ export const haulerIdentificationTestCases = [
       ],
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_TYPE, TRUCK]],
         }),
       ],
@@ -48,7 +48,7 @@ export const haulerIdentificationTestCases = [
       [`${ACTOR}-${HAULER}`, undefined],
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_TYPE, TRUCK]],
         }),
       ],
@@ -64,7 +64,7 @@ export const haulerIdentificationTestCases = [
       [`${ACTOR}-${HAULER}`, undefined],
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_TYPE, DocumentEventVehicleType.CART]],
         }),
       ],

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.errors.ts
@@ -1,6 +1,6 @@
 import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
 
-export class MassIdQualificationsProcessorErrors extends BaseProcessorErrors {
+export class MassIDQualificationsProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
     DOCUMENT_SUBTYPE_NOT_FOUND: 'Document subtype not found.',
     DOCUMENT_TYPE_NOT_FOUND: 'Document type not found.',

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.lambda.e2e.spec.ts
@@ -9,22 +9,22 @@ import {
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
 
-import { massIdQualificationsLambda } from './mass-id-qualifications.lambda';
-import { massIdQualificationsTestCases } from './mass-id-qualifications.test-cases';
+import { massIDQualificationsLambda } from './mass-id-qualifications.lambda';
+import { massIDQualificationsTestCases } from './mass-id-qualifications.test-cases';
 
-describe('MassIdQualificationsLambda E2E', () => {
+describe('MassIDQualificationsLambda E2E', () => {
   const documentKeyPrefix = faker.string.uuid();
 
-  const massId = new BoldStubsBuilder()
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
+  const massID = new BoldStubsBuilder()
+    .createMassIDDocuments()
+    .createMassIDAuditDocuments()
     .build();
 
-  it.each(massIdQualificationsTestCases)(
+  it.each(massIDQualificationsTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ massIdDocument, resultStatus }) => {
+    async ({ massIDDocument, resultStatus }) => {
       prepareEnvironmentTestE2E(
-        [massIdDocument, massId.massIdAuditDocument].map((document) => ({
+        [massIDDocument, massID.massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -33,10 +33,10 @@ describe('MassIdQualificationsLambda E2E', () => {
         })),
       );
 
-      const response = (await massIdQualificationsLambda(
+      const response = (await massIDQualificationsLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.lambda.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.lambda.ts
@@ -1,7 +1,7 @@
 import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
 
-import { MassIdQualificationsProcessor } from './mass-id-qualifications.processor';
+import { MassIDQualificationsProcessor } from './mass-id-qualifications.processor';
 
-const instance = new MassIdQualificationsProcessor();
+const instance = new MassIDQualificationsProcessor();
 
-export const massIdQualificationsLambda = wrapRuleIntoLambdaHandler(instance);
+export const massIDQualificationsLambda = wrapRuleIntoLambdaHandler(instance);

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.spec.ts
@@ -1,7 +1,7 @@
 import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { MassIdOrganicSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
+import { MassIDOrganicSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleInput,
   type RuleOutput,
@@ -10,13 +10,13 @@ import {
 import { stubEnumValue } from '@carrot-fndn/shared/testing';
 import { random } from 'typia';
 
-import { MassIdQualificationsProcessor } from './mass-id-qualifications.processor';
-import { massIdQualificationsTestCases } from './mass-id-qualifications.test-cases';
+import { MassIDQualificationsProcessor } from './mass-id-qualifications.processor';
+import { massIDQualificationsTestCases } from './mass-id-qualifications.test-cases';
 
 jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 
-describe('MassIdQualificationsProcessor', () => {
-  const ruleDataProcessor = new MassIdQualificationsProcessor();
+describe('MassIDQualificationsProcessor', () => {
+  const ruleDataProcessor = new MassIDQualificationsProcessor();
 
   const documentLoaderService = jest.mocked(loadDocument);
 
@@ -27,14 +27,14 @@ describe('MassIdQualificationsProcessor', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when subtype is in MassIdOrganicSubtype enum', () => {
-      const validSubtype = stubEnumValue(MassIdOrganicSubtype);
+    it('should return true when subtype is in MassIDOrganicSubtype enum', () => {
+      const validSubtype = stubEnumValue(MassIDOrganicSubtype);
       const result = ruleDataProcessor['isValidSubtype'](validSubtype);
 
       expect(result).toBe(true);
     });
 
-    it('should return false when subtype is not in MassIdOrganicSubtype enum', () => {
+    it('should return false when subtype is not in MassIDOrganicSubtype enum', () => {
       const result = ruleDataProcessor['isValidSubtype'](
         'THIS_IS_DEFINITELY_NOT_IN_MASS_SUBTYPE_ENUM',
       );
@@ -43,20 +43,20 @@ describe('MassIdQualificationsProcessor', () => {
     });
   });
 
-  it.each(massIdQualificationsTestCases)(
+  it.each(massIDQualificationsTestCases)(
     'should return $resultStatus when $scenario',
     async ({
-      massIdDocument,
+      massIDDocument,
       resultComment,
       resultStatus,
     }: {
-      massIdDocument: Document;
+      massIDDocument: Document;
       resultComment: string;
       resultStatus: RuleOutputStatus;
     }) => {
       const ruleInput = random<Required<RuleInput>>();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.ts
@@ -6,14 +6,14 @@ import {
   type Document,
   DocumentCategory,
   DocumentType,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-import { MassIdQualificationsProcessorErrors } from './mass-id-qualifications.errors';
+import { MassIDQualificationsProcessorErrors } from './mass-id-qualifications.errors';
 
-const ALLOWED_SUBTYPES: string[] = Object.values(MassIdOrganicSubtype);
+const ALLOWED_SUBTYPES: string[] = Object.values(MassIDOrganicSubtype);
 
 const { MASS_ID } = DocumentCategory;
 const { KG } = MeasurementUnit;
@@ -34,9 +34,9 @@ export const RESULT_COMMENTS = {
     'The document category, measurement unit, subtype, type, and value are correctly defined.',
 } as const;
 
-export class MassIdQualificationsProcessor extends ParentDocumentRuleProcessor<Document> {
+export class MassIDQualificationsProcessor extends ParentDocumentRuleProcessor<Document> {
   protected readonly processorErrors =
-    new MassIdQualificationsProcessorErrors();
+    new MassIDQualificationsProcessorErrors();
 
   private get RESULT_COMMENT() {
     return RESULT_COMMENTS;

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
@@ -1,25 +1,25 @@
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
-import { MassIdQualificationsProcessorErrors } from './mass-id-qualifications.errors';
+import { MassIDQualificationsProcessorErrors } from './mass-id-qualifications.errors';
 import { RESULT_COMMENTS } from './mass-id-qualifications.processor';
 
-const massIdStubs = new BoldStubsBuilder()
-  .createMassIdDocuments()
-  .createMassIdAuditDocuments()
+const massIDStubs = new BoldStubsBuilder()
+  .createMassIDDocuments()
+  .createMassIDAuditDocuments()
   .build();
-const processorErrors = new MassIdQualificationsProcessorErrors();
+const processorErrors = new MassIDQualificationsProcessorErrors();
 
-export const massIdQualificationsTestCases = [
+export const massIDQualificationsTestCases = [
   {
-    massIdDocument: massIdStubs.massIdDocument,
+    massIDDocument: massIDStubs.massIDDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'all the criteria are met',
   },
   {
-    massIdDocument: {
-      ...massIdStubs.massIdDocument,
+    massIDDocument: {
+      ...massIDStubs.massIDDocument,
       category: 'INVALID_CATEGORY',
     },
     resultComment: RESULT_COMMENTS.INVALID_CATEGORY('INVALID_CATEGORY'),
@@ -27,8 +27,8 @@ export const massIdQualificationsTestCases = [
     scenario: 'category does not match',
   },
   {
-    massIdDocument: {
-      ...massIdStubs.massIdDocument,
+    massIDDocument: {
+      ...massIDStubs.massIDDocument,
       type: 'INVALID_TYPE',
     },
     resultComment: RESULT_COMMENTS.INVALID_TYPE('INVALID_TYPE'),
@@ -36,8 +36,8 @@ export const massIdQualificationsTestCases = [
     scenario: 'type is not ORGANIC',
   },
   {
-    massIdDocument: {
-      ...massIdStubs.massIdDocument,
+    massIDDocument: {
+      ...massIDStubs.massIDDocument,
       measurementUnit: 'INVALID_UNIT',
     },
     resultComment: RESULT_COMMENTS.INVALID_MEASUREMENT_UNIT('INVALID_UNIT'),
@@ -45,8 +45,8 @@ export const massIdQualificationsTestCases = [
     scenario: 'measurement unit is not "kg"',
   },
   {
-    massIdDocument: {
-      ...massIdStubs.massIdDocument,
+    massIDDocument: {
+      ...massIDStubs.massIDDocument,
       currentValue: 0,
     },
     resultComment: RESULT_COMMENTS.INVALID_VALUE(0),
@@ -54,8 +54,8 @@ export const massIdQualificationsTestCases = [
     scenario: 'current value is not greater than 0',
   },
   {
-    massIdDocument: {
-      ...massIdStubs.massIdDocument,
+    massIDDocument: {
+      ...massIDStubs.massIDDocument,
       subtype: 'THIS_IS_DEFINITELY_NOT_IN_MASS_SUBTYPE_ENUM',
     },
     resultComment: RESULT_COMMENTS.INVALID_SUBTYPE(
@@ -65,20 +65,20 @@ export const massIdQualificationsTestCases = [
     scenario: 'subtype is defined but not in the allowed list',
   },
   {
-    massIdDocument: { ...massIdStubs.massIdDocument, type: undefined },
+    massIDDocument: { ...massIDStubs.massIDDocument, type: undefined },
     resultComment: processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'document type is not found',
   },
   {
-    massIdDocument: { ...massIdStubs.massIdDocument, subtype: undefined },
+    massIDDocument: { ...massIDStubs.massIDDocument, subtype: undefined },
     resultComment: processorErrors.ERROR_MESSAGE.DOCUMENT_SUBTYPE_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'document subtype is not found',
   },
   {
-    massIdDocument: {
-      ...massIdStubs.massIdDocument,
+    massIDDocument: {
+      ...massIDStubs.massIDDocument,
       subtype: 'INVALID_SUBTYPE',
       type: 'INVALID_TYPE',
     },

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.errors.ts
@@ -16,7 +16,7 @@ const { DEDUCTED_WEIGHT, GROSS_WEIGHT, SORTING_FACTOR } =
   DocumentEventAttributeName;
 const { KILOGRAM } = MethodologyDocumentEventAttributeFormat;
 
-export class MassIdSortingProcessorErrors extends BaseProcessorErrors {
+export class MassIDSortingProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
     FAILED_BY_ERROR: 'Unable to validate the mass-id-sorting.',
     INVALID_DEDUCTED_WEIGHT: (deductedWeight: unknown) =>

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.spec.ts
@@ -1,4 +1,4 @@
-import { stubBoldMassIdSortingEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDSortingEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEvent,
   type DocumentEventAttribute,
@@ -63,7 +63,7 @@ describe('mass-id-sorting helpers', () => {
 
   describe('getValidatedWeightAttributes', () => {
     it('should return error when deductedWeight is greater than or equal to grossWeight', () => {
-      const sortingEvent = stubBoldMassIdSortingEvent({
+      const sortingEvent = stubBoldMassIDSortingEvent({
         metadataAttributes: [
           {
             format: MethodologyDocumentEventAttributeFormat.KILOGRAM,
@@ -87,7 +87,7 @@ describe('mass-id-sorting helpers', () => {
     });
 
     it('should return error when deductedWeight equals grossWeight', () => {
-      const sortingEvent = stubBoldMassIdSortingEvent({
+      const sortingEvent = stubBoldMassIDSortingEvent({
         metadataAttributes: [
           {
             format: MethodologyDocumentEventAttributeFormat.KILOGRAM,
@@ -120,7 +120,7 @@ describe('mass-id-sorting helpers', () => {
         { name: 'ANY', value: 7 } as unknown as DocumentEvent,
         { name: 'ANY' } as unknown as DocumentEvent,
         { name: 'ANY' } as unknown as DocumentEvent,
-        stubBoldMassIdSortingEvent({ partialDocumentEvent: { value: 9 } }),
+        stubBoldMassIDSortingEvent({ partialDocumentEvent: { value: 9 } }),
       ];
 
       const result = findSortingEvents(events as unknown as DocumentEvent[]);

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.ts
@@ -113,13 +113,13 @@ export const getSortingDescription = (sortingEvent: DocumentEvent) =>
 
 export const getSortingFactor = (
   recyclerAccreditationDocument: Document,
-  massIdDocument: Document,
+  massIDDocument: Document,
 ): number | ValidationError => {
   const emissionAndCompostingMetricsEvent =
     getLastYearEmissionAndCompostingMetricsEvent({
       documentWithEmissionAndCompostingMetricsEvent:
         recyclerAccreditationDocument,
-      documentYear: getYear(massIdDocument.externalCreatedAt),
+      documentYear: getYear(massIDDocument.externalCreatedAt),
     });
 
   const sortingFactor = getEventAttributeValue(
@@ -172,16 +172,16 @@ export const getValidatedEventValues = (
 };
 
 export const getValidatedExternalEvents = (
-  massIdDocument: Document,
+  massIDDocument: Document,
 ): DocumentEvent[] | ValidationError => {
-  if (!isNonEmptyArray(massIdDocument.externalEvents)) {
+  if (!isNonEmptyArray(massIDDocument.externalEvents)) {
     return {
       code: ValidationErrorCode.MISSING_EXTERNAL_EVENTS,
       isError: true,
     };
   }
 
-  return massIdDocument.externalEvents;
+  return massIDDocument.externalEvents;
 };
 
 export const getValidatedWeightAttributes = (

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.lambda.e2e.spec.ts
@@ -9,47 +9,47 @@ import {
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
 
-import { massIdSortingLambda } from './mass-id-sorting.lambda';
+import { massIDSortingLambda } from './mass-id-sorting.lambda';
 import {
-  massIdSortingErrorTestCases,
-  massIdSortingTestCases,
+  massIDSortingErrorTestCases,
+  massIDSortingTestCases,
 } from './mass-id-sorting.test-cases';
 
-describe('MassIdSortingProcessor E2E', () => {
+describe('MassIDSortingProcessor E2E', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   const documentKeyPrefix = faker.string.uuid();
 
-  it.each(massIdSortingTestCases)(
+  it.each(massIDSortingTestCases)(
     'should return $resultStatus when $scenario',
     async ({
       accreditationDocuments,
       actorParticipants,
-      massIdEvents,
+      massIDEvents,
       partialDocument,
       resultComment,
       resultStatus,
     }) => {
       const {
-        massIdAuditDocument,
-        massIdDocument,
+        massIDAuditDocument,
+        massIDDocument,
         participantsAccreditationDocuments,
-      } = new BoldStubsBuilder({ massIdActorParticipants: actorParticipants })
-        .createMassIdDocuments({
-          externalEventsMap: massIdEvents,
+      } = new BoldStubsBuilder({ massIDActorParticipants: actorParticipants })
+        .createMassIDDocuments({
+          externalEventsMap: massIDEvents,
           partialDocument,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .createMethodologyDocument()
         .createParticipantAccreditationDocuments(accreditationDocuments)
         .build();
 
       prepareEnvironmentTestE2E(
         [
-          massIdDocument,
-          massIdAuditDocument,
+          massIDDocument,
+          massIDAuditDocument,
           ...participantsAccreditationDocuments.values(),
         ].map((document) => ({
           document,
@@ -60,9 +60,9 @@ describe('MassIdSortingProcessor E2E', () => {
         })),
       );
 
-      const response = (await massIdSortingLambda(
+      const response = (await massIDSortingLambda(
         stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),
@@ -76,12 +76,12 @@ describe('MassIdSortingProcessor E2E', () => {
     },
   );
 
-  describe('MassIdSortingProcessorErrors', () => {
-    it.each(massIdSortingErrorTestCases)(
+  describe('MassIDSortingProcessorErrors', () => {
+    it.each(massIDSortingErrorTestCases)(
       'should return $resultStatus when $scenario',
-      async ({ documents, massIdAuditDocument, resultStatus }) => {
+      async ({ documents, massIDAuditDocument, resultStatus }) => {
         prepareEnvironmentTestE2E(
-          [...documents, massIdAuditDocument].map((document) => ({
+          [...documents, massIDAuditDocument].map((document) => ({
             document,
             documentKey: toDocumentKey({
               documentId: document.id,
@@ -90,9 +90,9 @@ describe('MassIdSortingProcessor E2E', () => {
           })),
         );
 
-        const response = (await massIdSortingLambda(
+        const response = (await massIDSortingLambda(
           stubRuleInput({
-            documentId: massIdAuditDocument.id,
+            documentId: massIDAuditDocument.id,
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.lambda.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.lambda.ts
@@ -1,7 +1,7 @@
 import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
 
-import { MassIdSortingProcessor } from './mass-id-sorting.processor';
+import { MassIDSortingProcessor } from './mass-id-sorting.processor';
 
-const instance = new MassIdSortingProcessor();
+const instance = new MassIDSortingProcessor();
 
-export const massIdSortingLambda = wrapRuleIntoLambdaHandler(instance);
+export const massIDSortingLambda = wrapRuleIntoLambdaHandler(instance);

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.spec.ts
@@ -6,35 +6,35 @@ import {
 import { type RuleInput } from '@carrot-fndn/shared/rule/types';
 import { random } from 'typia';
 
-import { MassIdSortingProcessor } from './mass-id-sorting.processor';
+import { MassIDSortingProcessor } from './mass-id-sorting.processor';
 import {
-  massIdSortingErrorTestCases,
-  massIdSortingTestCases,
+  massIDSortingErrorTestCases,
+  massIDSortingTestCases,
 } from './mass-id-sorting.test-cases';
 
-describe('MassIdSortingProcessor', () => {
-  const ruleDataProcessor = new MassIdSortingProcessor();
+describe('MassIDSortingProcessor', () => {
+  const ruleDataProcessor = new MassIDSortingProcessor();
 
   beforeEach(() => {
     jest.restoreAllMocks();
   });
 
-  describe('MassIdSortingProcessor', () => {
-    it.each(massIdSortingTestCases)(
+  describe('MassIDSortingProcessor', () => {
+    it.each(massIDSortingTestCases)(
       'should return $resultStatus when $scenario',
       async ({
         accreditationDocuments,
         actorParticipants,
-        massIdEvents,
+        massIDEvents,
         partialDocument,
         resultComment,
         resultStatus,
       }) => {
         const { ruleInput, ruleOutput } = await createRuleTestFixture({
           accreditationDocuments,
-          massIdActorParticipants: actorParticipants,
-          massIdDocumentsParams: {
-            externalEventsMap: massIdEvents,
+          massIDActorParticipants: actorParticipants,
+          massIDDocumentsParams: {
+            externalEventsMap: massIDEvents,
             partialDocument,
           },
           ruleDataProcessor,
@@ -51,22 +51,22 @@ describe('MassIdSortingProcessor', () => {
     );
   });
 
-  describe('MassIdSortingProcessorErrors', () => {
-    it.each(massIdSortingErrorTestCases)(
+  describe('MassIDSortingProcessorErrors', () => {
+    it.each(massIDSortingErrorTestCases)(
       'should return $resultStatus when $scenario',
       async ({
         documents,
-        massIdAuditDocument,
+        massIDAuditDocument,
         resultComment,
         resultStatus,
       }) => {
-        const allDocuments = [massIdAuditDocument, ...documents];
+        const allDocuments = [massIDAuditDocument, ...documents];
 
-        spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+        spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
         const ruleInput = {
           ...random<Required<RuleInput>>(),
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
         };
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -30,7 +30,7 @@ import {
 } from '@carrot-fndn/shared/rule/types';
 import { type MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared/types';
 
-import { MassIdSortingProcessorErrors } from './mass-id-sorting.errors';
+import { MassIDSortingProcessorErrors } from './mass-id-sorting.errors';
 import {
   calculateSortingValues,
   findSortingEvents,
@@ -64,7 +64,7 @@ export const RESULT_COMMENTS = {
 } as const;
 
 interface DocumentPair {
-  massIdDocument: Document;
+  massIDDocument: Document;
   recyclerAccreditationDocument: Document;
 }
 
@@ -83,8 +83,8 @@ interface SortingData {
   valueBeforeSorting: number;
 }
 
-export class MassIdSortingProcessor extends RuleDataProcessor {
-  protected readonly processorErrors = new MassIdSortingProcessorErrors();
+export class MassIDSortingProcessor extends RuleDataProcessor {
+  protected readonly processorErrors = new MassIDSortingProcessorErrors();
 
   async process(ruleInput: RuleInput): Promise<RuleOutput> {
     try {
@@ -193,7 +193,7 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
     documentQuery: DocumentQuery<Document> | undefined,
   ): Promise<DocumentPair> {
     let recyclerAccreditationDocument: Document | undefined;
-    let massIdDocument: Document | undefined;
+    let massIDDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
       const documentRelation = mapDocumentRelation(document);
@@ -206,7 +206,7 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
       }
 
       if (MASS_ID.matches(documentRelation)) {
-        massIdDocument = document;
+        massIDDocument = document;
       }
     });
 
@@ -217,21 +217,21 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
     );
 
     this.validateOrThrow(
-      isNil(massIdDocument),
+      isNil(massIDDocument),
       this.processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
     );
 
     return {
-      massIdDocument: massIdDocument!,
+      massIDDocument: massIDDocument!,
       recyclerAccreditationDocument: recyclerAccreditationDocument!,
     };
   }
 
   private extractSortingData(documents: DocumentPair): SortingData {
-    const { massIdDocument, recyclerAccreditationDocument } = documents;
+    const { massIDDocument, recyclerAccreditationDocument } = documents;
 
     const externalEvents = this.unwrapOrThrow(
-      getValidatedExternalEvents(massIdDocument),
+      getValidatedExternalEvents(massIDDocument),
       this.processorErrors.ERROR_MESSAGE.MISSING_EXTERNAL_EVENTS,
     );
 
@@ -241,7 +241,7 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
     );
 
     const sortingFactor = this.unwrapOrThrow(
-      getSortingFactor(recyclerAccreditationDocument, massIdDocument),
+      getSortingFactor(recyclerAccreditationDocument, massIDDocument),
       this.processorErrors.ERROR_MESSAGE.MISSING_SORTING_FACTOR,
     );
 
@@ -312,7 +312,7 @@ export class MassIdSortingProcessor extends RuleDataProcessor {
 
     return {
       ...calculations,
-      documentCurrentValue: massIdDocument.currentValue,
+      documentCurrentValue: massIDDocument.currentValue,
       sortingDescription,
       sortingFactor,
       valueAfterSorting: eventValues.valueAfterSorting,

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -3,8 +3,8 @@ import {
   BoldStubsBuilder,
   MASS_ID_ACTOR_PARTICIPANTS,
   stubBoldEmissionAndCompostingMetricsEvent,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdSortingEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDSortingEvent,
   stubDocumentEvent,
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
@@ -13,7 +13,7 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
@@ -23,13 +23,13 @@ import {
 import { faker } from '@faker-js/faker';
 import { addYears } from 'date-fns';
 
-import { MassIdSortingProcessorErrors } from './mass-id-sorting.errors';
+import { MassIDSortingProcessorErrors } from './mass-id-sorting.errors';
 import {
   RESULT_COMMENTS,
   SORTING_TOLERANCE,
 } from './mass-id-sorting.processor';
 
-const processorErrors = new MassIdSortingProcessorErrors();
+const processorErrors = new MassIDSortingProcessorErrors();
 
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const {
@@ -52,7 +52,7 @@ const createAccreditationDocuments = (sortingFactor: number) =>
           [ACCREDITATION_CONTEXT]: stubDocumentEvent({
             name: ACCREDITATION_CONTEXT,
             participant: actorParticipants.get(
-              MassIdDocumentActorType.RECYCLER,
+              MassIDDocumentActorType.RECYCLER,
             )!,
           }),
           [EMISSION_AND_COMPOSTING_METRICS]:
@@ -60,7 +60,7 @@ const createAccreditationDocuments = (sortingFactor: number) =>
               metadataAttributes: [[SORTING_FACTOR, sortingFactor]],
               partialDocumentEvent: {
                 participant: actorParticipants.get(
-                  MassIdDocumentActorType.RECYCLER,
+                  MassIDDocumentActorType.RECYCLER,
                 )!,
               },
             }),
@@ -85,17 +85,17 @@ const createWeightAttributes = (
   },
 ];
 
-const createMassIdEvents = (
+const createMassIDEvents = (
   valueBeforeSorting: number,
   grossWeight: number,
   deductedWeight: number,
   sortingValue?: number,
   includeDescription = true,
 ) => ({
-  [DROP_OFF]: stubBoldMassIdDropOffEvent({
+  [DROP_OFF]: stubBoldMassIDDropOffEvent({
     partialDocumentEvent: { value: valueBeforeSorting },
   }),
-  [SORTING]: stubBoldMassIdSortingEvent({
+  [SORTING]: stubBoldMassIDSortingEvent({
     metadataAttributes: [
       ...createWeightAttributes(grossWeight, deductedWeight),
       ...(includeDescription
@@ -128,7 +128,7 @@ const createErrorTestCase = (
   resultComment: string,
 ) => ({
   documents,
-  massIdAuditDocument,
+  massIDAuditDocument,
   resultComment,
   resultStatus: RuleOutputStatus.FAILED,
   scenario,
@@ -173,18 +173,18 @@ const actorParticipants = new Map(
 );
 
 const {
-  massIdAuditDocument,
-  massIdDocument,
+  massIDAuditDocument,
+  massIDDocument,
   participantsAccreditationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocuments({
+  .createMassIDDocuments({
     externalEventsMap: {
-      [DROP_OFF]: stubBoldMassIdDropOffEvent({
+      [DROP_OFF]: stubBoldMassIDDropOffEvent({
         partialDocumentEvent: {
           value: 0,
         },
       }),
-      [SORTING]: stubBoldMassIdSortingEvent({
+      [SORTING]: stubBoldMassIDSortingEvent({
         metadataAttributes: [
           {
             format: KILOGRAM,
@@ -206,15 +206,15 @@ const {
       externalCreatedAt: addYears(new Date(), 1).toISOString(),
     },
   })
-  .createMassIdAuditDocuments()
+  .createMassIDAuditDocuments()
   .createMethodologyDocument()
   .createParticipantAccreditationDocuments()
   .build();
 
-export const massIdSortingTestCases = [
+export const massIDSortingTestCases = [
   {
     actorParticipants,
-    massIdEvents: createMassIdEvents(
+    massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight,
       deductedWeight,
@@ -222,7 +222,7 @@ export const massIdSortingTestCases = [
       false,
     ),
     partialDocument: {
-      ...massIdDocument,
+      ...massIDDocument,
       currentValue: calculatedSortingValue,
     },
     resultComment: RESULT_COMMENTS.MISSING_SORTING_DESCRIPTION,
@@ -232,14 +232,14 @@ export const massIdSortingTestCases = [
   {
     accreditationDocuments: createAccreditationDocuments(sortingFactor),
     actorParticipants,
-    massIdEvents: createMassIdEvents(
+    massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight,
       deductedWeight,
       calculatedSortingValue,
     ),
     partialDocument: {
-      ...massIdDocument,
+      ...massIDDocument,
       currentValue: calculatedSortingValue,
     },
     resultComment: RESULT_COMMENTS.PASSED(0),
@@ -250,14 +250,14 @@ export const massIdSortingTestCases = [
   {
     accreditationDocuments: createAccreditationDocuments(sortingFactor),
     actorParticipants,
-    massIdEvents: createMassIdEvents(
+    massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight,
       deductedWeight,
       calculatedSortingValue,
     ),
     partialDocument: {
-      ...massIdDocument,
+      ...massIDDocument,
       currentValue: calculatedSortingValue + 1,
     },
     resultComment: RESULT_COMMENTS.DOCUMENT_VALUE_MISMATCH(
@@ -271,13 +271,13 @@ export const massIdSortingTestCases = [
   {
     accreditationDocuments: createAccreditationDocuments(sortingFactor),
     actorParticipants,
-    massIdEvents: createMassIdEvents(
+    massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight,
       deductedWeight,
       wrongSortingValue,
     ),
-    partialDocument: { ...massIdDocument, currentValue: wrongSortingValue },
+    partialDocument: { ...massIDDocument, currentValue: wrongSortingValue },
     resultComment: RESULT_COMMENTS.FAILED(
       Math.abs(calculatedSortingValue - wrongSortingValue),
     ),
@@ -287,14 +287,14 @@ export const massIdSortingTestCases = [
   {
     accreditationDocuments: createAccreditationDocuments(sortingFactor),
     actorParticipants,
-    massIdEvents: createMassIdEvents(
+    massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight,
       mismatchedDeductedWeight,
       calculatedSortingValue,
     ),
     partialDocument: {
-      ...massIdDocument,
+      ...massIDDocument,
       currentValue: calculatedSortingValue,
     },
     resultComment: RESULT_COMMENTS.DEDUCTED_WEIGHT_MISMATCH(
@@ -308,14 +308,14 @@ export const massIdSortingTestCases = [
   {
     accreditationDocuments: createAccreditationDocuments(sortingFactor),
     actorParticipants,
-    massIdEvents: createMassIdEvents(
+    massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight + 0.2,
       (grossWeight + 0.2) * (1 - sortingFactor),
       calculatedSortingValue,
     ),
     partialDocument: {
-      ...massIdDocument,
+      ...massIDDocument,
       currentValue: calculatedSortingValue,
     },
     resultComment: RESULT_COMMENTS.GROSS_WEIGHT_MISMATCH(
@@ -328,9 +328,9 @@ export const massIdSortingTestCases = [
 ];
 
 const invalidSortingValue = new BoldStubsBuilder()
-  .createMassIdDocuments({
+  .createMassIDDocuments({
     externalEventsMap: {
-      [SORTING]: stubBoldMassIdSortingEvent({
+      [SORTING]: stubBoldMassIDSortingEvent({
         metadataAttributes: [
           {
             format: KILOGRAM,
@@ -352,12 +352,12 @@ const invalidSortingValue = new BoldStubsBuilder()
       externalCreatedAt: addYears(new Date(), 1).toISOString(),
     },
   })
-  .createMassIdAuditDocuments()
+  .createMassIDAuditDocuments()
   .createMethodologyDocument()
   .createParticipantAccreditationDocuments()
   .build();
 
-export const massIdSortingErrorTestCases = [
+export const massIDSortingErrorTestCases = [
   createErrorTestCase(
     'the MassID document does not exist',
     [...participantsAccreditationDocuments.values()],
@@ -366,22 +366,22 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the MassID document does not contain external events',
     [
-      { ...massIdDocument, externalEvents: [] },
+      { ...massIDDocument, externalEvents: [] },
       ...participantsAccreditationDocuments.values(),
     ],
     processorErrors.ERROR_MESSAGE.MISSING_EXTERNAL_EVENTS,
   ),
   createErrorTestCase(
     `the ${RECYCLER} accreditation does not exist`,
-    [massIdDocument],
+    [massIDDocument],
     processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
   ),
   createErrorTestCase(
     `the MassID document does not contain a ${SORTING} event`,
     [
       {
-        ...massIdDocument,
-        externalEvents: massIdDocument.externalEvents?.filter(
+        ...massIDDocument,
+        externalEvents: massIDDocument.externalEvents?.filter(
           (event) => event.name !== SORTING.toString(),
         ),
       },
@@ -392,8 +392,8 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the value after sorting is not valid',
     [
-      invalidSortingValue.massIdDocument,
-      invalidSortingValue.massIdAuditDocument,
+      invalidSortingValue.massIDDocument,
+      invalidSortingValue.massIDAuditDocument,
       ...invalidSortingValue.participantsAccreditationDocuments.values(),
     ],
     processorErrors.ERROR_MESSAGE.INVALID_VALUE_AFTER_SORTING(0),
@@ -401,14 +401,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     `the ${RECYCLER} accreditation does not contain a ${SORTING_FACTOR} attribute`,
     [
-      modifyDocumentEvents(massIdDocument, {
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+      modifyDocumentEvents(massIDDocument, {
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(
             valueBeforeSorting,
             deductedWeight,
           ),
           partialDocumentEvent: {
-            value: massIdDocument.externalEvents?.find(
+            value: massIDDocument.externalEvents?.find(
               eventNameIsAnyOf([DROP_OFF]),
             )?.value,
           },
@@ -427,20 +427,20 @@ export const massIdSortingErrorTestCases = [
   ),
   createErrorTestCase(
     'the value before sorting is not greater than 0',
-    [massIdDocument, ...participantsAccreditationDocuments.values()],
+    [massIDDocument, ...participantsAccreditationDocuments.values()],
     processorErrors.ERROR_MESSAGE.INVALID_VALUE_BEFORE_SORTING(0),
   ),
   createErrorTestCase(
     'the gross weight has invalid format',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributesWithFormat(
             10,
             deductedWeight,
@@ -457,14 +457,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the deducted weight has invalid format',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributesWithFormat(
             valueBeforeSorting,
             5,
@@ -481,14 +481,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the gross weight is not greater than 0',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(0, deductedWeight),
           partialDocumentEvent: { value: calculatedSortingValue },
         }),
@@ -500,14 +500,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the deducted weight is not greater than 0',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(valueBeforeSorting, 0),
           partialDocumentEvent: { value: calculatedSortingValue },
         }),
@@ -519,14 +519,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the gross weight has valid value but invalid format',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributesWithFormat(
             15,
             8,
@@ -543,14 +543,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the deducted weight has valid value but invalid format',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributesWithFormat(
             15,
             8,
@@ -567,14 +567,14 @@ export const massIdSortingErrorTestCases = [
   createErrorTestCase(
     'the deducted weight is greater than or equal to gross weight',
     [
-      modifyDocumentEvents(massIdDocument, {
+      modifyDocumentEvents(massIDDocument, {
         [String(DROP_OFF)]: {
-          ...massIdDocument.externalEvents?.find(
+          ...massIDDocument.externalEvents?.find(
             (e) => e.name === String(DROP_OFF),
           ),
           value: valueBeforeSorting,
         },
-        [String(SORTING)]: stubBoldMassIdSortingEvent({
+        [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(5, 10),
           partialDocumentEvent: { value: calculatedSortingValue },
         }),

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.constants.ts
@@ -11,14 +11,14 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 export const buildDocumentsCriteria = (
-  massIdCertificateMatcher: DocumentMatcher,
+  massIDCertificateMatcher: DocumentMatcher,
 ): DocumentCriteria => ({
   parentDocument: {
     omit: true,
     relatedDocuments: [
       MASS_ID_AUDIT.match,
       {
-        ...massIdCertificateMatcher.match,
+        ...massIDCertificateMatcher.match,
         relatedDocuments: [CREDIT_ORDER_MATCH.match],
       },
     ],

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.helpers.ts
@@ -23,7 +23,7 @@ export const hasMethodologySlugAttribute = (
     }),
   );
 
-const isMassIdAuditPassed = (document: Document): boolean =>
+const isMassIDAuditPassed = (document: Document): boolean =>
   getOrDefault(document.externalEvents, []).some((event) =>
     eventHasMetadataAttribute({
       event,
@@ -38,7 +38,7 @@ const isDocumentCancelled = (document: Document): boolean =>
 export const hasNonCancelledDocuments = (documents: Document[]): boolean =>
   documents.some((document) => !isDocumentCancelled(document));
 
-export const isMassIdAuditInProgress = (document: Document): boolean =>
+export const isMassIDAuditInProgress = (document: Document): boolean =>
   !isDocumentCancelled(document) &&
   getOrDefault(document.externalEvents, []).some(
     (event) =>
@@ -48,12 +48,12 @@ export const isMassIdAuditInProgress = (document: Document): boolean =>
       }),
   );
 
-export const hasPassedOrInProgressMassIdAuditForTheSameMethodology = (
-  massIdAuditDocuments: Document[],
+export const hasPassedOrInProgressMassIDAuditForTheSameMethodology = (
+  massIDAuditDocuments: Document[],
   methodologySlug: BoldMethodologySlug,
 ): boolean =>
-  massIdAuditDocuments.some(
+  massIDAuditDocuments.some(
     (document) =>
       hasMethodologySlugAttribute(document, methodologySlug) &&
-      (isMassIdAuditPassed(document) || isMassIdAuditInProgress(document)),
+      (isMassIDAuditPassed(document) || isMassIDAuditInProgress(document)),
   );

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.lambda.e2e.spec.ts
@@ -26,8 +26,8 @@ describe('NoConflictingCertificateOrCreditProcessor E2E', () => {
 
   it.each(noConflictingCertificateOrCreditTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ documents, massIdAuditDocument, resultComment, resultStatus }) => {
-      const allDocuments = [...documents, massIdAuditDocument];
+    async ({ documents, massIDAuditDocument, resultComment, resultStatus }) => {
+      const allDocuments = [...documents, massIDAuditDocument];
 
       prepareEnvironmentTestE2E(
         allDocuments.map((document) => ({
@@ -41,7 +41,7 @@ describe('NoConflictingCertificateOrCreditProcessor E2E', () => {
 
       const response = (await lambda(
         stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.spec.ts
@@ -23,14 +23,14 @@ describe('NoConflictingCertificateOrCreditProcessor', () => {
 
   it.each(noConflictingCertificateOrCreditTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ documents, massIdAuditDocument, resultComment, resultStatus }) => {
-      const allDocuments = [...documents, massIdAuditDocument];
+    async ({ documents, massIDAuditDocument, resultComment, resultStatus }) => {
+      const allDocuments = [...documents, massIDAuditDocument];
 
       spyOnDocumentQueryServiceLoad(stubDocument(), allDocuments);
 
       const ruleInput = {
         ...random<Required<RuleInput>>(),
-        documentId: massIdAuditDocument.id,
+        documentId: massIDAuditDocument.id,
       };
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
@@ -33,7 +33,7 @@ import {
 } from './no-conflicting-certificate-or-credit.constants';
 import {
   hasNonCancelledDocuments,
-  hasPassedOrInProgressMassIdAuditForTheSameMethodology,
+  hasPassedOrInProgressMassIDAuditForTheSameMethodology,
 } from './no-conflicting-certificate-or-credit.helpers';
 import { NoConflictingCertificateOrCreditProcessorErrors } from './no-conflicting-certificate-or-credit.processor.errors';
 
@@ -41,8 +41,8 @@ const { MASS_ID } = DocumentCategory;
 
 interface RuleSubject {
   creditDocuments: Document[];
-  massIdCertificateDocuments: Document[];
-  relatedMassIdAuditDocuments: Document[];
+  massIDCertificateDocuments: Document[];
+  relatedMassIDAuditDocuments: Document[];
 }
 
 export const RESULT_COMMENTS = {
@@ -53,17 +53,17 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
   readonly errorProcessor =
     new NoConflictingCertificateOrCreditProcessorErrors();
 
-  private readonly massIdCertificateMatcher: DocumentMatcher;
+  private readonly massIDCertificateMatcher: DocumentMatcher;
 
   private readonly methodologySlug: BoldMethodologySlug;
 
   constructor(
-    massIdCertificateMatcher: DocumentMatcher,
+    massIDCertificateMatcher: DocumentMatcher,
     methodologySlug: BoldMethodologySlug,
   ) {
     super();
 
-    this.massIdCertificateMatcher = massIdCertificateMatcher;
+    this.massIDCertificateMatcher = massIDCertificateMatcher;
     this.methodologySlug = methodologySlug;
   }
 
@@ -94,15 +94,15 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
       context: {
         s3KeyPrefix: ruleInput.documentKeyPrefix,
       },
-      criteria: buildDocumentsCriteria(this.massIdCertificateMatcher),
+      criteria: buildDocumentsCriteria(this.massIDCertificateMatcher),
       documentId: ruleInput.documentId,
     });
   }
 
   private evaluateResult({
     creditDocuments,
-    massIdCertificateDocuments,
-    relatedMassIdAuditDocuments,
+    massIDCertificateDocuments,
+    relatedMassIDAuditDocuments,
   }: RuleSubject): EvaluateResultOutput {
     if (hasNonCancelledDocuments(creditDocuments)) {
       throw this.errorProcessor.getKnownError(
@@ -111,17 +111,17 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
       );
     }
 
-    if (hasNonCancelledDocuments(massIdCertificateDocuments)) {
+    if (hasNonCancelledDocuments(massIDCertificateDocuments)) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CERTIFICATE_DOCUMENT(
-          assert<NonEmptyString>(this.massIdCertificateMatcher.match.type),
+          assert<NonEmptyString>(this.massIDCertificateMatcher.match.type),
         ),
       );
     }
 
     if (
-      hasPassedOrInProgressMassIdAuditForTheSameMethodology(
-        relatedMassIdAuditDocuments,
+      hasPassedOrInProgressMassIDAuditForTheSameMethodology(
+        relatedMassIDAuditDocuments,
         this.methodologySlug,
       )
     ) {
@@ -143,8 +143,8 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
     ruleInput: RuleInput,
   ): Promise<RuleSubject> {
     const creditDocuments: Document[] = [];
-    const massIdCertificateDocuments: Document[] = [];
-    const relatedMassIdAuditDocuments: Document[] = [];
+    const massIDCertificateDocuments: Document[] = [];
+    const relatedMassIDAuditDocuments: Document[] = [];
 
     await documentQuery?.iterator().each(({ document }) => {
       const documentRelation = mapDocumentRelation(document);
@@ -153,22 +153,22 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
         creditDocuments.push(document);
       }
 
-      if (this.massIdCertificateMatcher.matches(documentRelation)) {
-        massIdCertificateDocuments.push(document);
+      if (this.massIDCertificateMatcher.matches(documentRelation)) {
+        massIDCertificateDocuments.push(document);
       }
 
       if (
         MASS_ID_AUDIT.matches(documentRelation) &&
         documentRelation.documentId !== ruleInput.documentId
       ) {
-        relatedMassIdAuditDocuments.push(document);
+        relatedMassIDAuditDocuments.push(document);
       }
     });
 
     return {
       creditDocuments,
-      massIdCertificateDocuments,
-      relatedMassIdAuditDocuments,
+      massIDCertificateDocuments,
+      relatedMassIDAuditDocuments,
     };
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
@@ -31,50 +31,50 @@ const openDocumentField = {
   },
 };
 
-const simpleMassIdStubs = new BoldStubsBuilder({
+const simpleMassIDStubs = new BoldStubsBuilder({
   methodologyName: RECYCLING,
 })
-  .createMassIdDocuments(openDocumentField)
-  .createMassIdAuditDocuments(openDocumentField)
+  .createMassIDDocuments(openDocumentField)
+  .createMassIDAuditDocuments(openDocumentField)
   .build();
-const massIdWithAuditStubs = new BoldStubsBuilder({
+const massIDWithAuditStubs = new BoldStubsBuilder({
   methodologyName: RECYCLING,
 })
-  .createMassIdDocuments(openDocumentField)
-  .createMassIdAuditDocuments(openDocumentField)
-  .createMassIdCertificateDocuments(openDocumentField)
+  .createMassIDDocuments(openDocumentField)
+  .createMassIDAuditDocuments(openDocumentField)
+  .createMassIDCertificateDocuments(openDocumentField)
   .build();
 
-const massIdWithCreditsStubs = new BoldStubsBuilder({
+const massIDWithCreditsStubs = new BoldStubsBuilder({
   methodologyName: RECYCLING,
 })
-  .createMassIdDocuments(openDocumentField)
-  .createMassIdAuditDocuments(openDocumentField)
-  .createMassIdCertificateDocuments(openDocumentField)
+  .createMassIDDocuments(openDocumentField)
+  .createMassIDAuditDocuments(openDocumentField)
+  .createMassIDCertificateDocuments(openDocumentField)
   .createCreditOrderDocument(openDocumentField)
   .build();
 
-const duplicatedMassIdAuditDocument: Document = {
-  ...simpleMassIdStubs.massIdAuditDocument,
+const duplicatedMassIDAuditDocument: Document = {
+  ...simpleMassIDStubs.massIDAuditDocument,
   id: faker.string.uuid(),
 };
 
-const massIdWithTwoAuditDocuments: Document = {
-  ...simpleMassIdStubs.massIdDocument,
+const massIDWithTwoAuditDocuments: Document = {
+  ...simpleMassIDStubs.massIDDocument,
   externalEvents: [
-    ...(simpleMassIdStubs.massIdDocument.externalEvents ?? []),
+    ...(simpleMassIDStubs.massIDDocument.externalEvents ?? []),
     stubDocumentEvent({
       name: RELATED,
-      relatedDocument: mapDocumentRelation(duplicatedMassIdAuditDocument),
+      relatedDocument: mapDocumentRelation(duplicatedMassIDAuditDocument),
     }),
   ],
 };
 
 const boldCarbonEventName = `${CARBON} Methodology`;
-const massIdAuditForOtherMethodology: Document = {
-  ...duplicatedMassIdAuditDocument,
+const massIDAuditForOtherMethodology: Document = {
+  ...duplicatedMassIDAuditDocument,
   externalEvents: [
-    ...(duplicatedMassIdAuditDocument.externalEvents?.filter(
+    ...(duplicatedMassIDAuditDocument.externalEvents?.filter(
       (event) => !event.name.includes(RECYCLING),
     ) ?? []),
     stubDocumentEventWithMetadataAttributes(
@@ -85,32 +85,32 @@ const massIdAuditForOtherMethodology: Document = {
     ),
   ],
 };
-const massIdWithAuditDocumentsForDifferentMethodologies: Document = {
-  ...simpleMassIdStubs.massIdDocument,
+const massIDWithAuditDocumentsForDifferentMethodologies: Document = {
+  ...simpleMassIDStubs.massIDDocument,
   externalEvents: [
-    ...(simpleMassIdStubs.massIdDocument.externalEvents ?? []),
+    ...(simpleMassIDStubs.massIDDocument.externalEvents ?? []),
     stubDocumentEvent({
       name: RELATED,
-      relatedDocument: mapDocumentRelation(massIdAuditForOtherMethodology),
+      relatedDocument: mapDocumentRelation(massIDAuditForOtherMethodology),
     }),
   ],
 };
 
 export const noConflictingCertificateOrCreditTestCases = [
   {
-    documents: [simpleMassIdStubs.massIdDocument],
-    massIdAuditDocument: simpleMassIdStubs.massIdAuditDocument,
+    documents: [simpleMassIDStubs.massIDDocument],
+    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'no Credit is linked to the MassID',
   },
   {
     documents: [
-      massIdWithTwoAuditDocuments,
-      simpleMassIdStubs.massIdAuditDocument,
-      duplicatedMassIdAuditDocument,
+      massIDWithTwoAuditDocuments,
+      simpleMassIDStubs.massIDAuditDocument,
+      duplicatedMassIDAuditDocument,
     ],
-    massIdAuditDocument: simpleMassIdStubs.massIdAuditDocument,
+    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
         BoldMethodologyName.RECYCLING,
@@ -121,18 +121,18 @@ export const noConflictingCertificateOrCreditTestCases = [
   },
   {
     documents: [
-      massIdWithTwoAuditDocuments,
-      simpleMassIdStubs.massIdAuditDocument,
+      massIDWithTwoAuditDocuments,
+      simpleMassIDStubs.massIDAuditDocument,
       {
-        ...duplicatedMassIdAuditDocument,
+        ...duplicatedMassIDAuditDocument,
         externalEvents: [
-          ...(duplicatedMassIdAuditDocument.externalEvents?.filter(
+          ...(duplicatedMassIDAuditDocument.externalEvents?.filter(
             (event) => !event.name.includes(RuleOutputStatus.PASSED),
           ) ?? []),
         ],
       },
     ],
-    massIdAuditDocument: simpleMassIdStubs.massIdAuditDocument,
+    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
         BoldMethodologyName.RECYCLING,
@@ -143,11 +143,11 @@ export const noConflictingCertificateOrCreditTestCases = [
   },
   {
     documents: [
-      massIdAuditForOtherMethodology,
-      simpleMassIdStubs.massIdAuditDocument,
-      massIdWithAuditDocumentsForDifferentMethodologies,
+      massIDAuditForOtherMethodology,
+      simpleMassIDStubs.massIDAuditDocument,
+      massIDWithAuditDocumentsForDifferentMethodologies,
     ],
-    massIdAuditDocument: simpleMassIdStubs.massIdAuditDocument,
+    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -155,11 +155,11 @@ export const noConflictingCertificateOrCreditTestCases = [
   },
   {
     documents: [
-      massIdWithAuditStubs.massIdDocument,
-      massIdWithAuditStubs.massIdAuditDocument,
-      massIdWithAuditStubs.massIdCertificateDocument,
+      massIDWithAuditStubs.massIDDocument,
+      massIDWithAuditStubs.massIDAuditDocument,
+      massIDWithAuditStubs.massIDCertificateDocument,
     ],
-    massIdAuditDocument: massIdWithAuditStubs.massIdAuditDocument,
+    massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CERTIFICATE_DOCUMENT(
         DocumentType.RECYCLED_ID,
@@ -169,12 +169,12 @@ export const noConflictingCertificateOrCreditTestCases = [
   },
   {
     documents: [
-      massIdWithCreditsStubs.massIdDocument,
-      massIdWithCreditsStubs.massIdAuditDocument,
-      massIdWithCreditsStubs.massIdCertificateDocument,
-      massIdWithCreditsStubs.creditOrderDocument,
+      massIDWithCreditsStubs.massIDDocument,
+      massIDWithCreditsStubs.massIDAuditDocument,
+      massIDWithCreditsStubs.massIDCertificateDocument,
+      massIDWithCreditsStubs.creditOrderDocument,
     ],
-    massIdAuditDocument: massIdWithCreditsStubs.massIdAuditDocument,
+    massIDAuditDocument: massIDWithCreditsStubs.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT,
     resultStatus: RuleOutputStatus.FAILED,
@@ -182,32 +182,32 @@ export const noConflictingCertificateOrCreditTestCases = [
   },
   {
     documents: [
-      massIdWithAuditStubs.massIdDocument,
-      massIdWithAuditStubs.massIdAuditDocument,
+      massIDWithAuditStubs.massIDDocument,
+      massIDWithAuditStubs.massIDAuditDocument,
       {
-        ...massIdWithAuditStubs.massIdCertificateDocument,
+        ...massIDWithAuditStubs.massIDCertificateDocument,
         status: MethodologyDocumentStatus.CANCELLED,
       },
     ],
-    massIdAuditDocument: massIdWithAuditStubs.massIdAuditDocument,
+    massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'has cancelled certificate document',
   },
   {
     documents: [
-      massIdWithAuditStubs.massIdDocument,
-      massIdWithAuditStubs.massIdAuditDocument,
+      massIDWithAuditStubs.massIDDocument,
+      massIDWithAuditStubs.massIDAuditDocument,
       {
-        ...massIdWithAuditStubs.massIdCertificateDocument,
+        ...massIDWithAuditStubs.massIDCertificateDocument,
         status: MethodologyDocumentStatus.CANCELLED,
       },
       {
-        ...massIdWithCreditsStubs.creditOrderDocument,
+        ...massIDWithCreditsStubs.creditOrderDocument,
         status: MethodologyDocumentStatus.CANCELLED,
       },
     ],
-    massIdAuditDocument: massIdWithAuditStubs.massIdAuditDocument,
+    massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario: 'has cancelled credit document',

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.lambda.e2e.spec.ts
@@ -20,9 +20,9 @@ describe('ParticipantAccreditationsAndVerificationsRequirementsProcessor E2E', (
 
   it.each(participantAccreditationsAndVerificationsRequirementsTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ documents, massIdAuditDocument, resultStatus }) => {
+    async ({ documents, massIDAuditDocument, resultStatus }) => {
       prepareEnvironmentTestE2E(
-        [...documents, massIdAuditDocument].map((document) => ({
+        [...documents, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -34,7 +34,7 @@ describe('ParticipantAccreditationsAndVerificationsRequirementsProcessor E2E', (
       const response =
         (await participantAccreditationsAndVerificationsRequirementsLambda(
           stubRuleInput({
-            documentId: massIdAuditDocument.id,
+            documentId: massIDAuditDocument.id,
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.spec.ts
@@ -15,15 +15,15 @@ describe('ParticipantAccreditationsAndVerificationsRequirementsProcessor', () =>
 
   it.each(participantAccreditationsAndVerificationsRequirementsTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ documents, massIdAuditDocument, resultComment, resultStatus }) => {
+    async ({ documents, massIDAuditDocument, resultComment, resultStatus }) => {
       spyOnDocumentQueryServiceLoad(stubDocument(), [
-        massIdAuditDocument,
+        massIDAuditDocument,
         ...documents,
       ]);
 
       const ruleInput = {
         ...random<Required<RuleInput>>(),
-        documentId: massIdAuditDocument.id,
+        documentId: massIDAuditDocument.id,
       };
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
@@ -50,7 +50,7 @@ const ACTORS_WITH_OPTIONAL_DATES = new Set([
 
 interface RuleSubject {
   accreditationDocuments: Map<string, Document[]>;
-  massIdDocument: Document;
+  massIDDocument: Document;
 }
 
 export const RESULT_COMMENTS = {
@@ -99,14 +99,14 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
 
   private evaluateResult({
     accreditationDocuments,
-    massIdDocument,
+    massIDDocument,
   }: RuleSubject): EvaluateResultOutput {
     this.verifyAllParticipantsHaveAccreditationDocuments({
       accreditationDocuments,
-      massIdDocument,
+      massIDDocument,
     });
 
-    const actorParticipants = this.getActorParticipants(massIdDocument);
+    const actorParticipants = this.getActorParticipants(massIDDocument);
 
     const validationError = this.validateAllActors(
       actorParticipants,
@@ -124,11 +124,11 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
   }
 
   private getActorParticipants(
-    massIdDocument: Document,
+    massIDDocument: Document,
   ): Map<string, MethodologyDocumentEventLabel> {
     // externalEvents is guaranteed to exist by verifyAllParticipantsHaveAccreditationDocuments
     return new Map(
-      massIdDocument
+      massIDDocument
         .externalEvents!.filter(
           eventLabelIsAnyOf([
             MethodologyDocumentEventLabel.INTEGRATOR,
@@ -147,13 +147,13 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
     documentQuery: DocumentQuery<Document> | undefined,
   ): Promise<RuleSubject> {
     const accreditationDocuments: Map<string, Document[]> = new Map();
-    let massIdDocument: Document | undefined;
+    let massIDDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
       const documentRelation = mapDocumentRelation(document);
 
       if (MASS_ID.matches(documentRelation)) {
-        massIdDocument = document;
+        massIDDocument = document;
       }
 
       if (PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.matches(documentRelation)) {
@@ -168,7 +168,7 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
       }
     });
 
-    if (isNil(massIdDocument)) {
+    if (isNil(massIDDocument)) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
       );
@@ -182,7 +182,7 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
 
     return {
       accreditationDocuments,
-      massIdDocument,
+      massIDDocument,
     };
   }
 
@@ -278,18 +278,18 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
 
   private verifyAllParticipantsHaveAccreditationDocuments({
     accreditationDocuments,
-    massIdDocument,
-  }: Omit<RuleSubject, 'massIdAuditDocument'>) {
-    if (!isNonEmptyArray(massIdDocument.externalEvents)) {
+    massIDDocument,
+  }: Omit<RuleSubject, 'massIDAuditDocument'>) {
+    if (!isNonEmptyArray(massIDDocument.externalEvents)) {
       throw this.errorProcessor.getKnownError(
         this.errorProcessor.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
-          massIdDocument.id,
+          massIDDocument.id,
         ),
       );
     }
 
     const actorParticipants: Map<string, string> = new Map(
-      massIdDocument.externalEvents
+      massIDDocument.externalEvents
         .filter(
           eventLabelIsAnyOf([
             MethodologyDocumentEventLabel.INTEGRATOR,

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
@@ -11,7 +11,7 @@ import {
   DocumentEventAttributeName,
   DocumentEventName,
   DocumentType,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -21,7 +21,7 @@ import { ParticipantAccreditationsAndVerificationsRequirementsProcessorErrors } 
 import { RESULT_COMMENTS } from './participant-accreditations-and-verifications-requirements.processor';
 
 const { HAULER, INTEGRATOR, PROCESSOR, RECYCLER, WASTE_GENERATOR } =
-  MassIdDocumentActorType;
+  MassIDDocumentActorType;
 const { ACCREDITATION_CONTEXT, ACCREDITATION_RESULT, LINK } = DocumentEventName;
 const { ACCREDITATION_STATUS, EFFECTIVE_DATE, EXPIRATION_DATE } =
   DocumentEventAttributeName;
@@ -47,25 +47,25 @@ const createExpiredAccreditationResultEvent = () =>
     ],
   });
 
-const createMassIdWithActorAccreditation = (
-  actorType: MassIdDocumentActorType,
+const createMassIDWithActorAccreditation = (
+  actorType: MassIDDocumentActorType,
   externalEventsMap: Map<
     DocumentEventName,
     ReturnType<typeof stubBoldAccreditationResultEvent>
   >,
 ) =>
   new BoldStubsBuilder()
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
+    .createMassIDDocuments()
+    .createMassIDAuditDocuments()
     .createMethodologyDocument()
     .createParticipantAccreditationDocuments(
       new Map([[actorType, { externalEventsMap }]]),
     )
     .build();
 
-const createMassIdWithMultipleActorAccreditations = (
+const createMassIDWithMultipleActorAccreditations = (
   actorAccreditations: Map<
-    MassIdDocumentActorType,
+    MassIDDocumentActorType,
     {
       externalEventsMap: Map<
         DocumentEventName,
@@ -73,32 +73,32 @@ const createMassIdWithMultipleActorAccreditations = (
       >;
     }
   >,
-  massIdActorParticipants?: Map<
-    MassIdDocumentActorType,
+  massIDActorParticipants?: Map<
+    MassIDDocumentActorType,
     ReturnType<typeof stubParticipant>
   >,
 ) => {
-  const builder = massIdActorParticipants
-    ? new BoldStubsBuilder({ massIdActorParticipants })
+  const builder = massIDActorParticipants
+    ? new BoldStubsBuilder({ massIDActorParticipants })
     : new BoldStubsBuilder();
 
   return builder
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
+    .createMassIDDocuments()
+    .createMassIDAuditDocuments()
     .createMethodologyDocument()
     .createParticipantAccreditationDocuments(actorAccreditations)
     .build();
 };
 
-const createMassIdAuditWithLinkEvent = (
-  massIdAuditDocument: ReturnType<
-    typeof createMassIdWithActorAccreditation
-  >['massIdAuditDocument'],
+const createMassIDAuditWithLinkEvent = (
+  massIDAuditDocument: ReturnType<
+    typeof createMassIDWithActorAccreditation
+  >['massIDAuditDocument'],
   secondAccreditation: ReturnType<typeof stubDocument>,
 ) => ({
-  ...massIdAuditDocument,
+  ...massIDAuditDocument,
   externalEvents: [
-    ...(massIdAuditDocument.externalEvents ?? []),
+    ...(massIDAuditDocument.externalEvents ?? []),
     stubDocumentEvent({
       name: LINK,
       relatedDocument: {
@@ -110,11 +110,11 @@ const createMassIdAuditWithLinkEvent = (
 });
 
 const createMultipleValidAccreditationsTestData = (
-  actorType: MassIdDocumentActorType,
+  actorType: MassIDDocumentActorType,
 ) => {
-  const massIdWithMultipleValid = new BoldStubsBuilder()
-    .createMassIdDocuments()
-    .createMassIdAuditDocuments()
+  const massIDWithMultipleValid = new BoldStubsBuilder()
+    .createMassIDDocuments()
+    .createMassIDAuditDocuments()
     .createMethodologyDocument()
     .createParticipantAccreditationDocuments(
       new Map([
@@ -131,7 +131,7 @@ const createMultipleValidAccreditationsTestData = (
     .build();
 
   const originalAccreditation =
-    massIdWithMultipleValid.participantsAccreditationDocuments.get(actorType)!;
+    massIDWithMultipleValid.participantsAccreditationDocuments.get(actorType)!;
 
   const secondAccreditation = stubDocument(
     {
@@ -153,25 +153,25 @@ const createMultipleValidAccreditationsTestData = (
   );
 
   return {
-    massIdWithMultipleValid,
+    massIDWithMultipleValid,
     originalAccreditation,
     secondAccreditation,
   };
 };
 
-const massIdAuditWithAccreditationsAndVerifications = new BoldStubsBuilder()
-  .createMassIdDocuments()
-  .createMassIdAuditDocuments()
+const massIDAuditWithAccreditationsAndVerifications = new BoldStubsBuilder()
+  .createMassIDDocuments()
+  .createMassIDAuditDocuments()
   .createMethodologyDocument()
   .createParticipantAccreditationDocuments()
   .build();
 
-const massIdWithExpiredAccreditation = createMassIdWithActorAccreditation(
+const massIDWithExpiredAccreditation = createMassIDWithActorAccreditation(
   INTEGRATOR,
   new Map([[ACCREDITATION_RESULT, createExpiredAccreditationResultEvent()]]),
 );
 
-const massIdWithWasteGeneratorNoResult = createMassIdWithActorAccreditation(
+const massIDWithWasteGeneratorNoResult = createMassIDWithActorAccreditation(
   WASTE_GENERATOR,
   new Map([
     [
@@ -183,24 +183,24 @@ const massIdWithWasteGeneratorNoResult = createMassIdWithActorAccreditation(
   ]),
 );
 
-const massIdWithWasteGeneratorValidResult = createMassIdWithActorAccreditation(
+const massIDWithWasteGeneratorValidResult = createMassIDWithActorAccreditation(
   WASTE_GENERATOR,
   new Map([[ACCREDITATION_RESULT, createValidAccreditationResultEvent()]]),
 );
 
-const massIdWithWasteGeneratorInvalidResult =
-  createMassIdWithActorAccreditation(
+const massIDWithWasteGeneratorInvalidResult =
+  createMassIDWithActorAccreditation(
     WASTE_GENERATOR,
     new Map([[ACCREDITATION_RESULT, createExpiredAccreditationResultEvent()]]),
   );
 
 const {
-  massIdWithMultipleValid: massIdWithWasteGeneratorMultipleValid,
+  massIDWithMultipleValid: massIDWithWasteGeneratorMultipleValid,
   secondAccreditation: wasteGeneratorSecondAccreditation,
 } = createMultipleValidAccreditationsTestData(WASTE_GENERATOR);
 
 const {
-  massIdWithMultipleValid: massIdWithProcessorMultipleValid,
+  massIDWithMultipleValid: massIDWithProcessorMultipleValid,
   originalAccreditation: processorOriginalAccreditation,
   secondAccreditation: processorSecondAccreditation,
 } = createMultipleValidAccreditationsTestData(PROCESSOR);
@@ -208,8 +208,8 @@ const {
 // Create a participant that has both PROCESSOR and RECYCLER roles
 const sharedParticipant = stubParticipant({ type: PROCESSOR });
 
-const massIdWithParticipantMultipleRoles =
-  createMassIdWithMultipleActorAccreditations(
+const massIDWithParticipantMultipleRoles =
+  createMassIDWithMultipleActorAccreditations(
     new Map([
       [
         INTEGRATOR,
@@ -258,8 +258,8 @@ const massIdWithParticipantMultipleRoles =
     ]),
   );
 
-const massIdWithWasteGeneratorButNoAccreditation =
-  createMassIdWithMultipleActorAccreditations(
+const massIDWithWasteGeneratorButNoAccreditation =
+  createMassIDWithMultipleActorAccreditations(
     new Map([
       [
         INTEGRATOR,
@@ -297,20 +297,20 @@ const massIdWithWasteGeneratorButNoAccreditation =
 export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   {
     documents: [
-      massIdAuditWithAccreditationsAndVerifications.massIdDocument,
-      ...massIdAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+      massIDAuditWithAccreditationsAndVerifications.massIDDocument,
+      ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument:
-      massIdAuditWithAccreditationsAndVerifications.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
       'the participants accreditation documents are found and the accreditation is active',
   },
   {
-    documents: [massIdAuditWithAccreditationsAndVerifications.massIdDocument],
-    massIdAuditDocument:
-      massIdAuditWithAccreditationsAndVerifications.massIdAuditDocument,
+    documents: [massIDAuditWithAccreditationsAndVerifications.massIDDocument],
+    massIDAuditDocument:
+      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
@@ -318,13 +318,13 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdAuditWithAccreditationsAndVerifications.massIdDocument,
+      massIDAuditWithAccreditationsAndVerifications.massIDDocument,
       ...[
-        ...massIdAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+        ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
       ].filter((document) => document.subtype !== INTEGRATOR),
     ],
-    massIdAuditDocument:
-      massIdAuditWithAccreditationsAndVerifications.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
         [INTEGRATOR],
@@ -334,10 +334,10 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      ...massIdAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+      ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument:
-      massIdAuditWithAccreditationsAndVerifications.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
     resultComment: processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the mass document does not exist',
@@ -345,26 +345,26 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   {
     documents: [
       {
-        ...massIdAuditWithAccreditationsAndVerifications.massIdDocument,
+        ...massIDAuditWithAccreditationsAndVerifications.massIDDocument,
         externalEvents: [],
       },
-      ...massIdAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+      ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument:
-      massIdAuditWithAccreditationsAndVerifications.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
-        massIdAuditWithAccreditationsAndVerifications.massIdDocument.id,
+        massIDAuditWithAccreditationsAndVerifications.massIDDocument.id,
       ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the mass document does not contain events',
   },
   {
     documents: [
-      massIdWithExpiredAccreditation.massIdDocument,
-      ...massIdWithExpiredAccreditation.participantsAccreditationDocuments.values(),
+      massIDWithExpiredAccreditation.massIDDocument,
+      ...massIDWithExpiredAccreditation.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument: massIdWithExpiredAccreditation.massIdAuditDocument,
+    massIDAuditDocument: massIDWithExpiredAccreditation.massIDAuditDocument,
     resultComment:
       processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
         [INTEGRATOR],
@@ -375,10 +375,10 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithWasteGeneratorNoResult.massIdDocument,
-      ...massIdWithWasteGeneratorNoResult.participantsAccreditationDocuments.values(),
+      massIDWithWasteGeneratorNoResult.massIDDocument,
+      ...massIDWithWasteGeneratorNoResult.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument: massIdWithWasteGeneratorNoResult.massIdAuditDocument,
+    massIDAuditDocument: massIDWithWasteGeneratorNoResult.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -386,11 +386,11 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithWasteGeneratorValidResult.massIdDocument,
-      ...massIdWithWasteGeneratorValidResult.participantsAccreditationDocuments.values(),
+      massIDWithWasteGeneratorValidResult.massIDDocument,
+      ...massIDWithWasteGeneratorValidResult.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument:
-      massIdWithWasteGeneratorValidResult.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDWithWasteGeneratorValidResult.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -398,11 +398,11 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithWasteGeneratorInvalidResult.massIdDocument,
-      ...massIdWithWasteGeneratorInvalidResult.participantsAccreditationDocuments.values(),
+      massIDWithWasteGeneratorInvalidResult.massIDDocument,
+      ...massIDWithWasteGeneratorInvalidResult.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument:
-      massIdWithWasteGeneratorInvalidResult.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDWithWasteGeneratorInvalidResult.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -410,12 +410,12 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithWasteGeneratorMultipleValid.massIdDocument,
-      ...massIdWithWasteGeneratorMultipleValid.participantsAccreditationDocuments.values(),
+      massIDWithWasteGeneratorMultipleValid.massIDDocument,
+      ...massIDWithWasteGeneratorMultipleValid.participantsAccreditationDocuments.values(),
       wasteGeneratorSecondAccreditation,
     ],
-    massIdAuditDocument: createMassIdAuditWithLinkEvent(
-      massIdWithWasteGeneratorMultipleValid.massIdAuditDocument,
+    massIDAuditDocument: createMassIDAuditWithLinkEvent(
+      massIDWithWasteGeneratorMultipleValid.massIDAuditDocument,
       wasteGeneratorSecondAccreditation,
     ),
     resultComment: RESULT_COMMENTS.PASSED,
@@ -425,10 +425,10 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithParticipantMultipleRoles.massIdDocument,
-      ...massIdWithParticipantMultipleRoles.participantsAccreditationDocuments.values(),
+      massIDWithParticipantMultipleRoles.massIDDocument,
+      ...massIDWithParticipantMultipleRoles.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument: massIdWithParticipantMultipleRoles.massIdAuditDocument,
+    massIDAuditDocument: massIDWithParticipantMultipleRoles.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -436,11 +436,11 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithWasteGeneratorButNoAccreditation.massIdDocument,
-      ...massIdWithWasteGeneratorButNoAccreditation.participantsAccreditationDocuments.values(),
+      massIDWithWasteGeneratorButNoAccreditation.massIDDocument,
+      ...massIDWithWasteGeneratorButNoAccreditation.participantsAccreditationDocuments.values(),
     ],
-    massIdAuditDocument:
-      massIdWithWasteGeneratorButNoAccreditation.massIdAuditDocument,
+    massIDAuditDocument:
+      massIDWithWasteGeneratorButNoAccreditation.massIDAuditDocument,
     resultComment: RESULT_COMMENTS.PASSED,
     resultStatus: RuleOutputStatus.PASSED,
     scenario:
@@ -448,12 +448,12 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases = [
   },
   {
     documents: [
-      massIdWithProcessorMultipleValid.massIdDocument,
-      ...massIdWithProcessorMultipleValid.participantsAccreditationDocuments.values(),
+      massIDWithProcessorMultipleValid.massIDDocument,
+      ...massIDWithProcessorMultipleValid.participantsAccreditationDocuments.values(),
       processorSecondAccreditation,
     ],
-    massIdAuditDocument: createMassIdAuditWithLinkEvent(
-      massIdWithProcessorMultipleValid.massIdAuditDocument,
+    massIDAuditDocument: createMassIDAuditWithLinkEvent(
+      massIDWithProcessorMultipleValid.massIDAuditDocument,
       processorSecondAccreditation,
     ),
     resultComment:

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.constants.ts
@@ -1,5 +1,5 @@
 import {
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
@@ -7,40 +7,40 @@ import {
  * Read the file README.md for more information about the constants in this file.
  */
 export const PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON: Record<
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   Record<MethodologyBaseline, number>
 > = {
-  [MassIdOrganicSubtype.DOMESTIC_SLUDGE]: {
+  [MassIDOrganicSubtype.DOMESTIC_SLUDGE]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.066_584,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.227_18,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.155_804,
   },
-  [MassIdOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE]: {
+  [MassIDOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.629_488,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 1.250_643,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.974_574,
   },
-  [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]: {
+  [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.459_152,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.940_301,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.726_812,
   },
-  [MassIdOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE]: {
+  [MassIDOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.499_788,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 1.120_943,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.844_874,
   },
-  [MassIdOrganicSubtype.INDUSTRIAL_SLUDGE]: {
+  [MassIDOrganicSubtype.INDUSTRIAL_SLUDGE]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.223_611,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.512_684,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.384_207,
   },
-  [MassIdOrganicSubtype.TOBACCO]: {
+  [MassIDOrganicSubtype.TOBACCO]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.459_152,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 0.940_301,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 0.726_812,
   },
-  [MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS]: {
+  [MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS]: {
     [MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS]: 0.720_371,
     [MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS]: 1.415_883,
     [MethodologyBaseline.OPEN_AIR_DUMP]: 1.106_767,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
@@ -29,26 +29,26 @@ describe('PreventedEmissionsHelpers', () => {
   describe('getPreventedEmissionsFactor', () => {
     it('should return the correct prevented emissions factor for food waste and landfills without flaring', () => {
       const result = getPreventedEmissionsFactor(
-        MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+        MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
       );
 
       expect(result).toBe(
         PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[
-          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES
+          MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES
         ][MethodologyBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS],
       );
     });
 
     it('should return the correct prevented emissions factor for domestic sludge and open air dump', () => {
       const result = getPreventedEmissionsFactor(
-        MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+        MassIDOrganicSubtype.DOMESTIC_SLUDGE,
         MethodologyBaseline.OPEN_AIR_DUMP,
       );
 
       expect(result).toBe(
         PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[
-          MassIdOrganicSubtype.DOMESTIC_SLUDGE
+          MassIDOrganicSubtype.DOMESTIC_SLUDGE
         ][MethodologyBaseline.OPEN_AIR_DUMP],
       );
     });
@@ -58,12 +58,12 @@ describe('PreventedEmissionsHelpers', () => {
     it('should calculate prevented emissions correctly with positive values', () => {
       const exceedingEmissionCoefficient = 0.8;
       const preventedEmissionsByMaterialAndBaselinePerTon = 1500;
-      const massIdDocumentValue = 100;
+      const massIDDocumentValue = 100;
 
       const result = calculatePreventedEmissions(
         exceedingEmissionCoefficient,
         preventedEmissionsByMaterialAndBaselinePerTon,
-        massIdDocumentValue,
+        massIDDocumentValue,
       );
 
       expect(result).toBeCloseTo(149_920, 10);
@@ -72,12 +72,12 @@ describe('PreventedEmissionsHelpers', () => {
     it('should calculate prevented emissions correctly with zero coefficient', () => {
       const exceedingEmissionCoefficient = 0;
       const preventedEmissionsByMaterialAndBaselinePerTon = 1000;
-      const massIdDocumentValue = 50;
+      const massIDDocumentValue = 50;
 
       const result = calculatePreventedEmissions(
         exceedingEmissionCoefficient,
         preventedEmissionsByMaterialAndBaselinePerTon,
-        massIdDocumentValue,
+        massIDDocumentValue,
       );
 
       expect(result).toBe(50_000);
@@ -86,12 +86,12 @@ describe('PreventedEmissionsHelpers', () => {
     it('should handle fractional values correctly', () => {
       const exceedingEmissionCoefficient = 0.25;
       const preventedEmissionsByMaterialAndBaselinePerTon = 800.5;
-      const massIdDocumentValue = 10.5;
+      const massIDDocumentValue = 10.5;
 
       const result = calculatePreventedEmissions(
         exceedingEmissionCoefficient,
         preventedEmissionsByMaterialAndBaselinePerTon,
-        massIdDocumentValue,
+        massIDDocumentValue,
       );
 
       expect(result).toBe(8402.625);
@@ -100,12 +100,12 @@ describe('PreventedEmissionsHelpers', () => {
     it('should clamp to zero when exceedingEmissionCoefficient >= preventedEmissionsByMaterialAndBaselinePerTon', () => {
       const exceedingEmissionCoefficient = 2000;
       const preventedEmissionsByMaterialAndBaselinePerTon = 1500;
-      const massIdDocumentValue = 100;
+      const massIDDocumentValue = 100;
 
       const result = calculatePreventedEmissions(
         exceedingEmissionCoefficient,
         preventedEmissionsByMaterialAndBaselinePerTon,
-        massIdDocumentValue,
+        massIDDocumentValue,
       );
 
       expect(result).toBe(0);
@@ -121,9 +121,9 @@ describe('PreventedEmissionsHelpers', () => {
               [
                 BASELINES,
                 {
-                  [MassIdOrganicSubtype.DOMESTIC_SLUDGE]:
+                  [MassIDOrganicSubtype.DOMESTIC_SLUDGE]:
                     MethodologyBaseline.OPEN_AIR_DUMP,
-                  [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+                  [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
                     MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
                 },
               ],
@@ -134,7 +134,7 @@ describe('PreventedEmissionsHelpers', () => {
 
       const result = getWasteGeneratorBaselineByWasteSubtype(
         document,
-        MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+        MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         processorErrors,
       );
 
@@ -151,7 +151,7 @@ describe('PreventedEmissionsHelpers', () => {
               [
                 BASELINES,
                 {
-                  [MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+                  [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
                     MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
                 },
               ],
@@ -162,7 +162,7 @@ describe('PreventedEmissionsHelpers', () => {
 
       const result = getWasteGeneratorBaselineByWasteSubtype(
         document,
-        MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+        MassIDOrganicSubtype.DOMESTIC_SLUDGE,
         processorErrors,
       );
 
@@ -181,7 +181,7 @@ describe('PreventedEmissionsHelpers', () => {
       expect(() =>
         getWasteGeneratorBaselineByWasteSubtype(
           document,
-          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
       ).toThrow(
@@ -201,7 +201,7 @@ describe('PreventedEmissionsHelpers', () => {
       expect(() =>
         getWasteGeneratorBaselineByWasteSubtype(
           document,
-          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
       ).toThrow(
@@ -221,7 +221,7 @@ describe('PreventedEmissionsHelpers', () => {
       expect(() =>
         getWasteGeneratorBaselineByWasteSubtype(
           document,
-          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
       ).toThrow(
@@ -237,7 +237,7 @@ describe('PreventedEmissionsHelpers', () => {
       expect(() =>
         getWasteGeneratorBaselineByWasteSubtype(
           document,
-          MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+          MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
       ).toThrow(

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -5,7 +5,7 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type NonEmptyString } from '@carrot-fndn/shared/types';
@@ -24,7 +24,7 @@ const formatter = new Intl.NumberFormat('en-US', {
 });
 
 export const getPreventedEmissionsFactor = (
-  wasteSubtype: MassIdOrganicSubtype,
+  wasteSubtype: MassIDOrganicSubtype,
   wasteGeneratorBaseline: MethodologyBaseline,
 ): number => {
   const factor =
@@ -38,18 +38,18 @@ export const getPreventedEmissionsFactor = (
 export const calculatePreventedEmissions = (
   exceedingEmissionCoefficient: number,
   preventedEmissionsByMaterialAndBaselinePerTon: number,
-  massIdDocumentValue: number,
+  massIDDocumentValue: number,
 ): number => {
   const computedValue =
-    massIdDocumentValue * preventedEmissionsByMaterialAndBaselinePerTon -
-    massIdDocumentValue * exceedingEmissionCoefficient;
+    massIDDocumentValue * preventedEmissionsByMaterialAndBaselinePerTon -
+    massIDDocumentValue * exceedingEmissionCoefficient;
 
   return Math.max(0, computedValue);
 };
 
 export const getWasteGeneratorBaselineByWasteSubtype = (
   wasteGeneratorAccreditationDocument: Document,
-  wasteSubtype: MassIdOrganicSubtype,
+  wasteSubtype: MassIDOrganicSubtype,
   processorErrors: PreventedEmissionsProcessorErrors,
 ): MethodologyBaseline | undefined => {
   const recyclingBaselineEvent =

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
@@ -27,32 +27,32 @@ describe('PreventedEmissionsProcessor E2E', () => {
     async ({
       accreditationDocuments,
       externalCreatedAt,
-      massIdDocumentValue,
+      massIDDocumentValue,
       resultComment,
       resultStatus,
       subtype,
     }) => {
       const {
-        massIdAuditDocument,
-        massIdDocument,
+        massIDAuditDocument,
+        massIDDocument,
         participantsAccreditationDocuments,
       } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+        .createMassIDDocuments({
           partialDocument: {
-            currentValue: massIdDocumentValue as number,
+            currentValue: massIDDocumentValue as number,
             externalCreatedAt,
             subtype,
           },
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .createMethodologyDocument()
         .createParticipantAccreditationDocuments(accreditationDocuments)
         .build();
 
       prepareEnvironmentTestE2E(
         [
-          massIdDocument,
-          massIdAuditDocument,
+          massIDDocument,
+          massIDAuditDocument,
           ...participantsAccreditationDocuments.values(),
         ].map((document) => ({
           document,
@@ -65,7 +65,7 @@ describe('PreventedEmissionsProcessor E2E', () => {
 
       const response = (await preventedEmissionsLambda(
         stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),
@@ -82,9 +82,9 @@ describe('PreventedEmissionsProcessor E2E', () => {
   describe('PreventedEmissionsProcessorErrors', () => {
     it.each(preventedEmissionsErrorTestCases)(
       'should return $resultStatus when $scenario',
-      async ({ documents, massIdAuditDocument, resultStatus }) => {
+      async ({ documents, massIDAuditDocument, resultStatus }) => {
         prepareEnvironmentTestE2E(
-          [...documents, massIdAuditDocument].map((document) => ({
+          [...documents, massIDAuditDocument].map((document) => ({
             document,
             documentKey: toDocumentKey({
               documentId: document.id,
@@ -95,7 +95,7 @@ describe('PreventedEmissionsProcessor E2E', () => {
 
         const response = (await preventedEmissionsLambda(
           stubRuleInput({
-            documentId: massIdAuditDocument.id,
+            documentId: massIDAuditDocument.id,
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
@@ -25,7 +25,7 @@ describe('PreventedEmissionsProcessor', () => {
       async ({
         accreditationDocuments,
         externalCreatedAt,
-        massIdDocumentValue,
+        massIDDocumentValue,
         resultComment,
         resultContent,
         resultStatus,
@@ -33,9 +33,9 @@ describe('PreventedEmissionsProcessor', () => {
       }) => {
         const { ruleInput, ruleOutput } = await createRuleTestFixture({
           accreditationDocuments,
-          massIdDocumentsParams: {
+          massIDDocumentsParams: {
             partialDocument: {
-              currentValue: massIdDocumentValue as number,
+              currentValue: massIDDocumentValue as number,
               externalCreatedAt,
               subtype,
             },
@@ -60,17 +60,17 @@ describe('PreventedEmissionsProcessor', () => {
       'should return $resultStatus when $scenario',
       async ({
         documents,
-        massIdAuditDocument,
+        massIDAuditDocument,
         resultComment,
         resultStatus,
       }) => {
-        const allDocuments = [massIdAuditDocument, ...documents];
+        const allDocuments = [massIDAuditDocument, ...documents];
 
-        spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+        spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
         const ruleInput = {
           ...random<Required<RuleInput>>(),
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
         };
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -23,7 +23,7 @@ import {
   type Document,
   DocumentEventAttributeName,
   DocumentSubtype,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
@@ -52,7 +52,7 @@ const { BASELINES, EXCEEDING_EMISSION_COEFFICIENT } =
 export const RESULT_COMMENTS = {
   MISSING_EXCEEDING_EMISSION_COEFFICIENT: `The "${EXCEEDING_EMISSION_COEFFICIENT}" attribute was not found in the "Recycler Accreditation" document or it is invalid.`,
   MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE: (
-    wasteSubtype: MassIdOrganicSubtype,
+    wasteSubtype: MassIDOrganicSubtype,
   ) =>
     `The "${BASELINES}" was not found in the "Waste Generator Accreditation" document for the waste subtype "${wasteSubtype}" or it is invalid.`,
   PASSED: (
@@ -65,7 +65,7 @@ export const RESULT_COMMENTS = {
 } as const;
 
 interface Documents {
-  massIdDocument: Document;
+  massIDDocument: Document;
   recyclerAccreditationDocument: Document;
   wasteGeneratorVerificationDocument: Document;
 }
@@ -99,7 +99,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
   protected evaluateResult(ruleSubject: RuleSubject): EvaluateResultOutput {
     const {
       exceedingEmissionCoefficient,
-      massIdDocumentValue,
+      massIDDocumentValue,
       wasteGeneratorBaseline,
       wasteSubtype,
     } = ruleSubject;
@@ -127,7 +127,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     const preventedEmissions = calculatePreventedEmissions(
       exceedingEmissionCoefficient,
       preventedEmissionsByWasteSubtypeAndBaselinePerTon,
-      massIdDocumentValue,
+      massIDDocumentValue,
     );
 
     return {
@@ -135,7 +135,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         preventedEmissions,
         preventedEmissionsByWasteSubtypeAndBaselinePerTon,
         exceedingEmissionCoefficient,
-        massIdDocumentValue,
+        massIDDocumentValue,
       ),
       resultContent: {
         gasType: ruleSubject.gasType,
@@ -163,7 +163,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
   }
 
   protected getRuleSubject({
-    massIdDocument,
+    massIDDocument,
     recyclerAccreditationDocument,
     wasteGeneratorVerificationDocument,
   }: Documents): RuleSubject {
@@ -171,12 +171,12 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent:
           recyclerAccreditationDocument,
-        documentYear: getYear(massIdDocument.externalCreatedAt),
+        documentYear: getYear(massIDDocument.externalCreatedAt),
       });
 
     const gasType = getGasTypeFromEvent(lastEmissionAndCompostingMetricsEvent);
 
-    if (!is<MassIdOrganicSubtype>(massIdDocument.subtype)) {
+    if (!is<MassIDOrganicSubtype>(massIDDocument.subtype)) {
       throw this.processorErrors.getKnownError(
         this.processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
       );
@@ -184,7 +184,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
 
     const wasteGeneratorBaseline = getWasteGeneratorBaselineByWasteSubtype(
       wasteGeneratorVerificationDocument,
-      massIdDocument.subtype,
+      massIDDocument.subtype,
       this.processorErrors,
     );
 
@@ -194,9 +194,9 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         EXCEEDING_EMISSION_COEFFICIENT,
       ),
       gasType,
-      massIdDocumentValue: massIdDocument.currentValue,
+      massIDDocumentValue: massIDDocument.currentValue,
       wasteGeneratorBaseline,
-      wasteSubtype: massIdDocument.subtype,
+      wasteSubtype: massIDDocument.subtype,
     };
   }
 
@@ -204,7 +204,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     documentQuery: DocumentQuery<Document> | undefined,
   ): Promise<Documents> {
     let recyclerAccreditationDocument: Document | undefined;
-    let massIdDocument: Document | undefined;
+    let massIDDocument: Document | undefined;
     let wasteGeneratorVerificationDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
@@ -225,7 +225,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       }
 
       if (MASS_ID.matches(documentRelation)) {
-        massIdDocument = document;
+        massIDDocument = document;
       }
     });
 
@@ -237,7 +237,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     );
 
     throwIfMissing(
-      massIdDocument,
+      massIDDocument,
       this.processorErrors.ERROR_MESSAGE.MISSING_MASS_ID_DOCUMENT,
       this.processorErrors,
     );
@@ -250,7 +250,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     );
 
     return {
-      massIdDocument: massIdDocument as Document,
+      massIDDocument: massIDDocument as Document,
       recyclerAccreditationDocument: recyclerAccreditationDocument as Document,
       wasteGeneratorVerificationDocument:
         wasteGeneratorVerificationDocument as Document,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -7,8 +7,8 @@ import {
   Document,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
-  MassIdOrganicSubtype,
+  MassIDDocumentActorType,
+  MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -20,34 +20,34 @@ import { RESULT_COMMENTS } from './prevented-emissions.processor';
 
 const { BASELINES, EXCEEDING_EMISSION_COEFFICIENT, GREENHOUSE_GAS_TYPE } =
   DocumentEventAttributeName;
-const { RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
+const { RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
 const { EMISSION_AND_COMPOSTING_METRICS, RECYCLING_BASELINES } =
   DocumentEventName;
 
-const subtype = MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES;
+const subtype = MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES;
 const baseline = MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS;
 const exceedingEmissionCoefficient = 0.02;
-const massIdDocumentValue = 100;
+const massIDDocumentValue = 100;
 const baselineValue =
   PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[subtype][baseline];
 const expectedPreventedEmissionsValue =
-  massIdDocumentValue * (baselineValue - exceedingEmissionCoefficient);
+  massIDDocumentValue * (baselineValue - exceedingEmissionCoefficient);
 
 const exceedingEmissionCoefficientExceedingBaseline = baselineValue + 1;
 
 const processorErrors = new PreventedEmissionsProcessorErrors();
 
 const {
-  massIdAuditDocument,
-  massIdDocument,
+  massIDAuditDocument,
+  massIDDocument,
   participantsAccreditationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocuments({
+  .createMassIDDocuments({
     partialDocument: {
       externalCreatedAt: addYears(new Date(), 1).toISOString(),
     },
   })
-  .createMassIdAuditDocuments()
+  .createMassIDAuditDocuments()
   .createMethodologyDocument()
   .createParticipantAccreditationDocuments()
   .build();
@@ -80,13 +80,13 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
         exceedingEmissionCoefficient: undefined,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue: 1,
+        massIDDocumentValue: 1,
         wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
@@ -125,13 +125,13 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
-    massIdDocumentValue,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
+    massIDDocumentValue,
     resultComment: RESULT_COMMENTS.PASSED(
       0,
       baselineValue,
       exceedingEmissionCoefficientExceedingBaseline,
-      massIdDocumentValue,
+      massIDDocumentValue,
     ),
     resultContent: {
       gasType: 'Methane (CH4)',
@@ -140,7 +140,7 @@ export const preventedEmissionsTestCases = [
         exceedingEmissionCoefficient:
           exceedingEmissionCoefficientExceedingBaseline,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue,
+        massIDDocumentValue,
         wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
@@ -177,13 +177,13 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
         exceedingEmissionCoefficient: null,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue: 1,
+        massIDDocumentValue: 1,
         wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
@@ -222,13 +222,13 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
-    massIdDocumentValue,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
+    massIDDocumentValue,
     resultComment: RESULT_COMMENTS.PASSED(
       expectedPreventedEmissionsValue,
       baselineValue,
       exceedingEmissionCoefficient,
-      massIdDocumentValue,
+      massIDDocumentValue,
     ),
     resultContent: {
       gasType: 'Methane (CH4)',
@@ -236,7 +236,7 @@ export const preventedEmissionsTestCases = [
       ruleSubject: {
         exceedingEmissionCoefficient,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue,
+        massIDDocumentValue,
         wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
@@ -275,23 +275,23 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
-    massIdDocumentValue,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
+    massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE(
-      MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+      MassIDOrganicSubtype.DOMESTIC_SLUDGE,
     ),
     resultContent: {
       ruleSubject: {
         exceedingEmissionCoefficient,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue,
+        massIDDocumentValue,
         wasteGeneratorBaseline: undefined,
-        wasteSubtype: MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+        wasteSubtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
       },
     },
     resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the Waste Generator verification document does not have the "${BASELINES}" info for the waste subtype "${MassIdOrganicSubtype.DOMESTIC_SLUDGE}"`,
-    subtype: MassIdOrganicSubtype.DOMESTIC_SLUDGE,
+    scenario: `the Waste Generator verification document does not have the "${BASELINES}" info for the waste subtype "${MassIDOrganicSubtype.DOMESTIC_SLUDGE}"`,
+    subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
   },
   {
     accreditationDocuments: new Map([
@@ -320,14 +320,14 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
-    massIdDocumentValue,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
+    massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
         exceedingEmissionCoefficient: 0,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue,
+        massIDDocumentValue,
         wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
@@ -363,14 +363,14 @@ export const preventedEmissionsTestCases = [
         },
       ],
     ]),
-    externalCreatedAt: massIdDocument.externalCreatedAt,
-    massIdDocumentValue,
+    externalCreatedAt: massIDDocument.externalCreatedAt,
+    massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
         exceedingEmissionCoefficient: -0.5,
         gasType: 'Methane (CH4)',
-        massIdDocumentValue,
+        massIDDocumentValue,
         wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
@@ -388,8 +388,8 @@ export const preventedEmissionsErrorTestCases = [
   {
     documents: [
       {
-        ...massIdDocument,
-        subtype: 'INVALID_SUBTYPE' as MassIdOrganicSubtype,
+        ...massIDDocument,
+        subtype: 'INVALID_SUBTYPE' as MassIDOrganicSubtype,
       },
       ...[...participantsAccreditationDocuments.values()].map((document) => {
         if (document.subtype === RECYCLER) {
@@ -426,7 +426,7 @@ export const preventedEmissionsErrorTestCases = [
         return document;
       }),
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
     resultStatus: RuleOutputStatus.FAILED,
@@ -434,7 +434,7 @@ export const preventedEmissionsErrorTestCases = [
   },
   {
     documents: [
-      massIdDocument,
+      massIDDocument,
       ...[...participantsAccreditationDocuments.values()].map((document) => {
         if (document.subtype === RECYCLER) {
           return {
@@ -459,7 +459,7 @@ export const preventedEmissionsErrorTestCases = [
         return document;
       }),
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
@@ -467,14 +467,14 @@ export const preventedEmissionsErrorTestCases = [
   },
   {
     documents: [...participantsAccreditationDocuments.values()],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: processorErrors.ERROR_MESSAGE.MISSING_MASS_ID_DOCUMENT,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'the MassID document was not found',
   },
   {
-    documents: [massIdDocument],
-    massIdAuditDocument,
+    documents: [massIDDocument],
+    massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
     resultStatus: RuleOutputStatus.FAILED,
@@ -482,7 +482,7 @@ export const preventedEmissionsErrorTestCases = [
   },
   {
     documents: [
-      massIdDocument,
+      massIDDocument,
       ...[...participantsAccreditationDocuments.values()]
         .filter((document) => document.subtype !== WASTE_GENERATOR)
         .map((document) => {
@@ -510,7 +510,7 @@ export const preventedEmissionsErrorTestCases = [
           return document;
         }),
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE
         .MISSING_WASTE_GENERATOR_VERIFICATION_DOCUMENT,
@@ -519,7 +519,7 @@ export const preventedEmissionsErrorTestCases = [
   },
   {
     documents: [
-      massIdDocument,
+      massIDDocument,
       ...[...participantsAccreditationDocuments.values()]
         .filter((document) => document.subtype !== WASTE_GENERATOR)
         .map((document) => {
@@ -551,7 +551,7 @@ export const preventedEmissionsErrorTestCases = [
         ],
       },
     ],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
     resultStatus: RuleOutputStatus.FAILED,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -1,5 +1,5 @@
 import {
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -12,11 +12,11 @@ export interface RuleSubject {
     | MethodologyDocumentEventAttributeValue
     | undefined;
   gasType: NonEmptyString;
-  massIdDocumentValue: number;
+  massIDDocumentValue: number;
   wasteGeneratorBaseline: MethodologyBaseline | undefined;
-  wasteSubtype: MassIdOrganicSubtype;
+  wasteSubtype: MassIDOrganicSubtype;
 }
 
 export type WasteGeneratorBaselineValues = Partial<
-  Record<MassIdOrganicSubtype, MethodologyBaseline>
+  Record<MassIDOrganicSubtype, MethodologyBaseline>
 >;

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('ProcessorIdentificationProcessor E2E', () => {
   it.each(processorIdentificationTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('ProcessorIdentificationProcessor E2E', () => {
       const response = (await processorIdentificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.processor.spec.ts
@@ -1,5 +1,5 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
   type RuleOutput,
@@ -20,11 +20,11 @@ describe('ProcessorIdentificationProcessor', () => {
     `should return $resultStatus when $scenario`,
     async ({ events, resultComment, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
-      const massIdDocumentStub = stubBoldMassIdDocument({
+      const massIDDocumentStub = stubBoldMassIDDocument({
         externalEventsMap: events,
       });
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocumentStub);
+      documentLoaderService.mockResolvedValueOnce(massIDDocumentStub);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('ProjectBoundaryLambda E2E', () => {
   it.each(projectBoundaryTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultContent, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('ProjectBoundaryLambda E2E', () => {
       const response = (await projectBoundaryLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.spec.ts
@@ -2,8 +2,8 @@ import { calculateDistance } from '@carrot-fndn/shared/helpers';
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
   BoldStubsBuilder,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -41,13 +41,13 @@ describe('ProjectBoundaryProcessor', () => {
     async ({ events, resultComment, resultContent, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
 
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       if (resultContent && typeof resultContent.distance === 'number') {
         const distanceInMeters = resultContent.distance * 1000;
@@ -84,16 +84,16 @@ describe('ProjectBoundaryProcessor', () => {
     it('should return FAILED when the distance is not calculated', async () => {
       const ruleInput = random<Required<RuleInput>>();
 
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: {
-            [DocumentEventName.DROP_OFF]: stubBoldMassIdDropOffEvent(),
-            [DocumentEventName.PICK_UP]: stubBoldMassIdPickUpEvent(),
+            [DocumentEventName.DROP_OFF]: stubBoldMassIDDropOffEvent(),
+            [DocumentEventName.PICK_UP]: stubBoldMassIDPickUpEvent(),
           },
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
@@ -2,8 +2,8 @@ import { calculateDistance } from '@carrot-fndn/shared/helpers';
 import {
   generateNearbyCoordinates,
   stubAddress,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -43,7 +43,7 @@ export const projectBoundaryTestCases = [
   },
   {
     events: {
-      [DROP_OFF]: stubBoldMassIdDropOffEvent({
+      [DROP_OFF]: stubBoldMassIDDropOffEvent({
         partialDocumentEvent: {
           address: {
             ...stubAddress(),
@@ -51,7 +51,7 @@ export const projectBoundaryTestCases = [
           },
         },
       }),
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         partialDocumentEvent: {
           address: {
             ...stubAddress(),

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.lambda.e2e.spec.ts
@@ -1,7 +1,7 @@
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
 import {
-  stubBoldMassIdDocument,
-  stubBoldMassIdRecycledEvent,
+  stubBoldMassIDDocument,
+  stubBoldMassIDRecycledEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
@@ -28,11 +28,11 @@ describe('ProjectPeriodLimitLambda E2E', () => {
   it.each(projectPeriodLimitTestCases)(
     'should return $resultStatus when $scenario',
     async ({ externalCreatedAt, resultComment, resultStatus }) => {
-      const massIdDocument = stubBoldMassIdDocument({
+      const massIDDocument = stubBoldMassIDDocument({
         externalEventsMap: new Map([
           [
             RECYCLED,
-            stubBoldMassIdRecycledEvent({
+            stubBoldMassIDRecycledEvent({
               partialDocumentEvent: externalCreatedAt
                 ? { externalCreatedAt }
                 : {},
@@ -42,7 +42,7 @@ describe('ProjectPeriodLimitLambda E2E', () => {
       });
 
       prepareEnvironmentTestE2E(
-        [massIdDocument].map((document) => ({
+        [massIDDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -54,7 +54,7 @@ describe('ProjectPeriodLimitLambda E2E', () => {
       const response = (await projectPeriodLimitLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.spec.ts
@@ -1,7 +1,7 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import {
-  stubBoldMassIdDocument,
-  stubBoldMassIdRecycledEvent,
+  stubBoldMassIDDocument,
+  stubBoldMassIDRecycledEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -35,11 +35,11 @@ describe('ProjectPeriodLimitProcessor', () => {
     async ({ externalCreatedAt, resultComment, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
 
-      const document = stubBoldMassIdDocument({
+      const document = stubBoldMassIDDocument({
         externalEventsMap: new Map([
           [
             RECYCLED,
-            stubBoldMassIdRecycledEvent({
+            stubBoldMassIDRecycledEvent({
               partialDocumentEvent: {
                 externalCreatedAt,
               },
@@ -67,7 +67,7 @@ describe('ProjectPeriodLimitProcessor', () => {
   it('should FAIL the rule if the Recycled event is not found', async () => {
     const ruleInput = random<Required<RuleInput>>();
 
-    const document = stubBoldMassIdDocument({
+    const document = stubBoldMassIDDocument({
       externalEventsMap: new Map([[RECYCLED, undefined]]),
     });
 

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('RecyclerActorProcessor E2E', () => {
   it.each(recyclerIdentificationTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('RecyclerActorProcessor E2E', () => {
       const response = (await recyclerIdentificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.processor.spec.ts
@@ -1,5 +1,5 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
   type RuleOutput,
@@ -20,11 +20,11 @@ describe('RecyclerIdentificationProcessor', () => {
     `should return $resultStatus when $scenario`,
     async ({ events, resultComment, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
-      const massIdDocumentStub = stubBoldMassIdDocument({
+      const massIDDocumentStub = stubBoldMassIDDocument({
         externalEventsMap: events,
       });
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocumentStub);
+      documentLoaderService.mockResolvedValueOnce(massIDDocumentStub);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('RegionalWasteClassificationLambda E2E', () => {
   it.each(regionalWasteClassificationTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdAuditDocument, massIdDocument].map((document) => ({
+        [massIDAuditDocument, massIDDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('RegionalWasteClassificationLambda E2E', () => {
       const response = (await regionalWasteClassificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.spec.ts
@@ -21,13 +21,13 @@ describe('RegionalWasteClassificationProcessor', () => {
     async ({ events, resultComment, resultContent, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
 
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
         .build();
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -1,6 +1,6 @@
 import {
   stubAddress,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
@@ -43,7 +43,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [
@@ -66,7 +66,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '020101'],
           [
@@ -89,7 +89,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [
@@ -112,7 +112,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, undefined],
           [
@@ -134,7 +134,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, undefined],
@@ -153,7 +153,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
@@ -173,7 +173,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: americanRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
@@ -192,7 +192,7 @@ export const regionalWasteClassificationTestCases = [
   {
     events: {
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, randomId],
           [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('VehicleIdentificationLambda E2E', () => {
   it.each(vehicleIdentificationTestCases)(
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('VehicleIdentificationLambda E2E', () => {
       const response = (await vehicleIdentificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.spec.ts
@@ -1,5 +1,5 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
   type RuleOutput,
@@ -20,7 +20,7 @@ describe('VehicleIdentificationProcessor', () => {
     'should return $resultStatus when $scenario',
     async ({ events, resultComment, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
-      const document = stubBoldMassIdDocument({
+      const document = stubBoldMassIDDocument({
         externalEventsMap: events,
       });
 

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
@@ -1,6 +1,6 @@
 import type { LicensePlate } from '@carrot-fndn/shared/types';
 
-import { stubBoldMassIdPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
   DocumentEventName,
@@ -24,7 +24,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_TYPE, 'INVALID_VEHICLE_TYPE']],
         }),
       ],
@@ -37,7 +37,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_TYPE, undefined]],
         }),
       ],
@@ -50,7 +50,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [VEHICLE_TYPE, OTHERS],
             [VEHICLE_DESCRIPTION, undefined],
@@ -66,7 +66,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [VEHICLE_TYPE, OTHERS],
             [VEHICLE_DESCRIPTION, 'VEHICLE_DESCRIPTION'],
@@ -88,7 +88,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_TYPE, vehicleType]],
         }),
       ],
@@ -101,7 +101,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [VEHICLE_TYPE, TRUCK],
             [VEHICLE_LICENSE_PLATE, undefined],
@@ -117,7 +117,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [VEHICLE_TYPE, TRUCK],
             [VEHICLE_LICENSE_PLATE, random<LicensePlate>()],
@@ -133,7 +133,7 @@ export const vehicleIdentificationTestCases = [
     events: new Map([
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [
             [VEHICLE_TYPE, TRUCK],
             [VEHICLE_LICENSE_PLATE, 'INVALID_LICENSE_PLATE'],

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.e2e.spec.ts
@@ -2,8 +2,8 @@ import { seedDocument } from '@carrot-fndn/shared/document/seeds';
 import { AuditApiService } from '@carrot-fndn/shared/methodologies/audit-api';
 import {
   BoldStubsBuilder,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDPickUpEvent,
   stubDocument,
   stubDocumentEvent,
   stubDocumentEventWithMetadataAttributes,
@@ -22,7 +22,7 @@ import { random } from 'typia';
 
 import {
   type EventsData,
-  fetchSimilarMassIdDocuments,
+  fetchSimilarMassIDDocuments,
 } from './waste-mass-is-unique.helpers';
 
 const { ACTOR } = DocumentEventName;
@@ -37,8 +37,8 @@ describe('Waste Mass Is Unique Helpers E2E', () => {
 
   const vehicleLicensePlate = random<LicensePlate>();
   const eventsData: EventsData = {
-    dropOffEvent: stubBoldMassIdDropOffEvent(),
-    pickUpEvent: stubBoldMassIdPickUpEvent({
+    dropOffEvent: stubBoldMassIDDropOffEvent(),
+    pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [
         {
           name: VEHICLE_LICENSE_PLATE,
@@ -60,8 +60,8 @@ describe('Waste Mass Is Unique Helpers E2E', () => {
   beforeAll(async () => {
     auditApiService = new AuditApiService();
 
-    const { massIdDocument } = new BoldStubsBuilder()
-      .createMassIdDocuments({
+    const { massIDDocument } = new BoldStubsBuilder()
+      .createMassIDDocuments({
         externalEventsMap: {
           [`${ACTOR}-${RECYCLER}`]: eventsData.recyclerEvent,
           [`${ACTOR}-${WASTE_GENERATOR}`]: eventsData.wasteGeneratorEvent,
@@ -71,25 +71,25 @@ describe('Waste Mass Is Unique Helpers E2E', () => {
       })
       .build();
 
-    v2DocumentStub = massIdDocument;
+    v2DocumentStub = massIDDocument;
 
     v2DocumentId = await seedDocument({
       partialDocument: v2DocumentStub,
     });
   });
 
-  describe('fetchSimilarMassIdDocuments', () => {
+  describe('fetchSimilarMassIDDocuments', () => {
     it('should return an empty array when no similar documents are found', async () => {
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments()
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments()
         .build();
 
-      const result = await fetchSimilarMassIdDocuments({
+      const result = await fetchSimilarMassIDDocuments({
         auditApiService,
-        document: massIdDocument,
+        document: massIDDocument,
         eventsData: {
-          dropOffEvent: stubBoldMassIdDropOffEvent(),
-          pickUpEvent: stubBoldMassIdPickUpEvent(),
+          dropOffEvent: stubBoldMassIDDropOffEvent(),
+          pickUpEvent: stubBoldMassIDPickUpEvent(),
           recyclerEvent: stubDocumentEvent({
             label: RECYCLER,
             name: ACTOR,
@@ -110,7 +110,7 @@ describe('Waste Mass Is Unique Helpers E2E', () => {
         partialDocument: v2DocumentStub,
       });
 
-      const result = await fetchSimilarMassIdDocuments({
+      const result = await fetchSimilarMassIDDocuments({
         auditApiService,
         document: v2DocumentStub,
         eventsData,
@@ -173,7 +173,7 @@ describe('Waste Mass Is Unique Helpers E2E', () => {
         partialDocument: v1DocumentStub,
       });
 
-      const result = await fetchSimilarMassIdDocuments({
+      const result = await fetchSimilarMassIDDocuments({
         auditApiService,
         document: v2DocumentStub,
         eventsData,

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.spec.ts
@@ -2,8 +2,8 @@ import type { AuditApiService } from '@carrot-fndn/shared/methodologies/audit-ap
 
 import {
   BoldStubsBuilder,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentCategory } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -30,46 +30,46 @@ describe('waste-mass-is-unique.helpers', () => {
     mockCheckDuplicateDocuments.mockReset();
   });
 
-  describe('mapMassIdV2Query', () => {
+  describe('mapMassIDV2Query', () => {
     it('should create a valid query object with proper structure', () => {
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments()
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments()
         .build();
 
       const eventsData: helpers.EventsData = {
-        dropOffEvent: stubBoldMassIdDropOffEvent(),
-        pickUpEvent: stubBoldMassIdPickUpEvent(),
+        dropOffEvent: stubBoldMassIDDropOffEvent(),
+        pickUpEvent: stubBoldMassIDPickUpEvent(),
         recyclerEvent: stubDocumentEvent(),
         vehicleLicensePlate: 'ABC123',
         wasteGeneratorEvent: stubDocumentEvent(),
       };
 
-      const query = helpers.mapMassIdV2Query(massIdDocument, eventsData);
+      const query = helpers.mapMassIDV2Query(massIDDocument, eventsData);
 
       expect(query).toHaveProperty('match.$and');
       expect(query.match.$and).toBeInstanceOf(Array);
       expect(query.match.$and).toHaveLength(4);
       expect(query.match).toHaveProperty('category', MASS_ID);
-      expect(query.match).toHaveProperty('type', massIdDocument.type);
-      expect(query.match).toHaveProperty('subtype', massIdDocument.subtype);
+      expect(query.match).toHaveProperty('type', massIDDocument.type);
+      expect(query.match).toHaveProperty('subtype', massIDDocument.subtype);
     });
   });
 
   describe('createOldFormatQuery', () => {
     it('should create a valid query object with proper structure', () => {
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments()
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments()
         .build();
 
       const eventsData: helpers.EventsData = {
-        dropOffEvent: stubBoldMassIdDropOffEvent(),
-        pickUpEvent: stubBoldMassIdPickUpEvent(),
+        dropOffEvent: stubBoldMassIDDropOffEvent(),
+        pickUpEvent: stubBoldMassIDPickUpEvent(),
         recyclerEvent: stubDocumentEvent(),
         vehicleLicensePlate: 'ABC123',
         wasteGeneratorEvent: stubDocumentEvent(),
       };
 
-      const query = helpers.mapMassIdV1Query(massIdDocument, eventsData);
+      const query = helpers.mapMassIDV1Query(massIDDocument, eventsData);
 
       expect(query).toHaveProperty('match.$and');
       expect(query.match.category).toBe('Mass');
@@ -78,10 +78,10 @@ describe('waste-mass-is-unique.helpers', () => {
     });
   });
 
-  describe('fetchSimilarMassIdDocuments', () => {
+  describe('fetchSimilarMassIDDocuments', () => {
     it('should call API with both new and old format queries and combine results', async () => {
-      const { massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments()
+      const { massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments()
         .build();
 
       const newFormatDuplicates = [
@@ -97,16 +97,16 @@ describe('waste-mass-is-unique.helpers', () => {
         .mockResolvedValueOnce(oldFormatDuplicates);
 
       const eventsData: helpers.EventsData = {
-        dropOffEvent: stubBoldMassIdDropOffEvent(),
-        pickUpEvent: stubBoldMassIdPickUpEvent(),
+        dropOffEvent: stubBoldMassIDDropOffEvent(),
+        pickUpEvent: stubBoldMassIDPickUpEvent(),
         recyclerEvent: stubDocumentEvent(),
         vehicleLicensePlate: 'ABC123',
         wasteGeneratorEvent: stubDocumentEvent(),
       };
 
-      const result = await helpers.fetchSimilarMassIdDocuments({
+      const result = await helpers.fetchSimilarMassIDDocuments({
         auditApiService: mockAuditApiService as unknown as AuditApiService,
-        document: massIdDocument,
+        document: massIDDocument,
         eventsData,
       });
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.ts
@@ -50,7 +50,7 @@ export const createLicensePlateRegex = (
 export const createAuditApiService = (): AuditApiService =>
   new AuditApiService();
 
-export const mapMassIdV2Query = (
+export const mapMassIDV2Query = (
   document: Document,
   requiredData: EventsData,
 ) => {
@@ -119,7 +119,7 @@ export const mapMassIdV2Query = (
   };
 };
 
-export const mapMassIdV1Query = (document: Document, events: EventsData) => {
+export const mapMassIDV1Query = (document: Document, events: EventsData) => {
   const {
     dropOffEvent,
     pickUpEvent,
@@ -201,7 +201,7 @@ export const mapMassIdV1Query = (document: Document, events: EventsData) => {
   };
 };
 
-export const fetchSimilarMassIdDocuments = async ({
+export const fetchSimilarMassIDDocuments = async ({
   auditApiService,
   document,
   eventsData,
@@ -210,8 +210,8 @@ export const fetchSimilarMassIdDocuments = async ({
   document: Document;
   eventsData: EventsData;
 }): Promise<ApiDocumentCheckDuplicatesResponse[]> => {
-  const v2FormatQuery = mapMassIdV2Query(document, eventsData);
-  const v1FormatQuery = mapMassIdV1Query(document, eventsData);
+  const v2FormatQuery = mapMassIDV2Query(document, eventsData);
+  const v1FormatQuery = mapMassIDV1Query(document, eventsData);
 
   const [v2FormattedDuplicates, v1FormattedDuplicates] = await Promise.all([
     auditApiService.checkDuplicateDocuments(v2FormatQuery),

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.lambda.e2e.spec.ts
@@ -41,9 +41,9 @@ describe('WasteMassIsUniqueLambda E2E', () => {
         oldDuplicateDocuments,
         resultStatus,
       }) => {
-        const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-          .createMassIdDocuments()
-          .createMassIdAuditDocuments()
+        const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+          .createMassIDDocuments()
+          .createMassIDAuditDocuments()
           .build();
 
         mockCheckDuplicateDocuments
@@ -51,7 +51,7 @@ describe('WasteMassIsUniqueLambda E2E', () => {
           .mockResolvedValueOnce(oldDuplicateDocuments);
 
         prepareEnvironmentTestE2E(
-          [massIdAuditDocument, massIdDocument].map((_document) => ({
+          [massIDAuditDocument, massIDDocument].map((_document) => ({
             document: _document,
             documentKey: toDocumentKey({
               documentId: _document.id,
@@ -63,7 +63,7 @@ describe('WasteMassIsUniqueLambda E2E', () => {
         const response = (await wasteMassIsUniqueLambda(
           stubRuleInput({
             documentKeyPrefix,
-            parentDocumentId: massIdDocument.id,
+            parentDocumentId: massIDDocument.id,
           }),
           stubContext(),
           () => stubRuleResponse(),
@@ -77,9 +77,9 @@ describe('WasteMassIsUniqueLambda E2E', () => {
   describe('wasteMassIsUniqueErrorTestCases', () => {
     it.each(wasteMassIsUniqueErrorTestCases)(
       'should return $resultStatus when $scenario',
-      async ({ massIdAuditDocument, massIdDocument, resultStatus }) => {
+      async ({ massIDAuditDocument, massIDDocument, resultStatus }) => {
         prepareEnvironmentTestE2E(
-          [massIdAuditDocument, massIdDocument].map((_document) => ({
+          [massIDAuditDocument, massIDDocument].map((_document) => ({
             document: _document,
             documentKey: toDocumentKey({
               documentId: _document?.id,
@@ -91,7 +91,7 @@ describe('WasteMassIsUniqueLambda E2E', () => {
         const response = (await wasteMassIsUniqueLambda(
           stubRuleInput({
             documentKeyPrefix,
-            parentDocumentId: massIdDocument?.id ?? faker.string.uuid(),
+            parentDocumentId: massIDDocument?.id ?? faker.string.uuid(),
           }),
           stubContext(),
           () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.spec.ts
@@ -40,15 +40,15 @@ describe('WasteMassIsUniqueProcessor Rule', () => {
       }) => {
         const ruleInput = random<Required<RuleInput>>();
 
-        const { massIdDocument } = new BoldStubsBuilder()
-          .createMassIdDocuments()
+        const { massIDDocument } = new BoldStubsBuilder()
+          .createMassIDDocuments()
           .build();
 
         mockCheckDuplicateDocuments
           .mockResolvedValueOnce(newDuplicateDocuments)
           .mockResolvedValueOnce(oldDuplicateDocuments);
 
-        documentLoaderService.mockResolvedValueOnce(massIdDocument);
+        documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);
 
@@ -68,10 +68,10 @@ describe('WasteMassIsUniqueProcessor Rule', () => {
   describe('WasteMassIsUniqueProcessor Errors', () => {
     it.each(wasteMassIsUniqueErrorTestCases)(
       `should return $resultStatus when $scenario`,
-      async ({ massIdDocument, resultComment, resultStatus }) => {
+      async ({ massIDDocument, resultComment, resultStatus }) => {
         const ruleInput = random<Required<RuleInput>>();
 
-        documentLoaderService.mockResolvedValueOnce(massIdDocument);
+        documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.ts
@@ -35,7 +35,7 @@ import { WasteMassIsUniqueProcessorErrors } from './waste-mass-is-unique.errors'
 import {
   createAuditApiService,
   type EventsData,
-  fetchSimilarMassIdDocuments,
+  fetchSimilarMassIDDocuments,
 } from './waste-mass-is-unique.helpers';
 
 const { ACTOR, DROP_OFF, PICK_UP } = DocumentEventName;
@@ -128,7 +128,7 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
   protected async getRuleSubject(document: Document): Promise<RuleSubject> {
     const eventsData = this.collectRequiredEventsData(document);
 
-    const duplicateDocuments = await fetchSimilarMassIdDocuments({
+    const duplicateDocuments = await fetchSimilarMassIDDocuments({
       auditApiService: createAuditApiService(),
       document,
       eventsData,

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
@@ -1,6 +1,6 @@
 import {
   BoldStubsBuilder,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
@@ -64,24 +64,24 @@ export const wasteMassIsUniqueTestCases = [
 
 const processorErrors = new WasteMassIsUniqueProcessorErrors();
 
-const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-  .createMassIdDocuments()
-  .createMassIdAuditDocuments()
+const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+  .createMassIDDocuments()
+  .createMassIDAuditDocuments()
   .build();
 
 export const wasteMassIsUniqueErrorTestCases = [
   {
-    massIdAuditDocument,
-    massIdDocument: undefined,
+    massIDAuditDocument,
+    massIDDocument: undefined,
     resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: 'when the MassID document is missing',
   },
   {
-    massIdAuditDocument,
-    massIdDocument: {
-      ...massIdDocument,
-      externalEvents: massIdDocument.externalEvents?.filter(
+    massIDAuditDocument,
+    massIDDocument: {
+      ...massIDDocument,
+      externalEvents: massIDDocument.externalEvents?.filter(
         (event) => event.name !== DROP_OFF.toString(),
       ),
     },
@@ -90,10 +90,10 @@ export const wasteMassIsUniqueErrorTestCases = [
     scenario: `when the "${DROP_OFF}" event is missing`,
   },
   {
-    massIdAuditDocument,
-    massIdDocument: {
-      ...massIdDocument,
-      externalEvents: massIdDocument.externalEvents?.filter(
+    massIDAuditDocument,
+    massIDDocument: {
+      ...massIDDocument,
+      externalEvents: massIDDocument.externalEvents?.filter(
         (event) => event.name !== PICK_UP.toString(),
       ),
     },
@@ -102,10 +102,10 @@ export const wasteMassIsUniqueErrorTestCases = [
     scenario: `when the "${PICK_UP}" event is missing`,
   },
   {
-    massIdAuditDocument,
-    massIdDocument: {
-      ...massIdDocument,
-      externalEvents: massIdDocument.externalEvents?.filter(
+    massIDAuditDocument,
+    massIDDocument: {
+      ...massIDDocument,
+      externalEvents: massIDDocument.externalEvents?.filter(
         (event) => event.label !== WASTE_GENERATOR.toString(),
       ),
     },
@@ -114,10 +114,10 @@ export const wasteMassIsUniqueErrorTestCases = [
     scenario: `when the "${WASTE_GENERATOR}" event is missing`,
   },
   {
-    massIdAuditDocument,
-    massIdDocument: {
-      ...massIdDocument,
-      externalEvents: massIdDocument.externalEvents?.filter(
+    massIDAuditDocument,
+    massIDDocument: {
+      ...massIDDocument,
+      externalEvents: massIDDocument.externalEvents?.filter(
         (event) => event.label !== RECYCLER.toString(),
       ),
     },
@@ -126,14 +126,14 @@ export const wasteMassIsUniqueErrorTestCases = [
     scenario: `when the "${RECYCLER}" event is missing`,
   },
   {
-    massIdAuditDocument,
-    massIdDocument: {
-      ...massIdDocument,
+    massIDAuditDocument,
+    massIDDocument: {
+      ...massIDDocument,
       externalEvents: [
-        ...(massIdDocument.externalEvents ?? []).filter(
+        ...(massIDDocument.externalEvents ?? []).filter(
           (event) => event.name !== PICK_UP.toString(),
         ),
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           metadataAttributes: [[VEHICLE_LICENSE_PLATE, undefined]],
         }),
       ],

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.lambda.e2e.spec.ts
@@ -18,15 +18,15 @@ describe('WasteOriginIdentificationProcessor E2E', () => {
   it.each(wasteOriginIdentificationTestCases)(
     'should validate waste origin identification - $scenario',
     async ({ events, resultComment, resultStatus }) => {
-      const { massIdAuditDocument, massIdDocument } = new BoldStubsBuilder()
-        .createMassIdDocuments({
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({
           externalEventsMap: events,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .build();
 
       prepareEnvironmentTestE2E(
-        [massIdDocument, massIdAuditDocument].map((document) => ({
+        [massIDDocument, massIDAuditDocument].map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -38,7 +38,7 @@ describe('WasteOriginIdentificationProcessor E2E', () => {
       const response = (await wasteOriginIdentificationLambda(
         stubRuleInput({
           documentKeyPrefix,
-          parentDocumentId: massIdDocument.id,
+          parentDocumentId: massIDDocument.id,
         }),
         stubContext(),
         () => stubRuleResponse(),

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.processor.spec.ts
@@ -1,5 +1,5 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { stubBoldMassIdDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldMassIDDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   type RuleInput,
   type RuleOutput,
@@ -19,11 +19,11 @@ describe('WasteOriginIdentificationProcessor', () => {
     `should return $resultStatus when $scenario`,
     async ({ events, resultComment, resultStatus }) => {
       const ruleInput = random<Required<RuleInput>>();
-      const massIdDocument = stubBoldMassIdDocument({
+      const massIDDocument = stubBoldMassIDDocument({
         externalEventsMap: events,
       });
 
-      documentLoaderService.mockResolvedValueOnce(massIdDocument);
+      documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
       const ruleOutput = await ruleDataProcessor.process(ruleInput);
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
@@ -1,5 +1,5 @@
 import {
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
@@ -29,7 +29,7 @@ export const wasteOriginIdentificationTestCases = [
   {
     events: {
       [`${ACTOR}-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
       }),
     },
@@ -43,7 +43,7 @@ export const wasteOriginIdentificationTestCases = [
         label: WASTE_GENERATOR,
         name: ACTOR,
       }),
-      [PICK_UP]: stubBoldMassIdPickUpEvent({
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
       }),
     },
@@ -57,7 +57,7 @@ export const wasteOriginIdentificationTestCases = [
         label: WASTE_GENERATOR,
         name: ACTOR,
       }),
-      [PICK_UP]: stubBoldMassIdPickUpEvent(),
+      [PICK_UP]: stubBoldMassIDPickUpEvent(),
     },
     resultComment: RESULT_COMMENT.WASTE_ORIGIN_IDENTIFIED,
     resultStatus: RuleOutputStatus.PASSED,
@@ -66,7 +66,7 @@ export const wasteOriginIdentificationTestCases = [
   {
     events: {
       [`${ACTOR}-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIdPickUpEvent(),
+      [PICK_UP]: stubBoldMassIDPickUpEvent(),
     },
     resultComment: RESULT_COMMENT.MISSING_WASTE_GENERATOR_EVENT,
     resultStatus: RuleOutputStatus.FAILED,
@@ -82,7 +82,7 @@ export const wasteOriginIdentificationTestCases = [
         label: WASTE_GENERATOR,
         name: ACTOR,
       }),
-      [PICK_UP]: stubBoldMassIdPickUpEvent(),
+      [PICK_UP]: stubBoldMassIDPickUpEvent(),
     },
     resultComment: RESULT_COMMENT.MULTIPLE_WASTE_GENERATOR_EVENTS,
     resultStatus: RuleOutputStatus.FAILED,

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.lambda.e2e.spec.ts
@@ -36,7 +36,7 @@ describe('WeighingProcessor E2E', () => {
     async (testCase) => {
       const {
         accreditationDocuments,
-        massIdDocumentEvents,
+        massIDDocumentEvents,
         resultComment,
         resultStatus,
       } = testCase;
@@ -48,22 +48,22 @@ describe('WeighingProcessor E2E', () => {
       }
 
       const {
-        massIdAuditDocument,
-        massIdDocument,
+        massIDAuditDocument,
+        massIDDocument,
         participantsAccreditationDocuments,
       } = new BoldStubsBuilder()
-        .createMassIdDocuments({
-          externalEventsMap: massIdDocumentEvents,
+        .createMassIDDocuments({
+          externalEventsMap: massIDDocumentEvents,
         })
-        .createMassIdAuditDocuments()
+        .createMassIDAuditDocuments()
         .createMethodologyDocument()
         .createParticipantAccreditationDocuments(accreditationDocuments)
         .build();
 
       prepareEnvironmentTestE2E(
         [
-          massIdDocument,
-          massIdAuditDocument,
+          massIDDocument,
+          massIDAuditDocument,
           ...participantsAccreditationDocuments.values(),
         ].map((document) => ({
           document,
@@ -76,7 +76,7 @@ describe('WeighingProcessor E2E', () => {
 
       const response = (await weighingLambda(
         stubRuleInput({
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),
@@ -93,9 +93,9 @@ describe('WeighingProcessor E2E', () => {
   describe('WeighingProcessorErrors', () => {
     it.each(weighingErrorTestCases)(
       'should return $resultStatus when $scenario',
-      async ({ documents, massIdAuditDocument, resultStatus }) => {
+      async ({ documents, massIDAuditDocument, resultStatus }) => {
         prepareEnvironmentTestE2E(
-          [...documents, massIdAuditDocument].map((document) => ({
+          [...documents, massIDAuditDocument].map((document) => ({
             document,
             documentKey: toDocumentKey({
               documentId: document.id,
@@ -106,7 +106,7 @@ describe('WeighingProcessor E2E', () => {
 
         const response = (await weighingLambda(
           stubRuleInput({
-            documentId: massIdAuditDocument.id,
+            documentId: massIDAuditDocument.id,
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.spec.ts
@@ -34,7 +34,7 @@ describe('WeighingProcessor', () => {
       async (testCase) => {
         const {
           accreditationDocuments,
-          massIdDocumentEvents,
+          massIDDocumentEvents,
           resultComment,
           resultStatus,
         } = testCase;
@@ -47,8 +47,8 @@ describe('WeighingProcessor', () => {
 
         const { ruleInput, ruleOutput } = await createRuleTestFixture({
           accreditationDocuments,
-          massIdDocumentsParams: {
-            externalEventsMap: massIdDocumentEvents,
+          massIDDocumentsParams: {
+            externalEventsMap: massIDDocumentEvents,
           },
           ruleDataProcessor,
           spyOnDocumentQueryServiceLoad,
@@ -69,17 +69,17 @@ describe('WeighingProcessor', () => {
       'should return $resultStatus when $scenario',
       async ({
         documents,
-        massIdAuditDocument,
+        massIDAuditDocument,
         resultComment,
         resultStatus,
       }) => {
-        const allDocuments = [massIdAuditDocument, ...documents];
+        const allDocuments = [massIDAuditDocument, ...documents];
 
-        spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+        spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
         const ruleInput = {
           ...random<Required<RuleInput>>(),
-          documentId: massIdAuditDocument.id,
+          documentId: massIDAuditDocument.id,
         };
 
         const ruleOutput = await ruleDataProcessor.process(ruleInput);

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -54,12 +54,12 @@ import {
 } from './weighing.helpers';
 
 interface DocumentPair {
-  massIdDocument: Document;
+  massIDDocument: Document;
   recyclerAccreditationDocument: Document;
 }
 
 interface RuleSubject {
-  massIdDocumentId: NonEmptyString;
+  massIDDocumentId: NonEmptyString;
   recyclerAccreditationDocument: Document;
   weighingEvents: DocumentEvent[];
 }
@@ -133,7 +133,7 @@ export class WeighingProcessor extends RuleDataProcessor {
   }
 
   protected async evaluateResult({
-    massIdDocumentId,
+    massIDDocumentId,
     recyclerAccreditationDocument,
     weighingEvents,
   }: RuleSubject): Promise<EvaluateResultOutput> {
@@ -186,7 +186,7 @@ export class WeighingProcessor extends RuleDataProcessor {
 
     const scaleTicketValidationResult = await this.validateScaleTicket({
       expectedNetWeight: weighingValues.eventValue,
-      massIdDocumentId,
+      massIDDocumentId,
       scaleTicketConfig,
       weighingEvent,
     });
@@ -227,13 +227,13 @@ export class WeighingProcessor extends RuleDataProcessor {
   }
 
   protected getRuleSubject({
-    massIdDocument,
+    massIDDocument,
     recyclerAccreditationDocument,
   }: DocumentPair): RuleSubject {
-    const weighingEvents = getWeighingEvents(massIdDocument);
+    const weighingEvents = getWeighingEvents(massIDDocument);
 
     return {
-      massIdDocumentId: massIdDocument.id,
+      massIDDocumentId: massIDDocument.id,
       recyclerAccreditationDocument,
       weighingEvents,
     };
@@ -241,12 +241,12 @@ export class WeighingProcessor extends RuleDataProcessor {
 
   protected async validateScaleTicket({
     expectedNetWeight,
-    massIdDocumentId,
+    massIDDocumentId,
     scaleTicketConfig,
     weighingEvent,
   }: {
     expectedNetWeight: number | undefined;
-    massIdDocumentId: NonEmptyString;
+    massIDDocumentId: NonEmptyString;
     scaleTicketConfig: MethodologyAdditionalVerification | undefined;
     weighingEvent: DocumentEvent;
   }): Promise<{
@@ -259,7 +259,7 @@ export class WeighingProcessor extends RuleDataProcessor {
 
     const textExtractorInput = this.buildScaleTicketTextExtractorInput(
       weighingEvent,
-      massIdDocumentId,
+      massIDDocumentId,
     );
 
     const scaleTicketValidation = await verifyScaleTicketNetWeight({
@@ -283,7 +283,7 @@ export class WeighingProcessor extends RuleDataProcessor {
 
   private buildScaleTicketTextExtractorInput(
     weighingEvent: DocumentEvent,
-    massIdDocumentId: NonEmptyString,
+    massIDDocumentId: NonEmptyString,
   ): TextExtractionInput | undefined {
     const scaleTicketAttachment = weighingEvent.attachments?.find(
       (attachment) =>
@@ -306,7 +306,7 @@ export class WeighingProcessor extends RuleDataProcessor {
     }
 
     const key = getAttachmentS3Key(
-      massIdDocumentId,
+      massIDDocumentId,
       scaleTicketAttachment.attachmentId,
     );
 
@@ -322,7 +322,7 @@ export class WeighingProcessor extends RuleDataProcessor {
     documentQuery: DocumentQuery<Document>,
   ): Promise<DocumentPair> {
     let recyclerAccreditationDocument: Document | undefined;
-    let massIdDocument: Document | undefined;
+    let massIDDocument: Document | undefined;
 
     await documentQuery.iterator().each(({ document }) => {
       const documentRelation = mapDocumentRelation(document);
@@ -335,7 +335,7 @@ export class WeighingProcessor extends RuleDataProcessor {
       }
 
       if (MASS_ID.matches(documentRelation)) {
-        massIdDocument = document;
+        massIDDocument = document;
       }
     });
 
@@ -346,12 +346,12 @@ export class WeighingProcessor extends RuleDataProcessor {
     );
 
     this.validateOrThrow(
-      isNil(massIdDocument),
+      isNil(massIDDocument),
       this.processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
     );
 
     return {
-      massIdDocument: massIdDocument as Document,
+      massIDDocument: massIDDocument as Document,
       recyclerAccreditationDocument: recyclerAccreditationDocument as Document,
     };
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -2,7 +2,7 @@ import {
   BoldStubsBuilder,
   type MetadataAttributeParameter,
   stubBoldAccreditationResultEvent,
-  stubBoldMassIdWeighingEvent,
+  stubBoldMassIDWeighingEvent,
   stubBoldMonitoringSystemsAndEquipmentEvent,
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
@@ -14,7 +14,7 @@ import {
   DocumentEventName,
   DocumentEventScaleType,
   DocumentEventWeighingCaptureMethod,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
@@ -48,7 +48,7 @@ const {
   VEHICLE_LICENSE_PLATE,
   WEIGHING_CAPTURE_METHOD,
 } = DocumentEventAttributeName;
-const { RECYCLER } = MassIdDocumentActorType;
+const { RECYCLER } = MassIDDocumentActorType;
 const { KILOGRAM } = MethodologyDocumentEventAttributeFormat;
 
 const scaleType = random<DocumentEventScaleType>();
@@ -154,7 +154,7 @@ const createWeighingEvent = (
   eventValueOverride: number = eventValue,
   participant?: ReturnType<typeof stubParticipant>,
 ): DocumentEvent =>
-  stubBoldMassIdWeighingEvent({
+  stubBoldMassIDWeighingEvent({
     metadataAttributes: overrideAttributes,
     partialDocumentEvent: {
       ...(participant && { participant }),
@@ -232,7 +232,7 @@ const createTwoStepWeighingEvents = (
 
 export const weighingTestCases = [
   {
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: undefined,
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.NO_WEIGHING_EVENTS,
@@ -240,10 +240,10 @@ export const weighingTestCases = [
     scenario: `the MassID document does not have ${WEIGHING} events`,
   },
   {
-    massIdDocumentEvents: {
-      [`${WEIGHING}-1`]: stubBoldMassIdWeighingEvent(),
-      [`${WEIGHING}-2`]: stubBoldMassIdWeighingEvent(),
-      [`${WEIGHING}-3`]: stubBoldMassIdWeighingEvent(),
+    massIDDocumentEvents: {
+      [`${WEIGHING}-1`]: stubBoldMassIDWeighingEvent(),
+      [`${WEIGHING}-2`]: stubBoldMassIDWeighingEvent(),
+      [`${WEIGHING}-3`]: stubBoldMassIDWeighingEvent(),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.MORE_THAN_TWO_WEIGHING_EVENTS,
     resultStatus: RuleOutputStatus.FAILED,
@@ -260,8 +260,8 @@ export const weighingTestCases = [
         },
       ],
     ]),
-    massIdDocumentEvents: {
-      [WEIGHING]: stubBoldMassIdWeighingEvent({
+    massIDDocumentEvents: {
+      [WEIGHING]: stubBoldMassIDWeighingEvent({
         metadataAttributes: validWeighingAttributes,
         partialDocumentEvent: {
           value: eventValue,
@@ -274,7 +274,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [CONTAINER_CAPACITY, undefined],
@@ -287,7 +287,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [CONTAINER_TYPE, DocumentEventContainerType.BAG],
@@ -310,7 +310,7 @@ export const weighingTestCases = [
         },
       ],
     ]),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [CONTAINER_TYPE, DocumentEventContainerType.BAG],
@@ -323,7 +323,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [CONTAINER_QUANTITY, 1],
@@ -337,7 +337,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [[GROSS_WEIGHT, undefined]]),
       ),
@@ -348,7 +348,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(validWeighingAttributes, 0),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.EVENT_VALUE(0),
@@ -357,7 +357,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [[TARE, undefined]]),
       ),
@@ -368,7 +368,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [[DESCRIPTION, undefined]]),
       ),
@@ -379,7 +379,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [[DESCRIPTION, '']]),
       ),
@@ -390,7 +390,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
@@ -407,7 +407,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [WEIGHING_CAPTURE_METHOD, weighingCaptureMethodMismatch],
@@ -423,7 +423,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [VEHICLE_LICENSE_PLATE, undefined],
@@ -436,7 +436,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [[CONTAINER_TYPE, undefined]]),
       ),
@@ -447,7 +447,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(validWeighingAttributes),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
@@ -458,7 +458,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withScaleTicketVerification: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(validWeighingAttributes),
     },
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_SCALE_TICKET_VALIDATION(
@@ -471,7 +471,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withScaleTicketVerification: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(validWeighingAttributes),
     },
     resultComment: 'Scale ticket mismatch',
@@ -483,7 +483,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withContainerCapacityException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [CONTAINER_CAPACITY, undefined],
@@ -500,7 +500,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: twoStepScaleType,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [`${WEIGHING}-2`]: createWeighingEvent(
         mergeAttributes(validWeighingAttributesWithoutQuantity, [
           [SCALE_TYPE, twoStepScaleType],
@@ -528,7 +528,7 @@ export const weighingTestCases = [
       scaleTypeValue: twoStepScaleType,
       withContainerCapacityException: true,
     }),
-    massIdDocumentEvents: createTwoStepWeighingEvents(
+    massIDDocumentEvents: createTwoStepWeighingEvents(
       twoStepScaleType,
       twoStepWeighingEventParticipant,
       [[CONTAINER_CAPACITY, undefined]],
@@ -543,7 +543,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: twoStepScaleType,
     }),
-    massIdDocumentEvents: createTwoStepWeighingEvents(
+    massIDDocumentEvents: createTwoStepWeighingEvents(
       twoStepScaleType,
       twoStepWeighingEventParticipant,
     ),
@@ -555,7 +555,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: twoStepScaleType,
     }),
-    massIdDocumentEvents: createTwoStepWeighingEvents(
+    massIDDocumentEvents: createTwoStepWeighingEvents(
       twoStepScaleType,
       twoStepWeighingEventParticipant,
       [],
@@ -573,7 +573,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: DocumentEventScaleType.CONVEYOR_BELT_SCALE,
     }),
-    massIdDocumentEvents: createTwoStepWeighingEvents(
+    massIDDocumentEvents: createTwoStepWeighingEvents(
       DocumentEventScaleType.CONVEYOR_BELT_SCALE,
       twoStepWeighingEventParticipant,
     ),
@@ -587,7 +587,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: twoStepScaleType,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [`${WEIGHING}-2`]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [SCALE_TYPE, twoStepScaleType],
@@ -615,7 +615,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       scaleTypeValue: scaleType,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         mergeAttributes(validWeighingAttributes, [
           [
@@ -632,7 +632,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(validWeighingAttributes, 98),
     },
     resultComment: INVALID_RESULT_COMMENTS.NET_WEIGHT_CALCULATION({
@@ -649,7 +649,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -667,7 +667,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -685,7 +685,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -703,7 +703,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(
         [
           [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
@@ -730,7 +730,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -748,7 +748,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -766,7 +766,7 @@ export const weighingTestCases = [
     accreditationDocuments: stubBaseAccreditationDocuments({
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -787,7 +787,7 @@ export const weighingTestCases = [
       tareExceptionValidUntil: '2020-01-01T00:00:00Z',
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -806,7 +806,7 @@ export const weighingTestCases = [
       tareExceptionValidUntil: 'invalid-date-format',
       withTareException: true,
     }),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -822,7 +822,7 @@ export const weighingTestCases = [
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),
-    massIdDocumentEvents: {
+    massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent([
         [WEIGHING_CAPTURE_METHOD, DocumentEventWeighingCaptureMethod.DIGITAL],
         [SCALE_TYPE, scaleType],
@@ -841,12 +841,12 @@ export const weighingTestCases = [
 const processorErrors = new WeighingProcessorErrors();
 
 const {
-  massIdAuditDocument,
-  massIdDocument,
+  massIDAuditDocument,
+  massIDDocument,
   participantsAccreditationDocuments,
 } = new BoldStubsBuilder()
-  .createMassIdDocuments()
-  .createMassIdAuditDocuments()
+  .createMassIDDocuments()
+  .createMassIDAuditDocuments()
   .createMethodologyDocument()
   .createParticipantAccreditationDocuments()
   .build();
@@ -854,14 +854,14 @@ const {
 export const weighingErrorTestCases = [
   {
     documents: [...participantsAccreditationDocuments.values()],
-    massIdAuditDocument,
+    massIDAuditDocument,
     resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the MassID document was not found`,
   },
   {
-    documents: [massIdDocument],
-    massIdAuditDocument,
+    documents: [massIDDocument],
+    massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
     resultStatus: RuleOutputStatus.FAILED,

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -3,12 +3,12 @@ import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   stubDocument,
   stubDocumentEvent,
-  stubMassIdDocument,
+  stubMassIDDocument,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubArray } from '@carrot-fndn/shared/testing';
 import { getYear } from 'date-fns';
@@ -27,7 +27,7 @@ const {
   PICK_UP,
   RULES_METADATA,
 } = DocumentEventName;
-const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
+const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
 
 const testEmissionAndCompostingMetricsEvent = (
   documentYear: number,
@@ -235,7 +235,7 @@ describe('Document getters', () => {
   describe('getParticipantActorType', () => {
     it(`should return "${WASTE_GENERATOR}" when the event is a pick up at the source`, () => {
       const sourcePickUpEvent = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [
           sourcePickUpEvent,
           stubDocumentEvent({ name: DROP_OFF }),
@@ -254,7 +254,7 @@ describe('Document getters', () => {
 
     it(`should return "${PROCESSOR}" when the event is a drop off at processor`, () => {
       const processorDropOffEvent = stubDocumentEvent({ name: DROP_OFF });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [
           stubDocumentEvent({ name: PICK_UP }),
           processorDropOffEvent,
@@ -273,7 +273,7 @@ describe('Document getters', () => {
 
     it(`should return "${PROCESSOR}" when the event is a pick up at processor`, () => {
       const processorPickUpEvent = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [
           stubDocumentEvent({ name: PICK_UP }),
           stubDocumentEvent({ name: DROP_OFF }),
@@ -292,7 +292,7 @@ describe('Document getters', () => {
 
     it(`should return "${RECYCLER}" when the event is a drop off at recycler`, () => {
       const recyclerDropOffEvent = stubDocumentEvent({ name: DROP_OFF });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [
           stubDocumentEvent({ name: PICK_UP }),
           stubDocumentEvent({ name: DROP_OFF }),
@@ -311,7 +311,7 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no pick up events', () => {
       const dropOffEvent = stubDocumentEvent({ name: DROP_OFF });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [dropOffEvent],
       });
 
@@ -325,7 +325,7 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no drop off events', () => {
       const pickUpEvent = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [pickUpEvent],
       });
 
@@ -339,7 +339,7 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no external events', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: undefined,
       });
 
@@ -353,7 +353,7 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has empty external events array', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [],
       });
 
@@ -368,7 +368,7 @@ describe('Document getters', () => {
     it('should return undefined when the document has non-array external events', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
       const document = {
-        ...stubMassIdDocument(),
+        ...stubMassIDDocument(),
         externalEvents: 'not an array',
       } as unknown as Document;
 
@@ -382,7 +382,7 @@ describe('Document getters', () => {
 
     it('should return undefined when the event is neither a pick-up nor a drop-off event', () => {
       const otherEvent = stubDocumentEvent({ name: ACCREDITATION_CONTEXT });
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [
           stubDocumentEvent({ name: PICK_UP }),
           stubDocumentEvent({ name: DROP_OFF }),
@@ -402,7 +402,7 @@ describe('Document getters', () => {
   describe('getDocumentEventById', () => {
     it('should return the document event by id', () => {
       const documentEvent = stubDocumentEvent();
-      const document = stubMassIdDocument({
+      const document = stubMassIDDocument({
         externalEvents: [documentEvent],
       });
 
@@ -412,7 +412,7 @@ describe('Document getters', () => {
     });
 
     it('should return undefined when the document event is not found', () => {
-      const document = stubMassIdDocument();
+      const document = stubMassIDDocument();
 
       const result = getDocumentEventById(document, 'non-existent-id');
 

--- a/libs/shared/methodologies/bold/getters/src/document.getters.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.ts
@@ -4,7 +4,7 @@ import {
   type DocumentEvent,
   DocumentEventAttributeName,
   DocumentEventName,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { NonZeroPositiveInt } from '@carrot-fndn/shared/types';
 
@@ -12,7 +12,7 @@ import { getEventAttributeValue } from './event.getters';
 
 const { DROP_OFF, EMISSION_AND_COMPOSTING_METRICS, PICK_UP, RULES_METADATA } =
   DocumentEventName;
-const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIdDocumentActorType;
+const { PROCESSOR, RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
 
 interface LastYearEmissionAndCompostingMetricsEventParameters {
   documentWithEmissionAndCompostingMetricsEvent: Document;
@@ -62,7 +62,7 @@ export const getParticipantActorType = ({
 }: {
   document: Document;
   event: DocumentEvent;
-}): MassIdDocumentActorType | undefined => {
+}): MassIDDocumentActorType | undefined => {
   const events = document.externalEvents;
 
   if (!isNonEmptyArray(events)) {

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id-audit.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id-audit.stubs.ts
@@ -23,7 +23,7 @@ const { PASSED } = RuleOutputStatus;
 
 const resultEventName = `Result: MassID ${PASSED}`;
 
-const boldMassIdAuditExternalEventsMap: Map<string, DocumentEvent> = new Map([
+const boldMassIDAuditExternalEventsMap: Map<string, DocumentEvent> = new Map([
   [
     resultEventName,
     stubDocumentEventWithMetadataAttributes(
@@ -35,13 +35,13 @@ const boldMassIdAuditExternalEventsMap: Map<string, DocumentEvent> = new Map([
   ],
 ]);
 
-export const stubBoldMassIdAuditDocument = ({
+export const stubBoldMassIDAuditDocument = ({
   externalEventsMap,
   partialDocument,
 }: StubBoldDocumentParameters = {}): Document => {
   const mergedEventsMap = isNil(externalEventsMap)
-    ? boldMassIdAuditExternalEventsMap
-    : mergeEventsMaps(boldMassIdAuditExternalEventsMap, externalEventsMap);
+    ? boldMassIDAuditExternalEventsMap
+    : mergeEventsMaps(boldMassIDAuditExternalEventsMap, externalEventsMap);
 
   return {
     ...stubDocument(

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-mass-id.stubs.ts
@@ -11,7 +11,7 @@ import {
   DocumentEventVehicleType,
   DocumentEventWeighingCaptureMethod,
   DocumentType,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MeasurementUnit,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -100,7 +100,7 @@ const defaultPickUpAttributes: MetadataAttributeParameter[] = [
   [VEHICLE_TYPE, random<DocumentEventVehicleType>()],
 ];
 
-export const stubBoldMassIdPickUpEvent = ({
+export const stubBoldMassIDPickUpEvent = ({
   metadataAttributes,
   partialDocumentEvent,
 }: StubBoldDocumentEventParameters = {}): DocumentEvent =>
@@ -126,7 +126,7 @@ const defaultTransportManifestAttributes: MetadataAttributeParameter[] = [
   },
 ];
 
-export const stubBoldMassIdTransportManifestEvent = ({
+export const stubBoldMassIDTransportManifestEvent = ({
   metadataAttributes,
   partialDocumentEvent,
   withExemptionJustification,
@@ -192,7 +192,7 @@ const defaultWeighingAttributes: MetadataAttributeParameter[] = [
   },
 ];
 
-export const stubBoldMassIdWeighingEvent = ({
+export const stubBoldMassIDWeighingEvent = ({
   metadataAttributes,
   partialDocumentEvent,
 }: StubBoldDocumentEventParameters = {}): DocumentEvent =>
@@ -213,7 +213,7 @@ const defaultDropOffAttributes: MetadataAttributeParameter[] = [
   [CAPTURED_GPS_LONGITUDE, faker.location.longitude()],
 ];
 
-export const stubBoldMassIdDropOffEvent = ({
+export const stubBoldMassIDDropOffEvent = ({
   metadataAttributes,
   partialDocumentEvent,
 }: StubBoldDocumentEventParameters = {}): DocumentEvent =>
@@ -239,7 +239,7 @@ const defaultRecyclingManifestAttributes: MetadataAttributeParameter[] = [
   },
 ];
 
-export const stubBoldMassIdRecyclingManifestEvent = ({
+export const stubBoldMassIDRecyclingManifestEvent = ({
   metadataAttributes,
   partialDocumentEvent,
   withExemptionJustification,
@@ -269,7 +269,7 @@ export const stubBoldMassIdRecyclingManifestEvent = ({
   );
 };
 
-export const stubBoldMassIdRecycledEvent = ({
+export const stubBoldMassIDRecycledEvent = ({
   metadataAttributes,
   partialDocumentEvent,
 }: StubBoldDocumentEventParameters = {}): DocumentEvent =>
@@ -287,7 +287,7 @@ const defaultSortingAttributes: MetadataAttributeParameter[] = [
   [SORTING_FACTOR, faker.number.float({ max: 1, min: 0 })],
 ];
 
-export const stubBoldMassIdSortingEvent = ({
+export const stubBoldMassIDSortingEvent = ({
   metadataAttributes,
   partialDocumentEvent,
 }: StubBoldDocumentEventParameters = {}): DocumentEvent =>
@@ -300,51 +300,51 @@ export const stubBoldMassIdSortingEvent = ({
     mergeMetadataAttributes(defaultSortingAttributes, metadataAttributes),
   );
 
-export type BoldMassIdExternalEventsMap = Map<
+export type BoldMassIDExternalEventsMap = Map<
   DocumentEventName | string,
   DocumentEvent
 >;
-export type BoldMassIdExternalEventsObject = Partial<
+export type BoldMassIDExternalEventsObject = Partial<
   Record<DocumentEventName, DocumentEvent>
 >;
 
-export const boldMassIdExternalEventsMap: BoldMassIdExternalEventsMap = new Map(
+export const boldMassIDExternalEventsMap: BoldMassIDExternalEventsMap = new Map(
   [
-    [PICK_UP, stubBoldMassIdPickUpEvent()],
+    [PICK_UP, stubBoldMassIDPickUpEvent()],
     [
       TRANSPORT_MANIFEST,
-      stubBoldMassIdTransportManifestEvent({
+      stubBoldMassIDTransportManifestEvent({
         withExemptionJustification: false,
       }),
     ],
-    [WEIGHING, stubBoldMassIdWeighingEvent()],
+    [WEIGHING, stubBoldMassIDWeighingEvent()],
     // eslint-disable-next-line perfectionist/sort-maps
-    [DROP_OFF, stubBoldMassIdDropOffEvent()],
-    [SORTING, stubBoldMassIdSortingEvent()],
+    [DROP_OFF, stubBoldMassIDDropOffEvent()],
+    [SORTING, stubBoldMassIDSortingEvent()],
     // eslint-disable-next-line perfectionist/sort-maps
     [
       RECYCLING_MANIFEST,
-      stubBoldMassIdRecyclingManifestEvent({
+      stubBoldMassIDRecyclingManifestEvent({
         withExemptionJustification: false,
       }),
     ],
     // eslint-disable-next-line perfectionist/sort-maps
-    [RECYCLED, stubBoldMassIdRecycledEvent()],
+    [RECYCLED, stubBoldMassIDRecycledEvent()],
   ],
 );
 
-export const stubBoldMassIdDocument = ({
+export const stubBoldMassIDDocument = ({
   externalEventsMap,
   partialDocument,
 }: StubBoldDocumentParameters = {}): Document => {
   const mergedEventsMap = isNil(externalEventsMap)
-    ? boldMassIdExternalEventsMap
-    : mergeEventsMaps(boldMassIdExternalEventsMap, externalEventsMap);
+    ? boldMassIDExternalEventsMap
+    : mergeEventsMaps(boldMassIDExternalEventsMap, externalEventsMap);
 
   return {
     ...stubDocument(
       {
-        subtype: stubEnumValue(MassIdOrganicSubtype),
+        subtype: stubEnumValue(MassIDOrganicSubtype),
         ...partialDocument,
         category: MASS_ID,
         currentValue: isNil(partialDocument?.currentValue)

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-participant-accreditation.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-participant-accreditation.stubs.ts
@@ -3,7 +3,7 @@ import {
   type Document,
   DocumentEventAccreditationStatus,
   type DocumentEventScaleType,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -109,7 +109,7 @@ const defaultRecyclingBaselinesEventMetadataAttributes: MetadataAttributeParamet
   [
     [
       BASELINES,
-      { [random<MassIdOrganicSubtype>()]: random<MethodologyBaseline>() },
+      { [random<MassIDOrganicSubtype>()]: random<MethodologyBaseline>() },
     ],
   ];
 

--- a/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
+++ b/libs/shared/methodologies/bold/testing/src/builders/bold-stub.builder.ts
@@ -10,7 +10,7 @@ import {
   type DocumentRelation,
   DocumentSubtype,
   DocumentType,
-  MassIdDocumentActorType,
+  MassIDDocumentActorType,
   MethodologyDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
@@ -33,11 +33,11 @@ import {
 } from '../stubs';
 import { stubBoldCertificateDocument } from './bold-certificate.stubs';
 import { stubBoldCreditOrderDocument } from './bold-credit-order.stubs';
-import { stubBoldMassIdAuditDocument } from './bold-mass-id-audit.stubs';
+import { stubBoldMassIDAuditDocument } from './bold-mass-id-audit.stubs';
 import {
-  stubBoldMassIdDocument,
-  stubBoldMassIdDropOffEvent,
-  stubBoldMassIdPickUpEvent,
+  stubBoldMassIDDocument,
+  stubBoldMassIDDropOffEvent,
+  stubBoldMassIDPickUpEvent,
 } from './bold-mass-id.stubs';
 import { stubBoldMethodologyDefinitionDocument } from './bold-methodology-definition.stubs';
 import { stubBoldAccreditationDocument } from './bold-participant-accreditation.stubs';
@@ -58,10 +58,10 @@ const { METHODOLOGY_SLUG } = DocumentEventAttributeName;
 
 export interface BoldStubsBuilderOptions {
   count?: number;
-  massIdActorParticipants?: Map<string, MethodologyParticipant>;
-  massIdAuditDocumentIds?: string[];
-  massIdCertificateDocumentIds?: string[];
-  massIdDocumentIds?: string[];
+  massIDActorParticipants?: Map<string, MethodologyParticipant>;
+  massIDAuditDocumentIds?: string[];
+  massIDCertificateDocumentIds?: string[];
+  massIDDocumentIds?: string[];
   methodologyActorParticipants?: Map<string, MethodologyParticipant>;
   methodologyName?: BoldMethodologyName;
 }
@@ -69,27 +69,27 @@ export interface BoldStubsBuilderOptions {
 export interface BoldStubsBuilderResult {
   boldMethodologyName: BoldMethodologyName;
   creditOrderDocument: Document;
-  massIdActorParticipants: Map<string, MethodologyParticipant>;
-  massIdActorParticipantsAddresses: Map<string, MethodologyAddress>;
-  massIdAuditDocument: Document;
-  massIdAuditDocuments: Document[];
-  massIdAuditIds: string[];
-  massIdCertificateDocument: Document;
-  massIdCertificateDocuments: Document[];
-  massIdDocument: Document;
-  massIdDocumentIds: string[];
-  massIdDocuments: Document[];
+  massIDActorParticipants: Map<string, MethodologyParticipant>;
+  massIDActorParticipantsAddresses: Map<string, MethodologyAddress>;
+  massIDAuditDocument: Document;
+  massIDAuditDocuments: Document[];
+  massIDAuditIds: string[];
+  massIDCertificateDocument: Document;
+  massIDCertificateDocuments: Document[];
+  massIDDocument: Document;
+  massIDDocumentIds: string[];
+  massIDDocuments: Document[];
   methodologyActorParticipants: Map<string, MethodologyParticipant>;
   methodologyDocument: Document | undefined;
   participantsAccreditationDocuments: Map<string, Document>;
 }
 
 export const MASS_ID_ACTOR_PARTICIPANTS = [
-  MassIdDocumentActorType.HAULER,
-  MassIdDocumentActorType.INTEGRATOR,
-  MassIdDocumentActorType.PROCESSOR,
-  MassIdDocumentActorType.RECYCLER,
-  MassIdDocumentActorType.WASTE_GENERATOR,
+  MassIDDocumentActorType.HAULER,
+  MassIDDocumentActorType.INTEGRATOR,
+  MassIDDocumentActorType.PROCESSOR,
+  MassIDDocumentActorType.RECYCLER,
+  MassIDDocumentActorType.WASTE_GENERATOR,
 ] as const;
 
 export const METHODOLOGY_ACTOR_PARTICIPANTS = [
@@ -107,11 +107,11 @@ const MASS_ID_CERTIFICATE_BY_METHODOLOGY_NAME = {
 export class BoldStubsBuilder {
   private _creditOrderDocument?: Document;
 
-  private _massIdAuditDocuments: Document[] = [];
+  private _massIDAuditDocuments: Document[] = [];
 
-  private _massIdCertificateDocuments: Document[] = [];
+  private _massIDCertificateDocuments: Document[] = [];
 
-  private _massIdDocuments: Document[] = [];
+  private _massIDDocuments: Document[] = [];
 
   private readonly actorsCoordinates: Map<
     string,
@@ -124,24 +124,24 @@ export class BoldStubsBuilder {
 
   private creditOrderRelation?: DocumentRelation;
 
-  private readonly massIdActorParticipants: Map<string, MethodologyParticipant>;
+  private readonly massIDActorParticipants: Map<string, MethodologyParticipant>;
 
-  private readonly massIdActorParticipantsAddresses: Map<
+  private readonly massIDActorParticipantsAddresses: Map<
     string,
     MethodologyAddress
   >;
 
-  private massIdAuditDocumentIds: string[];
+  private massIDAuditDocumentIds: string[];
 
-  private massIdAuditRelations: DocumentRelation[] = [];
+  private massIDAuditRelations: DocumentRelation[] = [];
 
-  private massIdCertificateDocumentIds: string[];
+  private massIDCertificateDocumentIds: string[];
 
-  private massIdCertificateDocumentRelations: DocumentRelation[] = [];
+  private massIDCertificateDocumentRelations: DocumentRelation[] = [];
 
-  private massIdDocumentIds: string[];
+  private massIDDocumentIds: string[];
 
-  private massIdRelations: DocumentRelation[] = [];
+  private massIDRelations: DocumentRelation[] = [];
 
   private readonly methodologyActorParticipants: Map<
     string,
@@ -166,20 +166,20 @@ export class BoldStubsBuilder {
     this.boldMethodologyName =
       options.methodologyName ?? random<BoldMethodologyName>();
 
-    this.massIdDocumentIds =
-      options.massIdDocumentIds ??
+    this.massIDDocumentIds =
+      options.massIDDocumentIds ??
       Array.from({ length: this.count }, () => faker.string.uuid());
 
-    this.massIdAuditDocumentIds =
-      options.massIdAuditDocumentIds ??
+    this.massIDAuditDocumentIds =
+      options.massIDAuditDocumentIds ??
       Array.from({ length: this.count }, () => faker.string.uuid());
 
-    this.massIdCertificateDocumentIds =
-      options.massIdCertificateDocumentIds ??
+    this.massIDCertificateDocumentIds =
+      options.massIDCertificateDocumentIds ??
       Array.from({ length: this.count }, () => faker.string.uuid());
 
-    this.massIdActorParticipants = this.initializeMassIdActorParticipants(
-      options.massIdActorParticipants,
+    this.massIDActorParticipants = this.initializeMassIDActorParticipants(
+      options.massIDActorParticipants,
     );
 
     this.methodologyActorParticipants =
@@ -187,22 +187,22 @@ export class BoldStubsBuilder {
         options.methodologyActorParticipants,
       );
     this.actorsCoordinates = this.initializeActorsCoordinates();
-    this.massIdActorParticipantsAddresses = this.initializeActorAddresses();
+    this.massIDActorParticipantsAddresses = this.initializeActorAddresses();
 
-    this.massIdRelations = this.createMassIdRelations();
-    this.massIdCertificateDocumentRelations =
-      this.createMassIdCertificateDocumentRelations();
-    this.massIdAuditRelations = this.createMassIdAuditRelations();
+    this.massIDRelations = this.createMassIDRelations();
+    this.massIDCertificateDocumentRelations =
+      this.createMassIDCertificateDocumentRelations();
+    this.massIDAuditRelations = this.createMassIDAuditRelations();
   }
 
-  addMassIdCertificateDocumentRelationsToMassIdAuditDocuments(): void {
-    this._massIdAuditDocuments = this._massIdAuditDocuments.map(
+  addMassIDCertificateDocumentRelationsToMassIDAuditDocuments(): void {
+    this._massIDAuditDocuments = this._massIDAuditDocuments.map(
       (document, index) =>
         this.addExternalEventToDocument(
           document,
           stubDocumentEvent({
             name: RELATED,
-            relatedDocument: this.massIdCertificateDocumentRelations[index],
+            relatedDocument: this.massIDCertificateDocumentRelations[index],
           }),
         ),
     );
@@ -210,9 +210,9 @@ export class BoldStubsBuilder {
 
   build(): BoldStubsBuilderResult {
     const _creditOrderDocument = this._creditOrderDocument;
-    const _massIdAuditDocuments = this._massIdAuditDocuments;
-    const _massIdCertificateDocuments = this._massIdCertificateDocuments;
-    const _massIdDocuments = this._massIdDocuments;
+    const _massIDAuditDocuments = this._massIDAuditDocuments;
+    const _massIDCertificateDocuments = this._massIDCertificateDocuments;
+    const _massIDDocuments = this._massIDDocuments;
 
     return {
       boldMethodologyName: this.boldMethodologyName,
@@ -225,40 +225,40 @@ export class BoldStubsBuilder {
 
         return _creditOrderDocument;
       },
-      massIdActorParticipants: this.massIdActorParticipants,
-      massIdActorParticipantsAddresses: this.massIdActorParticipantsAddresses,
-      get massIdAuditDocument() {
-        if (_massIdAuditDocuments.length === 0) {
+      massIDActorParticipants: this.massIDActorParticipants,
+      massIDActorParticipantsAddresses: this.massIDActorParticipantsAddresses,
+      get massIDAuditDocument() {
+        if (_massIDAuditDocuments.length === 0) {
           throw new Error(
-            'No massId audit documents created. Call createMassIdAuditDocuments() before building.',
+            'No MassID audit documents created. Call createMassIDAuditDocuments() before building.',
           );
         }
 
-        return _massIdAuditDocuments[0]!;
+        return _massIDAuditDocuments[0]!;
       },
-      massIdAuditDocuments: _massIdAuditDocuments,
-      massIdAuditIds: this.massIdAuditDocumentIds,
-      get massIdCertificateDocument() {
-        if (_massIdCertificateDocuments.length === 0) {
+      massIDAuditDocuments: _massIDAuditDocuments,
+      massIDAuditIds: this.massIDAuditDocumentIds,
+      get massIDCertificateDocument() {
+        if (_massIDCertificateDocuments.length === 0) {
           throw new Error(
             'No certificate documents created. Call createCertificateDocuments() before building.',
           );
         }
 
-        return _massIdCertificateDocuments[0]!;
+        return _massIDCertificateDocuments[0]!;
       },
-      massIdCertificateDocuments: _massIdCertificateDocuments,
-      get massIdDocument() {
-        if (_massIdDocuments.length === 0) {
+      massIDCertificateDocuments: _massIDCertificateDocuments,
+      get massIDDocument() {
+        if (_massIDDocuments.length === 0) {
           throw new Error(
-            'No massId documents created. Call createMassIdDocuments() before building.',
+            'No MassID documents created. Call createMassIDDocuments() before building.',
           );
         }
 
-        return _massIdDocuments[0]!;
+        return _massIDDocuments[0]!;
       },
-      massIdDocumentIds: this.massIdDocumentIds,
-      massIdDocuments: _massIdDocuments,
+      massIDDocumentIds: this.massIDDocumentIds,
+      massIDDocuments: _massIDDocuments,
       methodologyActorParticipants: this.methodologyActorParticipants,
       methodologyDocument: this.methodologyDocument,
       participantsAccreditationDocuments:
@@ -285,28 +285,28 @@ export class BoldStubsBuilder {
 
     this.addCertificatesReflationsToCreditOrderDocument();
 
-    this._massIdCertificateDocuments = this._massIdCertificateDocuments.map(
-      (document) => this.addCreditRelationToMassIdCertificateDocument(document),
+    this._massIDCertificateDocuments = this._massIDCertificateDocuments.map(
+      (document) => this.addCreditRelationToMassIDCertificateDocument(document),
     );
 
     return this;
   }
 
-  createMassIdAuditDocuments({
+  createMassIDAuditDocuments({
     externalEventsMap,
     partialDocument,
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
-    this.validateMassIdDocumentsExist();
+    this.validateMassIDDocumentsExist();
 
     const methodologyEventName = `${this.boldMethodologyName} Methodology`;
 
-    this._massIdAuditDocuments = this._massIdDocuments.map(
-      (massIdDocument, index) =>
-        stubBoldMassIdAuditDocument({
+    this._massIDAuditDocuments = this._massIDDocuments.map(
+      (massIDDocument, index) =>
+        stubBoldMassIDAuditDocument({
           externalEventsMap: {
             [LINK]: stubDocumentEvent({
               name: LINK,
-              relatedDocument: this.massIdRelations[index],
+              relatedDocument: this.massIDRelations[index],
             }),
             [methodologyEventName]: stubDocumentEventWithMetadataAttributes(
               {
@@ -319,31 +319,31 @@ export class BoldStubsBuilder {
           },
           partialDocument: {
             ...partialDocument,
-            currentValue: massIdDocument.currentValue,
-            id: this.massIdAuditRelations[index]!.documentId,
-            parentDocumentId: massIdDocument.id,
+            currentValue: massIDDocument.currentValue,
+            id: this.massIDAuditRelations[index]!.documentId,
+            parentDocumentId: massIDDocument.id,
           },
         }),
     );
 
-    this.addMassIdAuditRelationsToMassIdDocuments();
+    this.addMassIDAuditRelationsToMassIDDocuments();
 
     return this;
   }
 
-  createMassIdCertificateDocuments({
+  createMassIDCertificateDocuments({
     externalEventsMap,
     partialDocument,
   }: StubBoldDocumentParameters = {}): BoldStubsBuilder {
-    this.validateMassIdAuditDocumentsExist();
+    this.validateMassIDAuditDocumentsExist();
 
-    this.massIdCertificateDocumentRelations =
-      this.createMassIdCertificateDocumentRelations();
+    this.massIDCertificateDocumentRelations =
+      this.createMassIDCertificateDocumentRelations();
 
-    this._massIdCertificateDocuments = this._massIdAuditDocuments.map(
+    this._massIDCertificateDocuments = this._massIDAuditDocuments.map(
       (auditDocument, index) => {
         const defaultEventsMap =
-          this.createDefaultMassIdCertificateDocumentEventsMap(index);
+          this.createDefaultMassIDCertificateDocumentEventsMap(index);
 
         const mergedEventsMap = isNil(externalEventsMap)
           ? defaultEventsMap
@@ -353,22 +353,22 @@ export class BoldStubsBuilder {
           externalEventsMap: mergedEventsMap,
           partialDocument: {
             currentValue: auditDocument.currentValue,
-            type: this.massIdCertificateDocumentRelations[index]!.type,
+            type: this.massIDCertificateDocumentRelations[index]!.type,
             ...partialDocument,
-            id: this.massIdCertificateDocumentRelations[index]!.documentId,
+            id: this.massIDCertificateDocumentRelations[index]!.documentId,
             parentDocumentId: auditDocument.id,
           },
         });
       },
     );
 
-    this.addMassIdCertificateDocumentRelationsToMassIdDocuments();
-    this.addMassIdCertificateDocumentRelationsToMassIdAuditDocuments();
+    this.addMassIDCertificateDocumentRelationsToMassIDDocuments();
+    this.addMassIDCertificateDocumentRelationsToMassIDAuditDocuments();
 
     return this;
   }
 
-  createMassIdDocuments({
+  createMassIDDocuments({
     count,
     externalEventsMap,
     partialDocument,
@@ -379,30 +379,30 @@ export class BoldStubsBuilder {
       const newMassIdDocumentIds = Array.from({ length: this.count }, () =>
         faker.string.uuid(),
       );
-      const newMassIdAuditDocumentIds = Array.from({ length: this.count }, () =>
+      const newMassIDAuditDocumentIds = Array.from({ length: this.count }, () =>
         faker.string.uuid(),
       );
-      const newMassIdCertificateDocumentIds = Array.from(
+      const newMassIDCertificateDocumentIds = Array.from(
         {
           length: this.count,
         },
         () => faker.string.uuid(),
       );
 
-      this.massIdDocumentIds = newMassIdDocumentIds;
-      this.massIdAuditDocumentIds = newMassIdAuditDocumentIds;
-      this.massIdCertificateDocumentIds = newMassIdCertificateDocumentIds;
+      this.massIDDocumentIds = newMassIdDocumentIds;
+      this.massIDAuditDocumentIds = newMassIDAuditDocumentIds;
+      this.massIDCertificateDocumentIds = newMassIDCertificateDocumentIds;
 
-      this.massIdRelations = this.createMassIdRelations();
-      this.massIdAuditRelations = this.createMassIdAuditRelations();
-      this.massIdCertificateDocumentRelations =
-        this.createMassIdCertificateDocumentRelations();
+      this.massIDRelations = this.createMassIDRelations();
+      this.massIDAuditRelations = this.createMassIDAuditRelations();
+      this.massIDCertificateDocumentRelations =
+        this.createMassIDCertificateDocumentRelations();
     }
 
-    const actorEvents = this.createMassIdActorEvents();
+    const actorEvents = this.createMassIDActorEvents();
 
-    this._massIdDocuments = this.massIdDocumentIds.map((_, index) => {
-      const defaultEventsMap = this.createDefaultMassIdEventsMap(
+    this._massIDDocuments = this.massIDDocumentIds.map((_, index) => {
+      const defaultEventsMap = this.createDefaultMassIDEventsMap(
         index,
         actorEvents,
       );
@@ -410,11 +410,11 @@ export class BoldStubsBuilder {
         ? defaultEventsMap
         : this.mergeEventsMaps(defaultEventsMap, externalEventsMap);
 
-      return stubBoldMassIdDocument({
+      return stubBoldMassIDDocument({
         externalEventsMap: mergedEventsMap,
         partialDocument: {
           ...partialDocument,
-          id: this.massIdRelations[index]!.documentId,
+          id: this.massIDRelations[index]!.documentId,
         },
       });
     });
@@ -473,7 +473,7 @@ export class BoldStubsBuilder {
       },
     });
 
-    this._massIdAuditDocuments = this._massIdAuditDocuments.map(
+    this._massIDAuditDocuments = this._massIDAuditDocuments.map(
       (auditDocument) =>
         this.addExternalEventToDocument(
           auditDocument,
@@ -495,8 +495,8 @@ export class BoldStubsBuilder {
     for (const subtype of MASS_ID_ACTOR_PARTICIPANTS) {
       const relation = this.createParticipantAccreditationRelation(subtype);
       const primaryAddress =
-        this.massIdActorParticipantsAddresses.get(subtype)!;
-      const primaryParticipant = this.massIdActorParticipants.get(subtype)!;
+        this.massIDActorParticipantsAddresses.get(subtype)!;
+      const primaryParticipant = this.massIDActorParticipants.get(subtype)!;
 
       const defaultEventsMap = new Map([
         [
@@ -539,7 +539,7 @@ export class BoldStubsBuilder {
           }),
         );
 
-      this._massIdAuditDocuments = this._massIdAuditDocuments.map(
+      this._massIDAuditDocuments = this._massIDAuditDocuments.map(
         (auditDocument) =>
           this.addExternalEventToDocument(
             auditDocument,
@@ -564,7 +564,7 @@ export class BoldStubsBuilder {
       ...this._creditOrderDocument!,
       externalEvents: [
         ...(this._creditOrderDocument?.externalEvents ?? []),
-        ...this.massIdCertificateDocumentRelations.map((relation) =>
+        ...this.massIDCertificateDocumentRelations.map((relation) =>
           stubDocumentEvent({
             name: RELATED,
             relatedDocument: relation,
@@ -574,13 +574,13 @@ export class BoldStubsBuilder {
     };
   }
 
-  private addCreditRelationToMassIdCertificateDocument(
-    massIdCertificateDocument: Document,
+  private addCreditRelationToMassIDCertificateDocument(
+    massIDCertificateDocument: Document,
   ): Document {
     return {
-      ...massIdCertificateDocument,
+      ...massIDCertificateDocument,
       externalEvents: [
-        ...(massIdCertificateDocument.externalEvents ?? []),
+        ...(massIDCertificateDocument.externalEvents ?? []),
         stubDocumentEvent({
           name: RELATED,
           relatedDocument: this.creditOrderRelation,
@@ -599,25 +599,25 @@ export class BoldStubsBuilder {
     };
   }
 
-  private addMassIdAuditRelationsToMassIdDocuments(): void {
-    this._massIdDocuments = this._massIdDocuments.map((document, index) =>
+  private addMassIDAuditRelationsToMassIDDocuments(): void {
+    this._massIDDocuments = this._massIDDocuments.map((document, index) =>
       this.addExternalEventToDocument(
         document,
         stubDocumentEvent({
           name: LINK,
-          relatedDocument: this.massIdAuditRelations[index],
+          relatedDocument: this.massIDAuditRelations[index],
         }),
       ),
     );
   }
 
-  private addMassIdCertificateDocumentRelationsToMassIdDocuments(): void {
-    this._massIdDocuments = this._massIdDocuments.map((document, index) =>
+  private addMassIDCertificateDocumentRelationsToMassIDDocuments(): void {
+    this._massIDDocuments = this._massIDDocuments.map((document, index) =>
       this.addExternalEventToDocument(
         document,
         stubDocumentEvent({
           name: RELATED,
-          relatedDocument: this.massIdCertificateDocumentRelations[index],
+          relatedDocument: this.massIDCertificateDocumentRelations[index],
         }),
       ),
     );
@@ -631,7 +631,7 @@ export class BoldStubsBuilder {
     };
   }
 
-  private createDefaultMassIdCertificateDocumentEventsMap(
+  private createDefaultMassIDCertificateDocumentEventsMap(
     index: number,
   ): Map<string, DocumentEvent> {
     const methodologyEventName = `${this.boldMethodologyName} Methodology`;
@@ -641,14 +641,14 @@ export class BoldStubsBuilder {
         MASS_ID,
         stubDocumentEvent({
           name: MASS_ID,
-          relatedDocument: this.massIdRelations[index]!,
+          relatedDocument: this.massIDRelations[index]!,
         }),
       ],
       [
         MASS_ID_AUDIT,
         stubDocumentEvent({
           name: MASS_ID_AUDIT,
-          relatedDocument: this.massIdAuditRelations[index]!,
+          relatedDocument: this.massIDAuditRelations[index]!,
         }),
       ],
       [
@@ -661,20 +661,20 @@ export class BoldStubsBuilder {
     ]);
   }
 
-  private createDefaultMassIdEventsMap(
+  private createDefaultMassIDEventsMap(
     index: number,
     actorEvents: Record<string, DocumentEvent>,
   ): Map<string, DocumentEvent> {
     return new Map([
       [
         DROP_OFF,
-        stubBoldMassIdDropOffEvent({
+        stubBoldMassIDDropOffEvent({
           partialDocumentEvent: {
-            address: this.massIdActorParticipantsAddresses.get(
-              MassIdDocumentActorType.RECYCLER,
+            address: this.massIDActorParticipantsAddresses.get(
+              MassIDDocumentActorType.RECYCLER,
             )!,
-            participant: this.massIdActorParticipants.get(
-              MassIdDocumentActorType.RECYCLER,
+            participant: this.massIDActorParticipants.get(
+              MassIDDocumentActorType.RECYCLER,
             )!,
           },
         }),
@@ -683,18 +683,18 @@ export class BoldStubsBuilder {
         OUTPUT,
         stubDocumentEvent({
           name: OUTPUT,
-          relatedDocument: this.massIdAuditRelations[index],
+          relatedDocument: this.massIDAuditRelations[index],
         }),
       ],
       [
         PICK_UP,
-        stubBoldMassIdPickUpEvent({
+        stubBoldMassIDPickUpEvent({
           partialDocumentEvent: {
-            address: this.massIdActorParticipantsAddresses.get(
-              MassIdDocumentActorType.WASTE_GENERATOR,
+            address: this.massIDActorParticipantsAddresses.get(
+              MassIDDocumentActorType.WASTE_GENERATOR,
             )!,
-            participant: this.massIdActorParticipants.get(
-              MassIdDocumentActorType.WASTE_GENERATOR,
+            participant: this.massIDActorParticipants.get(
+              MassIDDocumentActorType.WASTE_GENERATOR,
             )!,
           },
         }),
@@ -703,12 +703,12 @@ export class BoldStubsBuilder {
     ]);
   }
 
-  private createMassIdActorEvents(): Record<string, DocumentEvent> {
+  private createMassIDActorEvents(): Record<string, DocumentEvent> {
     return Object.fromEntries(
-      Array.from(this.massIdActorParticipants, ([actorType, participant]) => [
+      Array.from(this.massIDActorParticipants, ([actorType, participant]) => [
         `${ACTOR}-${actorType}`,
         stubDocumentEvent({
-          address: this.massIdActorParticipantsAddresses.get(actorType)!,
+          address: this.massIDActorParticipantsAddresses.get(actorType)!,
           label: actorType,
           name: ACTOR,
           participant,
@@ -717,8 +717,8 @@ export class BoldStubsBuilder {
     );
   }
 
-  private createMassIdAuditRelations(): DocumentRelation[] {
-    return this.massIdAuditDocumentIds.map((documentId) => ({
+  private createMassIDAuditRelations(): DocumentRelation[] {
+    return this.massIDAuditDocumentIds.map((documentId) => ({
       category: METHODOLOGY,
       documentId,
       subtype: PROCESS,
@@ -726,16 +726,16 @@ export class BoldStubsBuilder {
     }));
   }
 
-  private createMassIdCertificateDocumentRelations(): DocumentRelation[] {
-    return this.massIdCertificateDocumentIds.map((documentId) => ({
+  private createMassIDCertificateDocumentRelations(): DocumentRelation[] {
+    return this.massIDCertificateDocumentIds.map((documentId) => ({
       category: METHODOLOGY,
       documentId,
       type: MASS_ID_CERTIFICATE_BY_METHODOLOGY_NAME[this.boldMethodologyName],
     }));
   }
 
-  private createMassIdRelations(): DocumentRelation[] {
-    return this.massIdDocumentIds.map((documentId) => ({
+  private createMassIDRelations(): DocumentRelation[] {
+    return this.massIDDocumentIds.map((documentId) => ({
       bidirectional: false,
       category: MASS_ID,
       documentId,
@@ -801,7 +801,7 @@ export class BoldStubsBuilder {
     );
   }
 
-  private initializeMassIdActorParticipants(
+  private initializeMassIDActorParticipants(
     providedParticipants?: Map<string, MethodologyParticipant>,
   ): Map<string, MethodologyParticipant> {
     if (providedParticipants) {
@@ -846,35 +846,35 @@ export class BoldStubsBuilder {
 
   private validateAllDocumentsExist(): void {
     if (
-      this._massIdDocuments.length === 0 ||
-      this._massIdAuditDocuments.length === 0
+      this._massIDDocuments.length === 0 ||
+      this._massIDAuditDocuments.length === 0
     ) {
       throw new Error(
-        'MassID documents must be created first. Call createMassIdDocuments() and createMassIdAuditDocuments() before this method.',
+        'MassID documents must be created first. Call createMassIDDocuments() and createMassIDAuditDocuments() before this method.',
       );
     }
   }
 
   private validateCertificateDocumentsExist(): void {
-    if (this._massIdCertificateDocuments.length === 0) {
+    if (this._massIDCertificateDocuments.length === 0) {
       throw new Error(
         'MassID Certificate documents must be created first. Call createCertificateDocuments() before this method.',
       );
     }
   }
 
-  private validateMassIdAuditDocumentsExist(): void {
-    if (this._massIdAuditDocuments.length === 0) {
+  private validateMassIDAuditDocumentsExist(): void {
+    if (this._massIDAuditDocuments.length === 0) {
       throw new Error(
-        'MassID Audit documents must be created first. Call createMassIdAuditDocuments() before this method.',
+        'MassID Audit documents must be created first. Call createMassIDAuditDocuments() before this method.',
       );
     }
   }
 
-  private validateMassIdDocumentsExist(): void {
-    if (this._massIdDocuments.length === 0) {
+  private validateMassIDDocumentsExist(): void {
+    if (this._massIDDocuments.length === 0) {
       throw new Error(
-        'MassID documents must be created first. Call createMassIdDocuments() before this method.',
+        'MassID documents must be created first. Call createMassIDDocuments() before this method.',
       );
     }
   }

--- a/libs/shared/methodologies/bold/testing/src/helpers/rule-processor.helpers.ts
+++ b/libs/shared/methodologies/bold/testing/src/helpers/rule-processor.helpers.ts
@@ -8,14 +8,14 @@ import { BoldStubsBuilder, type StubBoldDocumentParameters } from '../builders';
 
 interface CreateBoldStubsParameters {
   accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
-  massIdActorParticipants?: Map<string, MethodologyParticipant> | undefined;
-  massIdDocumentsParams?: StubBoldDocumentParameters | undefined;
+  massIDActorParticipants?: Map<string, MethodologyParticipant> | undefined;
+  massIDDocumentsParams?: StubBoldDocumentParameters | undefined;
 }
 
 interface ProcessRuleTestParameters {
   accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
-  massIdActorParticipants?: Map<string, MethodologyParticipant> | undefined;
-  massIdDocumentsParams?: StubBoldDocumentParameters | undefined;
+  massIDActorParticipants?: Map<string, MethodologyParticipant> | undefined;
+  massIDDocumentsParams?: StubBoldDocumentParameters | undefined;
   ruleDataProcessor: RuleDataProcessor;
   spyOnDocumentQueryServiceLoad: (
     rootDocument: Document,
@@ -31,16 +31,16 @@ interface TestExpectedRuleOutputParameters {
   ruleOutput: RuleOutput;
 }
 
-export function createBoldStubsForMassIdProcessor({
+export function createBoldStubsForMassIDProcessor({
   accreditationDocuments,
-  massIdActorParticipants,
-  massIdDocumentsParams,
+  massIDActorParticipants,
+  massIDDocumentsParams,
 }: CreateBoldStubsParameters) {
   return new BoldStubsBuilder({
-    ...(massIdActorParticipants && { massIdActorParticipants }),
+    ...(massIDActorParticipants && { massIDActorParticipants }),
   })
-    .createMassIdDocuments(massIdDocumentsParams)
-    .createMassIdAuditDocuments()
+    .createMassIDDocuments(massIDDocumentsParams)
+    .createMassIDAuditDocuments()
     .createMethodologyDocument()
     .createParticipantAccreditationDocuments(accreditationDocuments)
     .build();
@@ -48,8 +48,8 @@ export function createBoldStubsForMassIdProcessor({
 
 export async function createRuleTestFixture({
   accreditationDocuments,
-  massIdActorParticipants,
-  massIdDocumentsParams,
+  massIDActorParticipants,
+  massIDDocumentsParams,
   ruleDataProcessor,
   spyOnDocumentQueryServiceLoad,
 }: ProcessRuleTestParameters): Promise<{
@@ -57,26 +57,26 @@ export async function createRuleTestFixture({
   ruleOutput: RuleOutput;
 }> {
   const {
-    massIdAuditDocument,
-    massIdDocument,
+    massIDAuditDocument,
+    massIDDocument,
     participantsAccreditationDocuments,
-  } = createBoldStubsForMassIdProcessor({
+  } = createBoldStubsForMassIDProcessor({
     accreditationDocuments,
-    massIdActorParticipants,
-    massIdDocumentsParams,
+    massIDActorParticipants,
+    massIDDocumentsParams,
   });
 
   const allDocuments = [
-    massIdDocument,
-    massIdAuditDocument,
+    massIDDocument,
+    massIDAuditDocument,
     ...participantsAccreditationDocuments.values(),
   ];
 
-  spyOnDocumentQueryServiceLoad(massIdAuditDocument, allDocuments);
+  spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
 
   const ruleInput = {
     ...random<Required<RuleInput>>(),
-    documentId: massIdAuditDocument.id,
+    documentId: massIDAuditDocument.id,
   };
 
   return { ruleInput, ruleOutput: await ruleDataProcessor.process(ruleInput) };

--- a/libs/shared/methodologies/bold/testing/src/stubs/document.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/stubs/document.stubs.ts
@@ -45,7 +45,7 @@ export const stubDocumentRelation = (
   ...partial,
 });
 
-export const stubMassIdDocument = (
+export const stubMassIDDocument = (
   partialDocument?: PartialDeep<Document>,
 ): Document =>
   stubDocument({

--- a/libs/shared/methodologies/bold/types/src/document.types.ts
+++ b/libs/shared/methodologies/bold/types/src/document.types.ts
@@ -5,12 +5,12 @@ import type {
   DocumentCategory,
   DocumentSubtype,
   DocumentType,
-  MassIdOrganicSubtype,
+  MassIDOrganicSubtype,
 } from './enum.types';
 
 export interface Document extends MethodologyDocument {
   category: DocumentCategory | string;
   externalEvents?: DocumentEvent[] | undefined;
-  subtype?: DocumentSubtype | MassIdOrganicSubtype | string | undefined;
+  subtype?: DocumentSubtype | MassIDOrganicSubtype | string | undefined;
   type?: DocumentType | string | undefined;
 }

--- a/libs/shared/methodologies/bold/types/src/enum.types.ts
+++ b/libs/shared/methodologies/bold/types/src/enum.types.ts
@@ -153,7 +153,7 @@ export enum DocumentEventWeighingCaptureMethod {
   TRANSPORT_MANIFEST = 'Transport Manifest',
 }
 
-export enum MassIdOrganicSubtype {
+export enum MassIDOrganicSubtype {
   DOMESTIC_SLUDGE = 'Domestic Sludge',
   EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = 'EFB similar to Garden, Yard and Park Waste',
   FOOD_FOOD_WASTE_AND_BEVERAGES = 'Food, Food Waste and Beverages',
@@ -164,23 +164,23 @@ export enum MassIdOrganicSubtype {
 }
 
 export enum DocumentSubtype {
-  DOMESTIC_SLUDGE = MassIdOrganicSubtype.DOMESTIC_SLUDGE,
-  EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = MassIdOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE,
-  FOOD_FOOD_WASTE_AND_BEVERAGES = MassIdOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-  GARDEN_YARD_AND_PARK_WASTE = MassIdOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE,
+  DOMESTIC_SLUDGE = MassIDOrganicSubtype.DOMESTIC_SLUDGE,
+  EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE = MassIDOrganicSubtype.EFB_SIMILAR_TO_GARDEN_YARD_AND_PARK_WASTE,
+  FOOD_FOOD_WASTE_AND_BEVERAGES = MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+  GARDEN_YARD_AND_PARK_WASTE = MassIDOrganicSubtype.GARDEN_YARD_AND_PARK_WASTE,
   GROUP = 'Group',
   HAULER = MethodologyActorType.HAULER,
-  INDUSTRIAL_SLUDGE = MassIdOrganicSubtype.INDUSTRIAL_SLUDGE,
+  INDUSTRIAL_SLUDGE = MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
   INTEGRATOR = MethodologyActorType.INTEGRATOR,
   PROCESS = 'Process',
   PROCESSOR = MethodologyActorType.PROCESSOR,
   RECYCLER = MethodologyActorType.RECYCLER,
   SOURCE = 'Source',
   TCC = 'TCC',
-  TOBACCO = MassIdOrganicSubtype.TOBACCO,
+  TOBACCO = MassIDOrganicSubtype.TOBACCO,
   TRC = 'TRC',
   WASTE_GENERATOR = MethodologyActorType.WASTE_GENERATOR,
-  WOOD_AND_WOOD_PRODUCTS = MassIdOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
+  WOOD_AND_WOOD_PRODUCTS = MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
 }
 
 export enum DocumentType {
@@ -193,7 +193,7 @@ export enum DocumentType {
   RECYCLED_ID = 'RecycledID',
 }
 
-export enum MassIdDocumentActorType {
+export enum MassIDDocumentActorType {
   HAULER = MethodologyActorType.HAULER,
   INTEGRATOR = MethodologyActorType.INTEGRATOR,
   PROCESSOR = MethodologyActorType.PROCESSOR,

--- a/libs/shared/methodologies/bold/types/src/rewards-distribution.types.ts
+++ b/libs/shared/methodologies/bold/types/src/rewards-distribution.types.ts
@@ -33,11 +33,11 @@ export interface CertificateReward {
 export type CertificateRewardDistributionOutput =
   RewardDistributionResultContent;
 
-export interface MassIdReward {
+export interface MassIDReward {
   actorType: RewardsDistributionActorType;
   address: RewardActorAddress;
   // TODO: update with custom tag to validate BigNumber string
-  massIdPercentage: NonEmptyString;
+  massIDPercentage: NonEmptyString;
   participant: RewardActorParticipant;
   preserveSensitiveData: boolean | undefined;
 }
@@ -52,6 +52,6 @@ export type RewardActorParticipant = Pick<
 >;
 
 export interface RewardDistributionResultContent {
-  massIdDocumentId: NonEmptyString;
-  massIdRewards: NonEmptyArray<MassIdReward>;
+  massIDDocumentId: NonEmptyString;
+  massIDRewards: NonEmptyArray<MassIDReward>;
 }

--- a/tools/create-rule.js
+++ b/tools/create-rule.js
@@ -261,7 +261,7 @@ describe('${pascalCase}Lambda E2E', () => {
     'should return $resultStatus when $scenario',
     async ({ document, resultStatus }) => {
       prepareEnvironmentTestE2E(
-        [document, stubs.massIdAuditDocumentStub].map((_document) => ({
+        [document, stubs.massIDAuditDocumentStub].map((_document) => ({
           document: _document,
           documentKey: toDocumentKey({
             documentId: _document.id,


### PR DESCRIPTION
### 🧾 Summary

Standardizes MassID nomenclature across the entire codebase by renaming all instances of `MassId` to `MassID` in class names, enums, types, interfaces, variables, and function names to ensure consistent naming conventions.

### 🧩 Context

The codebase had inconsistent naming for MassID-related entities, using both `MassId` and `MassID` throughout different parts of the code. This standardization ensures:

- **MassID** is used for the document name
- **MassIDId** is used for unique identifiers
- **MassIDAudit** is used for audit documents
- **MassIDAuditId** is used for audit document identifiers

This refactoring improves code consistency, maintainability, and reduces confusion when working with MassID-related code.

### 🧱 Scope of this PR

This PR includes:

- Renaming all class names (e.g., `MassIdQualificationsProcessor` → `MassIDQualificationsProcessor`)
- Updating enum names (`MassIdOrganicSubtype` → `MassIDOrganicSubtype`, `MassIdDocumentActorType` → `MassIDDocumentActorType`)
- Standardizing type and interface names (`MassIdReward` → `MassIDReward`, `ActorMassIdPercentageInputDto` → `ActorMassIDPercentageInputDto`)
- Updating function names (`createMassIdAuditDocuments` → `createMassIDAuditDocuments`, `stubBoldMassIdPickUpEvent` → `stubBoldMassIDPickUpEvent`)
- Renaming variables and properties (`massIdDocument` → `massIDDocument`, `massIdAuditDocument` → `massIDAuditDocument`)
- Updating all related test cases, helper functions, and test utilities

**Not included**: This PR does not change any functionality, only naming conventions. All tests should pass without modification as this is a pure refactoring.

### 🧪 How to test

1. Run the test suite to ensure all tests pass:
   ```bash
   pnpm test:all
   ```

2. Verify that linting passes:
   ```bash
   pnpm lint:all
   ```

3. Check that the build succeeds:
   ```bash
   pnpm build-lambda
   ```

4. Search the codebase to confirm no instances of `MassId` (with lowercase 'd') remain in class names, enums, or exported functions.

### 🧠 Considerations for Review

- **Large scope**: This PR touches 112 files, but all changes are related to the same refactoring (nomenclature standardization)
- **No functional changes**: This is a pure refactoring - no business logic was modified
- **Breaking changes**: This is a breaking change for any external code that imports these classes, enums, or functions. However, since this is an internal repository, all usages have been updated
- **Test coverage**: All existing tests have been updated to use the new naming, ensuring no test coverage was lost
- **Consistency**: The changes ensure consistent naming throughout the codebase, making it easier to maintain and understand

### 🔗 Related Links

N/A

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies naming from `MassId` to `MassID` across Bold methodologies to ensure consistency, touching processors, helpers, and tests.
> 
> - Renames APIs and props (e.g., `massIdCertificateValue` → `massIDCertificateValue`, `aggregateMassIdCertificatesRewards` → `aggregateMassIDCertificatesRewards`, enums like `MassIdOrganicSubtype` → `MassIDOrganicSubtype`)
> - Updates processor/lambda identifiers (`MassId*` → `MassID*`) and app exports to `massID*Lambda`
> - Refactors test utilities/stubs (`stubBoldMassId*` → `stubBoldMassID*`) and variable names throughout specs
> - Minor formatting in `.vscode/settings.json`; no behavioral changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe1cbea1b3a5ac4f5fd032c1649b4c27197f097e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized "MassID" capitalization across public APIs, test helpers, builders and type names for consistent naming and clearer public surface.

* **Chores**
  * Minor configuration formatting cleanup (styling/whitespace only; no behavioral changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->