### PR TITLE
feat(rule): use similarity comparison for regional waste classification description

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.helpers.ts
@@ -1,23 +1,4 @@
 import { SUBTYPE_TO_CDM_CODE_MAP } from '@carrot-fndn/shared/methodologies/bold/utils';
 
-const isAlphaNumericUnicode = (ch: string): boolean => /\p{L}|\p{N}/u.test(ch);
-
 export const getCdmCodeFromSubtype = (subtype: string): string | undefined =>
   SUBTYPE_TO_CDM_CODE_MAP.get(subtype);
-
-export const normalizeDescriptionForComparison = (value: string): string => {
-  const normalized = value.normalize('NFKC').trim();
-
-  let start = 0;
-  let end = normalized.length - 1;
-
-  while (start <= end && !isAlphaNumericUnicode(normalized.charAt(start))) {
-    start += 1;
-  }
-
-  while (end >= start && !isAlphaNumericUnicode(normalized.charAt(end))) {
-    end -= 1;
-  }
-
-  return normalized.slice(start, end + 1);
-};

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -176,6 +176,33 @@ export const regionalWasteClassificationTestCases = [
       [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
       [PICK_UP]: stubBoldMassIDPickUpEvent({
         metadataAttributes: [
+          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 02'],
+          [
+            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+            'Residuos de tecidos animais',
+          ],
+        ],
+      }),
+    },
+    partialDocument: {
+      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultComment: RESULT_COMMENTS.VALID_CLASSIFICATION,
+    resultContent: {
+      description: 'Residuos de tecidos animais',
+      id: '02 01 02',
+      recyclerCountryCode: 'BR',
+      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    },
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario:
+      'the local waste classification description matches after aggressive normalization (accent stripped).',
+  },
+  {
+    events: {
+      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+      [PICK_UP]: stubBoldMassIDPickUpEvent({
+        metadataAttributes: [
           [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
           [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
         ],


### PR DESCRIPTION
## Summary

- Replace exact-match description normalization with `isNameMatch` (aggressive normalization + Dice coefficient) at 90% similarity threshold
- Removes custom `normalizeDescriptionForComparison` helper in favor of the shared `isNameMatch` already used by cross-validation in `document-manifest-data`
- Handles real-world variations like stripped accents, capitalization differences, and minor punctuation differences

## Test plan

- [x] Existing 14 test cases continue to pass
- [x] New test case: accent-stripped description (`'Residuos de tecidos animais'`) now correctly passes against expected `'Resíduos de tecidos animais'`

## Prod verification

```bash
aws-vault exec smaug-prod -- pnpm run-rule run \
  libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification \
  --methodology-execution-id 2a4c953f-1f07-49a1-b1ed-252e33101c78 \
  --audit-document-id 54345af9-5b92-4d65-a138-de244fa148ac \
  --audited-document-id 55a18979-da5f-4358-a901-1108e7f87d77
```

Result:

```json
{
  "status": "PASSED",
  "comment": "The local waste classification \"Local Waste Classification ID\" and \"Local Waste Classification Description\" match an Ibama code.",
  "resultContent": {
    "description": "Lodos do Tratamento local de efluentes",
    "id": "020204",
    "recyclerCountryCode": "BR",
    "subtype": "Domestic Sludge"
  }
}
```

The description `"Lodos do Tratamento local de efluentes"` (mid-sentence capitalization) matched the expected `"Lodos do tratamento local de efluentes"` — a case that would have failed with the previous exact-match logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)