### PR TITLE
feat(shared): add address normalization and OCR-aware comparison helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,27 @@ fix(shared): prevent racing of requests
 - Test env: `.env-files/.env.test`
 - Coverage output: `./coverage/{projectRoot}`
 
+### No Real Data in Tests
+
+**Never commit real data in test files or any file in the repository.** This includes:
+
+- Company names (e.g. real client or partner names)
+- Tax IDs (CPF, CNPJ)
+- Vehicle license plates
+- Addresses (street names, cities that identify real locations)
+- Person names tied to real individuals
+- Phone numbers, emails, or any other PII
+
+Always use obviously fake, synthetic values. Examples:
+
+- Companies: `VERDE CAMPO LTDA`, `EXEMPLO INDUSTRIAS`
+- CNPJs: `11.222.333/0004-55`, `77.888.999/0001-22`
+- Plates: `FKE1A23`, `HIJ3K56`
+- Addresses: `Rua Modelo, 100`, `Av. Principal, 500`, `Cidade Centro`
+- People: `Pedro Santos`, `Ana Ferreira`
+
+When writing parser tests that include raw OCR text, ensure both the input text and the expected assertion values use fake data consistently.
+
 ## Pull Requests
 
 Use gh CLI with these repo-specific settings:

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/cross-validation.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/cross-validation.helpers.spec.ts
@@ -82,6 +82,10 @@ describe('cross-validation.helpers', () => {
       expect(normalizeQuantityToKg(1.12, 'tonelada')).toBe(1120);
     });
 
+    it('should return quantity as-is when unit is Quilograma', () => {
+      expect(normalizeQuantityToKg(80, 'Quilograma')).toBe(80);
+    });
+
     it('should return undefined for unknown units', () => {
       expect(normalizeQuantityToKg(5, 'm³')).toBeUndefined();
     });

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/cross-validation.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/cross-validation.helpers.ts
@@ -22,6 +22,9 @@ export interface FieldValidationResult {
   reviewReason?: ReviewReason;
 }
 
+export const formatScoreAsPercent = (score: number): string =>
+  `${(score * 100).toFixed(0)}%`;
+
 export const collectResults = (
   results: FieldValidationResult[],
 ): {

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/cross-validation.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/cross-validation.helpers.ts
@@ -108,7 +108,7 @@ export const normalizeQuantityToKg = (
 
   const normalized = unit.toLowerCase();
 
-  if (normalized === 'kg') {
+  if (normalized === 'kg' || normalized === 'quilograma') {
     return quantity;
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/field.comparators.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/field.comparators.ts
@@ -8,6 +8,7 @@ import type { MethodologyAddress } from '@carrot-fndn/shared/types';
 
 import {
   dateDifferenceInDays,
+  isAddressMatch,
   isNameMatch,
   utcIsoToLocalDate,
 } from '@carrot-fndn/shared/helpers';
@@ -239,7 +240,7 @@ const buildAddressDebug = (
   }
 
   const eventAddressString = buildAddressString(eventAddress);
-  const { score } = isNameMatch(extractedAddress, eventAddressString);
+  const { score } = isAddressMatch(extractedAddress, eventAddressString);
 
   return {
     addressSimilarity: `${(score * 100).toFixed(0)}%`,
@@ -260,11 +261,9 @@ const validateEntityAddress = (
 
   const eventAddressString = buildAddressString(eventAddress);
   const extractedAddress = buildExtractedAddress(entityWithAddress);
-  const { isMatch, score } = isNameMatch(
+  const { isMatch, score } = isAddressMatch(
     extractedAddress,
     eventAddressString,
-    undefined,
-    true,
   );
 
   if (isMatch) {

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/field.comparators.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/field.comparators.ts
@@ -19,7 +19,11 @@ import type {
 } from '../document-manifest-data.result-content.types';
 import type { FieldValidationResult } from './cross-validation.helpers';
 
-import { buildAddressString, normalizeTaxId } from './cross-validation.helpers';
+import {
+  buildAddressString,
+  formatScoreAsPercent,
+  normalizeTaxId,
+} from './cross-validation.helpers';
 
 export interface ComparisonOutput<TDebug> {
   debug: TDebug;
@@ -243,7 +247,7 @@ const buildAddressDebug = (
   const { score } = isAddressMatch(extractedAddress, eventAddressString);
 
   return {
-    addressSimilarity: `${(score * 100).toFixed(0)}%`,
+    addressSimilarity: formatScoreAsPercent(score),
     confidence: entityWithAddress.address.confidence,
     event: eventAddressString,
     extracted: extractedAddress,
@@ -278,7 +282,7 @@ const validateEntityAddress = (
           event: eventAddressString,
           extracted: extractedAddress,
           field: 'address',
-          similarity: `${(score * 100).toFixed(0)}%`,
+          similarity: formatScoreAsPercent(score),
         },
       ],
     },
@@ -347,7 +351,7 @@ export const compareEntity = (
   })();
 
   const nameSimilarity =
-    nameResult === undefined ? null : `${(nameResult.score * 100).toFixed(0)}%`;
+    nameResult === undefined ? null : formatScoreAsPercent(nameResult.score);
 
   const taxIdMatch =
     eventTaxId === undefined

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/waste.comparators.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/waste.comparators.spec.ts
@@ -426,6 +426,124 @@ describe('cross-validation waste comparators', () => {
       });
     });
 
+    describe('floating-point tolerance', () => {
+      it('should not raise mismatch when extracted weight has floating-point noise below event weight', () => {
+        // 0.0392 TON * 1000 = 39.199999999999996 (IEEE 754) vs event 39.2 kg
+        const entries: WasteTypeEntryData[] = [
+          {
+            code: '01 01 01',
+            description: 'Papel',
+            quantity: 39.199_999_999_999_996,
+            unit: 'kg',
+          },
+        ];
+
+        const result = compareWasteQuantity(
+          entries,
+          '01 01 01',
+          'Papel',
+          [{ value: 39.2 }],
+          { onMismatch: onQuantityMismatch },
+        );
+
+        expect(result.debug?.isMatch).toBe(true);
+        expect(result.debug?.source).toBe('matched-entry');
+        expect(result.validation).toEqual([]);
+      });
+
+      it('should not raise mismatch for other observed floating-point cases', () => {
+        // 0.3696 TON * 1000 = 369.59999999999997 vs event 369.6 kg
+        const entries: WasteTypeEntryData[] = [
+          {
+            code: '01 01 01',
+            description: 'Papel',
+            quantity: 369.599_999_999_999_97,
+            unit: 'kg',
+          },
+        ];
+
+        const result = compareWasteQuantity(
+          entries,
+          '01 01 01',
+          'Papel',
+          [{ value: 369.6 }],
+          { onMismatch: onQuantityMismatch },
+        );
+
+        expect(result.debug?.isMatch).toBe(true);
+        expect(result.validation).toEqual([]);
+      });
+
+      it('should still raise mismatch for real weight discrepancies', () => {
+        const entries: WasteTypeEntryData[] = [
+          {
+            code: '01 01 01',
+            description: 'Papel',
+            quantity: 39.2,
+            unit: 'kg',
+          },
+        ];
+
+        const result = compareWasteQuantity(
+          entries,
+          '01 01 01',
+          'Papel',
+          [{ value: 80 }],
+          { onMismatch: onQuantityMismatch },
+        );
+
+        expect(result.debug?.isMatch).toBe(false);
+        expect(result.validation).toHaveLength(1);
+        expect(result.validation[0]?.reviewReason?.code).toBe(
+          'WEIGHT_BELOW_WEIGHING',
+        );
+      });
+
+      it('should tolerate floating-point noise in total-weight fallback strategy', () => {
+        const entries: WasteTypeEntryData[] = [
+          {
+            description: 'Plastico',
+            quantity: 39.199_999_999_999_996,
+            unit: 'kg',
+          },
+        ];
+
+        const result = compareWasteQuantity(
+          entries,
+          '99 99 99',
+          'No match',
+          [{ value: 39.2 }],
+          { onMismatch: onQuantityMismatch },
+        );
+
+        expect(result.debug?.source).toBe('total-weight');
+        expect(result.debug?.isMatch).toBe(true);
+        expect(result.validation).toEqual([]);
+      });
+
+      it('should raise mismatch at tolerance boundary when difference exceeds 0.01 kg', () => {
+        const entries: WasteTypeEntryData[] = [
+          {
+            code: '01 01 01',
+            description: 'Papel',
+            quantity: 99.98,
+            unit: 'kg',
+          },
+        ];
+
+        const result = compareWasteQuantity(
+          entries,
+          '01 01 01',
+          'Papel',
+          [{ value: 100 }],
+          { onMismatch: onQuantityMismatch },
+        );
+
+        expect(result.debug?.isMatch).toBe(false);
+        expect(result.validation).toHaveLength(1);
+      });
+    });
+
     describe('skipValidation', () => {
       it('should skip validation when skipValidation is true', () => {
         const entries: WasteTypeEntryData[] = [

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/waste.comparators.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/waste.comparators.ts
@@ -15,6 +15,7 @@ import type { ComparisonOutput } from './field.comparators';
 
 import {
   computeCdfTotalKg,
+  formatScoreAsPercent,
   matchWasteTypeEntry,
   normalizeQuantityToKg,
 } from './cross-validation.helpers';
@@ -34,7 +35,7 @@ const buildWasteTypeDebugEntry = (
     descriptionSimilarity:
       match.descriptionSimilarity === null
         ? null
-        : `${(match.descriptionSimilarity * 100).toFixed(0)}%`,
+        : formatScoreAsPercent(match.descriptionSimilarity),
     extracted: entry.code
       ? `${entry.code} - ${entry.description}`
       : entry.description,

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/waste.comparators.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/cross-validation/waste.comparators.ts
@@ -154,6 +154,8 @@ const getWeighingValueKg = (
 ): number | undefined =>
   weighingEvents.find((e) => e.value !== undefined && e.value > 0)?.value;
 
+const WEIGHT_TOLERANCE_KG = 0.01;
+
 const buildWeightValidation = (
   extractedKg: number | undefined,
   weighingValue: number | undefined,
@@ -176,7 +178,10 @@ const buildWeightValidation = (
       : [];
   }
 
-  if (weighingValue === undefined || weighingValue <= extractedKg) {
+  if (
+    weighingValue === undefined ||
+    weighingValue <= extractedKg + WEIGHT_TOLERANCE_KG
+  ) {
     return [];
   }
 
@@ -240,7 +245,7 @@ export const compareWasteQuantity = (
     );
     const isMatch =
       normalizedKg !== undefined && weighingValue !== undefined
-        ? weighingValue <= normalizedKg
+        ? weighingValue <= normalizedKg + WEIGHT_TOLERANCE_KG
         : null;
 
     return {
@@ -262,7 +267,7 @@ export const compareWasteQuantity = (
   const extractedKg = hasValidQuantity ? totalKg : undefined;
   const isMatch =
     extractedKg !== undefined && weighingValue !== undefined
-      ? weighingValue <= extractedKg
+      ? weighingValue <= extractedKg + WEIGHT_TOLERANCE_KG
       : null;
 
   return {

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.result-content.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.result-content.types.ts
@@ -44,6 +44,7 @@ export interface EntityComparison extends ComparisonResult {
 
 export interface FieldComparison extends FieldComparisonBase {
   daysDiff?: null | number;
+  observation?: string;
   similarity?: null | string;
 }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/transport-manifest-cross-validation.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/transport-manifest-cross-validation.helpers.spec.ts
@@ -724,6 +724,110 @@ describe('transport-manifest-cross-validation.helpers', () => {
       expect(result.reviewRequired).toBe(false);
     });
 
+    it('should pass validation with observation when plates differ by single OCR-confusable char', () => {
+      const extractionResult = createExtractionResult({
+        vehiclePlate: {
+          confidence: 'high',
+          parsed: 'XYZ1I23',
+          rawMatch: 'XYZ1I23',
+        },
+      });
+
+      const eventData: MtrCrossValidationEventData = {
+        ...baseEventData,
+        pickUpEvent: {
+          address: STUB_BR_ADDRESS,
+          metadata: {
+            attributes: [
+              {
+                isPublic: true,
+                name: 'Vehicle License Plate',
+                value: 'XYZ1123',
+              },
+            ],
+          },
+        } as unknown as DocumentEvent,
+      };
+
+      const result = validateMtrExtractedData(extractionResult, eventData);
+
+      expect(result.failMessages).toHaveLength(0);
+      expect(result.reviewRequired).toBe(false);
+
+      const crossValidation = result.crossValidation as MtrCrossValidation;
+
+      expect(crossValidation.vehiclePlate.isMatch).toBe(true);
+      expect(crossValidation.vehiclePlate.observation).toBe(
+        'Plates differ by 1 character in an OCR-plausible substitution (e.g., letter/digit confusion). Accepted as match.',
+      );
+    });
+
+    it('should not add observation when plates match exactly after normalization', () => {
+      const extractionResult = createExtractionResult({
+        vehiclePlate: {
+          confidence: 'high',
+          parsed: 'ABC-1D34',
+          rawMatch: 'ABC-1D34',
+        },
+      });
+
+      const eventData: MtrCrossValidationEventData = {
+        ...baseEventData,
+        pickUpEvent: {
+          address: STUB_BR_ADDRESS,
+          metadata: {
+            attributes: [
+              {
+                isPublic: true,
+                name: 'Vehicle License Plate',
+                value: 'ABC1D34',
+              },
+            ],
+          },
+        } as unknown as DocumentEvent,
+      };
+
+      const result = validateMtrExtractedData(extractionResult, eventData);
+
+      expect(result.failMessages).toHaveLength(0);
+      expect(result.reviewRequired).toBe(false);
+
+      const crossValidation = result.crossValidation as MtrCrossValidation;
+
+      expect(crossValidation.vehiclePlate.isMatch).toBe(true);
+      expect(crossValidation.vehiclePlate.observation).toBeUndefined();
+    });
+
+    it('should still trigger review for non-OCR single char difference', () => {
+      const extractionResult = createExtractionResult({
+        vehiclePlate: {
+          confidence: 'high',
+          parsed: 'ABC1D23',
+          rawMatch: 'ABC1D23',
+        },
+      });
+
+      const eventData: MtrCrossValidationEventData = {
+        ...baseEventData,
+        pickUpEvent: {
+          address: STUB_BR_ADDRESS,
+          metadata: {
+            attributes: [
+              {
+                isPublic: true,
+                name: 'Vehicle License Plate',
+                value: 'ABC1D24',
+              },
+            ],
+          },
+        } as unknown as DocumentEvent,
+      };
+
+      const result = validateMtrExtractedData(extractionResult, eventData);
+
+      expect(result.reviewRequired).toBe(true);
+    });
+
     it('should skip date validation when confidence is not high', () => {
       const extractionResult = createExtractionResult({
         transportDate: {

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/transport-manifest-cross-validation.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/transport-manifest-cross-validation.helpers.ts
@@ -106,9 +106,7 @@ export const validateMtrExtractedData = (
     extractedData.vehiclePlate,
     eventPlateString,
     {
-      compareFn: (a, b) =>
-        normalizeVehiclePlate(a) === normalizeVehiclePlate(b) ||
-        isOcrPlausiblePlateMatch(a, b),
+      compareFn: isOcrPlausiblePlateMatch,
       notExtractedReason: REVIEW_REASONS.FIELD_NOT_EXTRACTED({
         field: 'vehicle plate',
       }),

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/transport-manifest-cross-validation.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/transport-manifest-cross-validation.helpers.ts
@@ -7,6 +7,7 @@ import {
 import { toWasteTypeEntryData } from '@carrot-fndn/shared/document-extractor-transport-manifest';
 import {
   getTimezoneFromAddress,
+  isOcrPlausiblePlateMatch,
   normalizeVehiclePlate,
 } from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
@@ -106,7 +107,8 @@ export const validateMtrExtractedData = (
     eventPlateString,
     {
       compareFn: (a, b) =>
-        normalizeVehiclePlate(a) === normalizeVehiclePlate(b),
+        normalizeVehiclePlate(a) === normalizeVehiclePlate(b) ||
+        isOcrPlausiblePlateMatch(a, b),
       notExtractedReason: REVIEW_REASONS.FIELD_NOT_EXTRACTED({
         field: 'vehicle plate',
       }),
@@ -114,6 +116,19 @@ export const validateMtrExtractedData = (
       routing: 'review',
     },
   );
+
+  const extractedPlate = extractedData.vehiclePlate?.parsed;
+
+  if (
+    extractedPlate !== undefined &&
+    eventPlateString !== undefined &&
+    normalizeVehiclePlate(extractedPlate) !==
+      normalizeVehiclePlate(eventPlateString) &&
+    isOcrPlausiblePlateMatch(extractedPlate, eventPlateString)
+  ) {
+    vehiclePlate.debug.observation =
+      'Plates differ by 1 character in an OCR-plausible substitution (e.g., letter/digit confusion). Accepted as match.';
+  }
 
   const receiverReasons: EntityComparisonReasons = {
     address: {

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-custom-1.parser.spec.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-custom-1.parser.spec.ts
@@ -45,32 +45,32 @@ describe('CdfCustom1Parser', () => {
   // Preamble blocks (generator, recycler, etc.) needed for parser to extract other fields
   const CDF_PREAMBLE_BLOCKS: TextBlock[] = [
     makeBlock('CDF 50193/24', 0.06, 0.05),
-    makeBlock('Jundiaí, 07 de Agosto de 2024.', 0.06, 0.1),
-    makeBlock('Empresa Recebedora: Tera Ambiental Ltda.', 0.06, 0.2),
-    makeBlock('CNPJ: 59.591.115/0003-02 IE: 407.275.597.112', 0.06, 0.22),
-    makeBlock('Empresa Geradora: AJINOMOTO DO BRASIL', 0.06, 0.3),
-    makeBlock('CNPJ: 46.344.354/0005-88 IE: 417325212115', 0.06, 0.32),
+    makeBlock('Cidade Centro, 07 de Agosto de 2024.', 0.06, 0.1),
+    makeBlock('Empresa Recebedora: Destino Ambiental Ltda.', 0.06, 0.2),
+    makeBlock('CNPJ: 33.444.555/0003-77 IE: 111.222.333.444', 0.06, 0.22),
+    makeBlock('Empresa Geradora: EXEMPLO INDUSTRIAS', 0.06, 0.3),
+    makeBlock('CNPJ: 11.222.333/0004-55 IE: 222333444555', 0.06, 0.32),
   ];
 
   const validCustomCdfText = [
-    'Tera Ambiental Ltda',
-    'Rua Paulino Corado, 20 - Sala 603 Jardim Santa Teresa, Jundiaí - SP',
+    'Destino Ambiental Ltda',
+    'Rua Comercial, 20 - Sala 603 Jardim Modelo, Cidade Centro - SP',
     'CDF 50193/24',
-    'Jundiaí, 07 de Agosto de 2024.',
+    'Cidade Centro, 07 de Agosto de 2024.',
     'CERTIFICADO DE DESTINAÇÃO FINAL',
     'N°50193/24',
-    'Informamos que a Tera Ambiental Ltda, com sede em Jundiaí, no estado de São Paulo,',
-    'inscrita no CNPJ: 59.591.115/0003-02, através da compostagem de lodo de esgoto,',
-    'certifica que as matérias-primas abaixo discriminados da empresa AJINOMOTO DO BRASIL',
+    'Informamos que a Destino Ambiental Ltda, com sede em Cidade Centro, no estado de São Paulo,',
+    'inscrita no CNPJ: 33.444.555/0003-77, através da compostagem de lodo de esgoto,',
+    'certifica que as matérias-primas abaixo discriminados da empresa EXEMPLO INDUSTRIAS',
     'no período abaixo identificado foram recebidas e tratadas em',
     'conformidade com a licença nº: 36013428 de 25/06/2024.',
-    'Empresa Recebedora: Tera Ambiental Ltda.',
-    'Endereço: Estrada Municipal do Varjão, 4.520',
-    'Cadastro na Cetesb: 407-0361098',
-    'CNPJ: 59.591.115/0003-02 IE: 407.275.597.112',
-    'Empresa Geradora: AJINOMOTO DO BRASIL INDÚSTRIA E COMÉRCIO DE ALIMENTOS LTDA.',
-    'Endereço: RODOVIA ANHANGUERA (SP 330) KM 131',
-    'CNPJ: 46.344.354/0005-88 IE: 417325212115',
+    'Empresa Recebedora: Destino Ambiental Ltda.',
+    'Endereço: Estrada Municipal Exemplo, 4.520',
+    'Cadastro na Cetesb: 100-0001234',
+    'CNPJ: 33.444.555/0003-77 IE: 111.222.333.444',
+    'Empresa Geradora: EXEMPLO INDUSTRIAS E COMERCIO DE ALIMENTOS LTDA.',
+    'Endereço: RODOVIA EXEMPLO (XX 100) KM 50',
+    'CNPJ: 11.222.333/0004-55 IE: 222333444555',
     'LODO SÓLIDO - SANITÁRIO: LODO GERADO NA ESTAÇÃO DE TRATAMENTO DE ÁGUA',
     'Descrição: Tipo de Matéria-Prima CADRI Data do Recebimento Quantidade (ton)',
     'LODO SÓLIDO - SANITÁRIO 42003189 01/07/2024 85,12',
@@ -89,13 +89,13 @@ describe('CdfCustom1Parser', () => {
       expect(result.data.documentNumber?.confidence).toBe('high');
       expect(result.data.issueDate?.parsed).toBe('07/08/2024');
       expect(result.data.issueDate?.confidence).toBe('high');
-      expect(result.data.recycler?.name.parsed).toBe('Tera Ambiental Ltda.');
-      expect(result.data.recycler?.taxId.parsed).toBe('59.591.115/0003-02');
+      expect(result.data.recycler?.name.parsed).toBe('Destino Ambiental Ltda.');
+      expect(result.data.recycler?.taxId.parsed).toBe('33.444.555/0003-77');
       expect(result.data.recycler?.name.confidence).toBe('high');
       expect(result.data.generator?.name.parsed).toBe(
-        'AJINOMOTO DO BRASIL INDUSTRIA E COMERCIO DE ALIMENTOS LTDA.',
+        'EXEMPLO INDUSTRIAS E COMERCIO DE ALIMENTOS LTDA.',
       );
-      expect(result.data.generator?.taxId.parsed).toBe('46.344.354/0005-88');
+      expect(result.data.generator?.taxId.parsed).toBe('11.222.333/0004-55');
       expect(result.data.generator?.name.confidence).toBe('high');
       expect(result.data.environmentalLicense?.parsed).toBe('36013428');
       expect(result.data.treatmentMethod?.parsed).toBe(
@@ -123,16 +123,16 @@ describe('CdfCustom1Parser', () => {
     it('should extract generator address when Endereço line has city/state format', () => {
       const text = [
         'CDF 31014/21',
-        'Jundiaí, 10 de Fevereiro de 2021.',
+        'Cidade Centro, 10 de Fevereiro de 2021.',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'N°31014/21',
         'certifica que as matérias-primas',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'Endereço: Estrada Municipal do Varjão, 4.520 Bairro Varjão Jundiaí/SP CEP: 13212-590',
-        'CNPJ: 59.591.115/0003-02',
-        'Empresa Geradora: COMPANHIA SANEAMENTO DE JUNDIAI',
-        'Endereço: ESTRADA MUNICIPAL DO VARJÃO, 4.520 JD. NOVO HORIZONTE, JUNDIAI /SP CEP: 13212-590',
-        'CNPJ: 01.201.289/0001-70 IE: ISENTO',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'Endereço: Estrada Municipal Exemplo, 4.520 Bairro Exemplo Cidade Centro/SP CEP: 13212-590',
+        'CNPJ: 33.444.555/0003-77',
+        'Empresa Geradora: COMPANHIA SANEAMENTO MUNICIPAL',
+        'Endereço: ESTRADA MUNICIPAL EXEMPLO, 4.520 JD. HORIZONTE, CIDADE CENTRO /SP CEP: 13212-590',
+        'CNPJ: 99.000.111/0001-44 IE: ISENTO',
         'Cadastro na Cetesb: 123',
         'CADRI',
         'matérias-primas',
@@ -143,20 +143,20 @@ describe('CdfCustom1Parser', () => {
       const result = parser.parse(stubTextExtractionResult(text));
 
       expect(result.data.generator?.name.parsed).toBe(
-        'COMPANHIA SANEAMENTO DE JUNDIAI',
+        'COMPANHIA SANEAMENTO MUNICIPAL',
       );
-      expect(result.data.generator?.taxId.parsed).toBe('01.201.289/0001-70');
+      expect(result.data.generator?.taxId.parsed).toBe('99.000.111/0001-44');
       expect(result.data.generator?.address.parsed).toBe(
-        'ESTRADA MUNICIPAL DO VARJAO, 4.520 JD. NOVO HORIZONTE',
+        'ESTRADA MUNICIPAL EXEMPLO, 4.520 JD. HORIZONTE',
       );
-      expect(result.data.generator?.city.parsed).toBe('JUNDIAI');
+      expect(result.data.generator?.city.parsed).toBe('CIDADE CENTRO');
       expect(result.data.generator?.state.parsed).toBe('SP');
       expect(result.data.generator?.address.confidence).toBe('high');
     });
 
     it('should set reviewRequired when required fields are missing', () => {
       const incompleteText = [
-        'Tera Ambiental Ltda',
+        'Destino Ambiental Ltda',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'Empresa Recebedora: Some Company',
       ].join('\n');
@@ -196,7 +196,7 @@ describe('CdfCustom1Parser', () => {
       ];
 
       for (const { expected, text } of variations) {
-        const fullText = `${text}\nJundiaí, 01 de Janeiro de 2024.`;
+        const fullText = `${text}\nCidade Centro, 01 de Janeiro de 2024.`;
         const result = parser.parse(stubTextExtractionResult(fullText));
 
         expect(result.data.documentNumber?.parsed).toBe(expected);
@@ -285,9 +285,9 @@ describe('CdfCustom1Parser', () => {
     it('should handle entity with short name after label', () => {
       const shortNameText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'Empresa Recebedora: AB',
-        'CNPJ: 59.591.115/0003-02',
+        'CNPJ: 33.444.555/0003-77',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(shortNameText));
@@ -377,12 +377,12 @@ describe('CdfCustom1Parser', () => {
     it('should not set processingPeriod when no receipt table rows exist', () => {
       const noTableText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'CNPJ: 59.591.115/0003-02',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'CNPJ: 33.444.555/0003-77',
         'Empresa Geradora: Generator LTDA',
-        'CNPJ: 46.344.354/0005-88',
+        'CNPJ: 11.222.333/0004-55',
         'Cadastro na Cetesb: 123',
         'CADRI',
         'matérias-primas',
@@ -398,16 +398,16 @@ describe('CdfCustom1Parser', () => {
     it('should not set processingPeriod when no rows match the receipt table pattern', () => {
       const invalidDatesText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
-        'CNPJ: 59.591.115/0003-02 IE: 407275597112',
-        'CNPJ: 46.344.354/0005-88 IE: 417325212115',
+        'Cidade Centro, 01 de Janeiro de 2024.',
+        'CNPJ: 33.444.555/0003-77 IE: 111222333444',
+        'CNPJ: 11.222.333/0004-55 IE: 222333444555',
         'LODO SÓLIDO - SANITÁRIO: LODO DE ETE',
         'Descrição: Tipo de Matéria-Prima CADRI Data',
         'LODO SÓLIDO - SANITÁRIO - invalid-date 85,12',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'CNPJ: 59.591.115/0003-02',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'CNPJ: 33.444.555/0003-77',
         'Empresa Geradora: Generator LTDA',
-        'CNPJ: 46.344.354/0005-88',
+        'CNPJ: 11.222.333/0004-55',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'Cadastro na Cetesb: 123',
         'CADRI',
@@ -422,18 +422,18 @@ describe('CdfCustom1Parser', () => {
     it('should skip receipt table rows with unparseable quantity', () => {
       const badQuantityText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
-        'CNPJ: 59.591.115/0003-02 IE: 407275597112',
-        'CNPJ: 46.344.354/0005-88 IE: 417325212115',
+        'Cidade Centro, 01 de Janeiro de 2024.',
+        'CNPJ: 33.444.555/0003-77 IE: 111222333444',
+        'CNPJ: 11.222.333/0004-55 IE: 222333444555',
         'LODO SÓLIDO - SANITÁRIO: LODO DE ETE',
         'Descrição: Tipo de Matéria-Prima CADRI Data',
         'LODO SÓLIDO - SANITÁRIO 42003189 01/07/2024 ...',
         'LODO SÓLIDO - SANITÁRIO 42003189 02/07/2024 90,50',
         'Quantidade Tratada de LODO SÓLIDO - SANITÁRIO 90,50',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'CNPJ: 59.591.115/0003-02',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'CNPJ: 33.444.555/0003-77',
         'Empresa Geradora: Generator LTDA',
-        'CNPJ: 46.344.354/0005-88',
+        'CNPJ: 11.222.333/0004-55',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'Cadastro na Cetesb: 123',
         'CADRI',
@@ -449,12 +449,12 @@ describe('CdfCustom1Parser', () => {
     it('should skip waste subtotals with unparseable quantity', () => {
       const badSubtotalText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'Quantidade Tratada de LODO SOLIDO - SANITARIO ...',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'CNPJ: 59.591.115/0003-02',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'CNPJ: 33.444.555/0003-77',
         'Empresa Geradora: Generator LTDA',
-        'CNPJ: 46.344.354/0005-88',
+        'CNPJ: 11.222.333/0004-55',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'Cadastro na Cetesb: 123',
         'CADRI',
@@ -471,13 +471,13 @@ describe('CdfCustom1Parser', () => {
     it('should not extract waste type descriptions when section markers are missing', () => {
       const noMarkersText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'LODO SÓLIDO - SANITÁRIO 42003189 01/07/2024 85,12',
         'Quantidade Tratada de LODO SÓLIDO - SANITÁRIO 85,12',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'CNPJ: 59.591.115/0003-02',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'CNPJ: 33.444.555/0003-77',
         'Empresa Geradora: Generator LTDA',
-        'CNPJ: 46.344.354/0005-88',
+        'CNPJ: 11.222.333/0004-55',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'Cadastro na Cetesb: 123',
         'CADRI',
@@ -494,12 +494,12 @@ describe('CdfCustom1Parser', () => {
     it('should fall back to total quantity when no table rows or subtotals are present', () => {
       const fallbackText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
-        'Empresa Recebedora: Tera Ambiental Ltda.',
-        'CNPJ: 59.591.115/0003-02',
+        'Empresa Recebedora: Destino Ambiental Ltda.',
+        'CNPJ: 33.444.555/0003-77',
         'Empresa Geradora: Generator LTDA',
-        'CNPJ: 46.344.354/0005-88',
+        'CNPJ: 11.222.333/0004-55',
         'Cadastro na Cetesb: 123',
         'CADRI',
         'matérias-primas',
@@ -582,7 +582,7 @@ describe('CdfCustom1Parser', () => {
           0.85,
         ),
         // Page break marker (footer at bottom of page 1)
-        makeBlock('Tera Ambiental Ltda', 0.435, 0.92),
+        makeBlock('Destino Ambiental Ltda', 0.435, 0.92),
         // Page 2 rows (top resets)
         ...makeReceiptRow(
           'LODO SOLIDO - SANITARIO',

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-custom-1.parser.spec.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-custom-1.parser.spec.ts
@@ -170,7 +170,7 @@ describe('CdfCustom1Parser', () => {
     it('should set low confidence for entities with missing CNPJ', () => {
       const noCnpjText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'Empresa Recebedora: Company Without CNPJ',
         'Empresa Geradora: Generator Without CNPJ',
@@ -233,7 +233,7 @@ describe('CdfCustom1Parser', () => {
     it('should extract environmental license from preamble text', () => {
       const licenseText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'conformidade com a licença nº: 36013428 de 25/06/2024.',
       ].join('\n');
 
@@ -245,7 +245,7 @@ describe('CdfCustom1Parser', () => {
     it('should extract treatment method from preamble text', () => {
       const treatmentText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'através da compostagem de lodo de esgoto, certifica que',
       ].join('\n');
 
@@ -259,7 +259,7 @@ describe('CdfCustom1Parser', () => {
     it('should handle waste quantity in Brazilian number format', () => {
       const quantityText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'Quantidade Total Tratado',
         '1.377,59',
       ].join('\n');
@@ -272,7 +272,7 @@ describe('CdfCustom1Parser', () => {
     it('should not extract waste quantity when value is NaN', () => {
       const nanQuantityText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'Quantidade Total Tratado',
         '...',
       ].join('\n');
@@ -298,7 +298,7 @@ describe('CdfCustom1Parser', () => {
     it('should handle quantity on the same line as label (fallback)', () => {
       const sameLineText = [
         'CDF 100/24',
-        'Jundiaí, 01 de Janeiro de 2024.',
+        'Cidade Centro, 01 de Janeiro de 2024.',
         'Quantidade Total Tratado 500,00',
       ].join('\n');
 

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.spec.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.spec.ts
@@ -18,15 +18,15 @@ describe('CDF shared helpers', () => {
 
     it('should extract recycler name and CNPJ from preamble', () => {
       const text =
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu';
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu';
 
       const result = extractRecyclerFromPreamble(text, preamblePattern);
 
       expect(result).toEqual({
         rawMatch: expect.any(String),
         value: {
-          name: 'ECO ADUBOS ORGANICOS LTDA',
-          taxId: '13.843.890/0001-45',
+          name: 'ADUBOS VERDES ORGANICOS LTDA',
+          taxId: '44.555.666/0001-88',
         },
       });
     });
@@ -40,27 +40,27 @@ describe('CDF shared helpers', () => {
     it('should handle unformatted CNPJ with custom pattern', () => {
       const unformattedPattern = /^(.+?),\s*CPF\/CNPJ\s+(\d{14})\s+certifica/m;
       const text =
-        'EMPRESA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu';
+        'EMPRESA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu';
 
       const result = extractRecyclerFromPreamble(text, unformattedPattern);
 
-      expect(result?.value.taxId).toBe('13843890000145');
+      expect(result?.value.taxId).toBe('44555666000188');
     });
   });
 
   describe('createRecyclerEntity', () => {
     it('should create high confidence entity from extracted data', () => {
       const result = createRecyclerEntity({
-        rawMatch: 'ECO ADUBOS, CPF/CNPJ 13.843.890/0001-45 certifica',
+        rawMatch: 'ADUBOS VERDES, CPF/CNPJ 44.555.666/0001-88 certifica',
         value: {
-          name: 'ECO ADUBOS',
-          taxId: '13.843.890/0001-45',
+          name: 'ADUBOS VERDES',
+          taxId: '44.555.666/0001-88',
         },
       });
 
-      expect(result.name.parsed).toBe('ECO ADUBOS');
+      expect(result.name.parsed).toBe('ADUBOS VERDES');
       expect(result.name.confidence).toBe('high');
-      expect(result.taxId.parsed).toBe('13.843.890/0001-45');
+      expect(result.taxId.parsed).toBe('44.555.666/0001-88');
     });
 
     it('should create low confidence entity when undefined', () => {

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-sinfat.parser.spec.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-sinfat.parser.spec.ts
@@ -16,12 +16,12 @@ describe('CdfSinfatParser', () => {
   const validCdfText = [
     'Periodo: 01/02/2023 até 28/02/2023',
     'Certificado de Destinação Final CDF nº 2154920/2023',
-    'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+    'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
     'os resíduos abaixo discriminados.',
     '',
     'Identificação do Gerador',
-    'Razão Social: Laticínios Bela Vista LTDA CPF/CNPJ: 02.089.969/0035-55',
-    'Endereço: Rua Empresário Agenello Senger, nº S/N Municipio: Carazinho UF: RS',
+    'Razão Social: Laticínios Modelo LTDA CPF/CNPJ: 55.666.777/0035-99',
+    'Endereço: Rua Industrial, nº S/N Municipio: Cidade Interior UF: RS',
     '',
     'Identificação dos Resíduos',
     '1. 040108 - Resíduos de couros (aparas, resíduos de corte, pó de rebaixamento, pó de lixamento)',
@@ -31,7 +31,7 @@ describe('CdfSinfatParser', () => {
     '',
     'Declaração',
     'Declaramos que os resíduos foram destinados conforme legislação ambiental vigente.',
-    'Carazinho, 10/04/2023',
+    'Cidade Interior, 10/04/2023',
     '',
     'MTRs incluidos',
     '2302037916, 2302037795, 2302037801',
@@ -69,19 +69,17 @@ describe('CdfSinfatParser', () => {
       expect(result.data.documentNumber?.confidence).toBe('high');
 
       expect(result.data.recycler?.name.parsed).toBe(
-        'ECO ADUBOS ORGANICOS LTDA',
+        'ADUBOS VERDES ORGANICOS LTDA',
       );
-      expect(result.data.recycler?.taxId.parsed).toBe('13.843.890/0001-45');
+      expect(result.data.recycler?.taxId.parsed).toBe('44.555.666/0001-88');
       expect(result.data.recycler?.name.confidence).toBe('high');
 
-      expect(result.data.generator?.name.parsed).toBe(
-        'Laticinios Bela Vista LTDA',
-      );
-      expect(result.data.generator?.taxId.parsed).toBe('02.089.969/0035-55');
+      expect(result.data.generator?.name.parsed).toBe('Laticinios Modelo LTDA');
+      expect(result.data.generator?.taxId.parsed).toBe('55.666.777/0035-99');
       expect(result.data.generator?.address.parsed).toBe(
-        'Rua Empresario Agenello Senger, nº S/N',
+        'Rua Industrial, nº S/N',
       );
-      expect(result.data.generator?.city.parsed).toBe('Carazinho');
+      expect(result.data.generator?.city.parsed).toBe('Cidade Interior');
       expect(result.data.generator?.state.parsed).toBe('RS');
       expect(result.data.generator?.name.confidence).toBe('high');
 
@@ -175,7 +173,7 @@ describe('CdfSinfatParser', () => {
         'Identificação do Gerador',
         'Razão Social: Some Company LTDA CPF/CNPJ: 02.089.969/0035-55',
         'Declaração',
-        'Carazinho, 10/04/2023',
+        'Cidade Interior, 10/04/2023',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(noRecyclerText));
@@ -187,9 +185,9 @@ describe('CdfSinfatParser', () => {
     it('should set low confidence when generator section is missing', () => {
       const noGeneratorText = [
         'Certificado de Destinação Final CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Declaração',
-        'Carazinho, 10/04/2023',
+        'Cidade Interior, 10/04/2023',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(noGeneratorText));
@@ -227,12 +225,12 @@ describe('CdfSinfatParser', () => {
     it('should extract issue date from Declaração section', () => {
       const text = [
         'CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Identificação do Gerador',
         'Razão Social: Company LTDA CPF/CNPJ: 02.089.969/0035-55',
         'Declaração',
         'Declaramos que os resíduos foram destinados.',
-        'Carazinho, 15/06/2024',
+        'Cidade Interior, 15/06/2024',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(text));
@@ -243,9 +241,9 @@ describe('CdfSinfatParser', () => {
     it('should extract generator taxId when it is a CPF', () => {
       const text = [
         'CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Identificação do Gerador',
-        'Razão Social: João da Silva CPF/CNPJ: 123.456.789-01',
+        'Razão Social: Pedro Santos CPF/CNPJ: 123.456.789-01',
         'Endereço: Rua Principal, 100 Municipio: São Paulo UF: SP',
         'Declaração',
         'São Paulo, 01/04/2024',
@@ -254,7 +252,7 @@ describe('CdfSinfatParser', () => {
       const result = parser.parse(stubTextExtractionResult(text));
 
       expect(result.data.generator?.taxId.parsed).toBe('123.456.789-01');
-      expect(result.data.generator?.name.parsed).toBe('Joao da Silva');
+      expect(result.data.generator?.name.parsed).toBe('Pedro Santos');
     });
 
     it('should extract processing period range', () => {
@@ -275,7 +273,7 @@ describe('CdfSinfatParser', () => {
     it('should not extract waste entries when none are present', () => {
       const noWasteText = [
         'CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Declaração',
         'City, 01/04/2024',
       ].join('\n');
@@ -288,7 +286,7 @@ describe('CdfSinfatParser', () => {
     it('should not extract transport manifests when section is missing', () => {
       const noMtrText = [
         'CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Declaração',
         'City, 01/04/2024',
       ].join('\n');
@@ -301,7 +299,7 @@ describe('CdfSinfatParser', () => {
     it('should extract environmental license', () => {
       const text = [
         'CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Licença Ambiental: LO-12345/2024',
         'Identificação do Gerador',
         'Razão Social: Company LTDA CPF/CNPJ: 02.089.969/0035-55',
@@ -317,7 +315,7 @@ describe('CdfSinfatParser', () => {
     it('should skip rows with non-code residuo text in bounding-box table', () => {
       const rawText = [
         'Certificado de Destinação Final CDF nº 100/2025',
-        'BIOCOMP LTDA, CPF/CNPJ 16.642.962/0003-46 certifica que recebeu',
+        'BIOPROCESSO LTDA, CPF/CNPJ 66.777.888/0003-11 certifica que recebeu',
         'Identificação dos Resíduos',
         'Resíduo Classe Quantidade Unidade Tecnologia',
         'random text',
@@ -341,7 +339,7 @@ describe('CdfSinfatParser', () => {
     it('should extract waste entry from blocks without quantity columns', () => {
       const rawText = [
         'Certificado de Destinação Final CDF nº 100/2025',
-        'BIOCOMP LTDA, CPF/CNPJ 16.642.962/0003-46 certifica que recebeu',
+        'BIOPROCESSO LTDA, CPF/CNPJ 66.777.888/0003-11 certifica que recebeu',
         'Identificação dos Resíduos',
         'Resíduo Classe Quantidade Unidade Tecnologia',
         '1. 020204 - Lodos do Tratamento',
@@ -374,12 +372,12 @@ describe('CdfSinfatParser', () => {
     it('should extract waste entries from bounding-box table when blocks are available', () => {
       const rawText = [
         'Certificado de Destinação Final CDF nº 3305038/2025',
-        'BIOCOMP SOLUCOES AMBIENTAIS LTDA, CPF/CNPJ 16.642.962/0003-46 certifica que recebeu',
+        'BIOPROCESSO SOLUCOES AMBIENTAIS LTDA, CPF/CNPJ 66.777.888/0003-11 certifica que recebeu',
         'Identificação dos Resíduos',
         'Resíduo Classe Quantidade Unidade Tecnologia',
         '1. 020204 - Lodos do Tratamento local de efluentes Classe II A 2,41000 Tonelada Compostagem',
         'Declaração',
-        'Papagaios, 31/03/2025',
+        'Cidade Rural, 31/03/2025',
         'MTRs incluidos',
         '1224257176, 1224231434',
         'Nome do Responsável',
@@ -427,7 +425,7 @@ describe('CdfSinfatParser', () => {
     it('should extract generator without address', () => {
       const text = [
         'CDF nº 100/2023',
-        'ECO ADUBOS ORGANICOS LTDA, CPF/CNPJ 13.843.890/0001-45 certifica que recebeu',
+        'ADUBOS VERDES ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
         'Identificação do Gerador',
         'Razão Social: Company LTDA CPF/CNPJ: 02.089.969/0035-55',
         'Declaração',

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-sinir.parser.spec.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-sinir.parser.spec.ts
@@ -40,15 +40,15 @@ describe('CdfSinirParser', () => {
     'CERTIFICADO DE DESTINAÇÃO FINAL',
     'CDF nº 3001234/2025',
     'Periodo: 01/04/2025 a 30/04/2025',
-    'EMPRESA RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+    'EMPRESA RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
     'os resíduos abaixo discriminados.',
     'Licença Ambiental: LO-1234/2024',
     '',
     'Razão Social:',
-    'LATICÍNIOS BELA VISTA LTDA',
+    'LATICÍNIOS MODELO LTDA',
     'CPF/CNPJ:',
-    '02089969003555',
-    'Endereço: Rua Empresário Agenello Senger, nº S/N Municipio: Carazinho UF: RS',
+    '55666777003599',
+    'Endereço: Rua Industrial, nº S/N Municipio: Cidade Interior UF: RS',
     '',
     'Identificação dos Resíduos',
     '040108 - Resíduos de couros',
@@ -58,7 +58,7 @@ describe('CdfSinirParser', () => {
     '',
     'Declaração',
     'Declaramos que os resíduos foram destinados.',
-    'Carazinho, 10/05/2025',
+    'Cidade Interior, 10/05/2025',
     '',
     'Manifestos Incluídos:',
     '240001460711, 240001460712, 240001460713',
@@ -77,19 +77,17 @@ describe('CdfSinirParser', () => {
       expect(result.data.recycler?.name.parsed).toBe(
         'EMPRESA RECICLADORA LTDA',
       );
-      expect(result.data.recycler?.taxId.parsed).toBe('13843890000145');
+      expect(result.data.recycler?.taxId.parsed).toBe('44555666000188');
       expect(result.data.recycler?.name.confidence).toBe('high');
 
-      expect(result.data.generator?.name.parsed).toBe(
-        'LATICINIOS BELA VISTA LTDA',
-      );
-      expect(result.data.generator?.taxId.parsed).toBe('02089969003555');
+      expect(result.data.generator?.name.parsed).toBe('LATICINIOS MODELO LTDA');
+      expect(result.data.generator?.taxId.parsed).toBe('55666777003599');
       expect(result.data.generator?.name.confidence).toBe('high');
 
       expect(result.data.generator?.address.parsed).toBe(
-        'Rua Empresario Agenello Senger, nº S/N',
+        'Rua Industrial, nº S/N',
       );
-      expect(result.data.generator?.city.parsed).toBe('Carazinho');
+      expect(result.data.generator?.city.parsed).toBe('Cidade Interior');
       expect(result.data.generator?.state.parsed).toBe('RS');
 
       expect(result.data.issueDate?.parsed).toBe('10/05/2025');
@@ -180,20 +178,20 @@ describe('CdfSinirParser', () => {
     it('should handle unformatted 14-digit CNPJ for recycler', () => {
       const text = [
         'CDF nº 100/2023',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Declaração',
         'City, 01/04/2024',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(text));
 
-      expect(result.data.recycler?.taxId.parsed).toBe('13843890000145');
+      expect(result.data.recycler?.taxId.parsed).toBe('44555666000188');
     });
 
     it('should extract generator with separate-line labels', () => {
       const text = [
         'CDF nº 100/2023',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Razão Social:',
         'EMPRESA GERADORA LTDA',
         'CNPJ:',
@@ -212,18 +210,18 @@ describe('CdfSinirParser', () => {
       const text = [
         'CDF n° 2834634/2024',
         'Período : 20/03/2024 até 30/04/2024',
-        'COMPOSTAMAIS LTDA., CPF/CNPJ 33545743000104 certifica que',
-        'recebeu, em sua unidade de Araucária PR',
+        'COMPOST VERDE LTDA., CPF/CNPJ 77888999000122 certifica que',
+        'recebeu, em sua unidade de Cidade Industrial PR',
         'Identificação do Gerador',
         'Razão Social :Brasturinvest Investimentos Turistico SA',
-        'CNPJ/CPF : 03422594000540',
+        'CNPJ/CPF : 44555666000177',
         'Endereço :',
-        'Comendador Araújo,499 Pestana Curitiba Hotel Centro',
+        'Rua Central,499 Bairro Modelo Hotel Centro',
         'Munícipio :',
         'Curitiba',
         'UF PR',
         'Identificação dos Resíduos',
-        'Araucária, 06/05/2024',
+        'Cidade Industrial, 06/05/2024',
         'Responsável',
         'Sistema MTR do Sinir',
       ].join('\n');
@@ -234,9 +232,9 @@ describe('CdfSinirParser', () => {
         'Brasturinvest Investimentos Turistico SA',
       );
       expect(result.data.generator?.name.confidence).toBe('high');
-      expect(result.data.generator?.taxId.parsed).toBe('03422594000540');
+      expect(result.data.generator?.taxId.parsed).toBe('44555666000177');
       expect(result.data.generator?.address.parsed).toBe(
-        'Comendador Araujo,499 Pestana Curitiba Hotel Centro',
+        'Rua Central,499 Bairro Modelo Hotel Centro',
       );
       expect(result.data.generator?.city.parsed).toBe('Curitiba');
       expect(result.data.generator?.state.parsed).toBe('PR');
@@ -247,18 +245,18 @@ describe('CdfSinirParser', () => {
     it('should extract generator address from multi-line OCR layout', () => {
       const text = [
         'CDF n° 2834634/2024',
-        'COMPOSTAMAIS LTDA., CPF/CNPJ 33545743000104 certifica que',
-        'recebeu, em sua unidade de Araucária PR',
+        'COMPOST VERDE LTDA., CPF/CNPJ 77888999000122 certifica que',
+        'recebeu, em sua unidade de Cidade Industrial PR',
         'Razão Social :Empresa Geradora LTDA',
-        'CNPJ/CPF : 03422594000540',
+        'CNPJ/CPF : 44555666000177',
         'Endereço :',
-        'Rua Santa Catarina, 1575 Guaíra',
+        'Rua Floresta, 1575 Jardim',
         'Munícipio',
         'Curitiba',
         'UF PR',
         'Identificação dos Resíduos',
         'Declaração',
-        'Araucária, 06/05/2024',
+        'Cidade Industrial, 06/05/2024',
         'Responsável',
         'Sistema MTR do Sinir',
       ].join('\n');
@@ -266,7 +264,7 @@ describe('CdfSinirParser', () => {
       const result = parser.parse(stubTextExtractionResult(text));
 
       expect(result.data.generator?.address.parsed).toBe(
-        'Rua Santa Catarina, 1575 Guaira',
+        'Rua Floresta, 1575 Jardim',
       );
       expect(result.data.generator?.address.confidence).toBe('high');
       expect(result.data.generator?.city.parsed).toBe('Curitiba');
@@ -276,8 +274,8 @@ describe('CdfSinirParser', () => {
     it('should extract issue date before Responsável when Declaração is absent', () => {
       const text = [
         'CDF nº 100/2023',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
-        'Araucária, 18/02/2025',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
+        'Cidade Industrial, 18/02/2025',
         'Responsável',
         'Sistema MTR do Sinir',
       ].join('\n');
@@ -294,7 +292,7 @@ describe('CdfSinirParser', () => {
         'Razão Social:',
         'Company LTDA',
         'CNPJ:',
-        '02089969003555',
+        '55666777003599',
         'Declaração',
         'City, 10/04/2023',
       ].join('\n');
@@ -308,7 +306,7 @@ describe('CdfSinirParser', () => {
     it('should set low confidence when generator section is missing', () => {
       const noGeneratorText = [
         'CDF nº 100/2023',
-        'EMPRESA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'EMPRESA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Declaração',
         'City, 10/04/2023',
       ].join('\n');
@@ -333,7 +331,7 @@ describe('CdfSinirParser', () => {
     it('should not extract waste entries when none are present', () => {
       const noWasteText = [
         'CDF nº 100/2023',
-        'EMPRESA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'EMPRESA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Declaração',
         'City, 01/04/2024',
       ].join('\n');
@@ -346,7 +344,7 @@ describe('CdfSinirParser', () => {
     it('should not extract transport manifests when section is missing', () => {
       const noMtrText = [
         'CDF nº 100/2023',
-        'EMPRESA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'EMPRESA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Declaração',
         'City, 01/04/2024',
       ].join('\n');
@@ -360,12 +358,12 @@ describe('CdfSinirParser', () => {
       const rawText = [
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'CDF n° 3661772/2025',
-        'COMPOSTAMAIS LTDA., CPF/CNPJ 33545743000104 certifica que recebeu',
+        'COMPOST VERDE LTDA., CPF/CNPJ 77888999000122 certifica que recebeu',
         'Identificação dos Resíduos',
         'Resíduo Classe Quantidade Unidade Tratamento',
         '200108 Resíduos biodegradáveis de cozinha e cantinas CLASSE II A 1,1200 Tonelada Compostagem',
         'Declaração',
-        'Araucária, 18/02/2025',
+        'Cidade Industrial, 18/02/2025',
         'Responsável',
         'Sistema MTR do Sinir',
       ].join('\n');
@@ -415,7 +413,7 @@ describe('CdfSinirParser', () => {
       const rawText = [
         'CERTIFICADO DE DESTINAÇÃO FINAL',
         'CDF n° 100/2025',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Identificação dos Resíduos',
         'Resíduo Classe Quantidade Unidade Tratamento',
         '040108 Resíduos de couros CLASSE II A 1,9500 Tonelada Tratamento',
@@ -490,7 +488,7 @@ describe('CdfSinirParser', () => {
     it('should skip rows with non-code residuo text in bounding-box table', () => {
       const rawText = [
         'CDF n° 100/2025',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Resíduo Classe Quantidade Unidade Tratamento',
         'random text',
         'Declaração',
@@ -515,7 +513,7 @@ describe('CdfSinirParser', () => {
     it('should extract waste entry from blocks without quantity columns', () => {
       const rawText = [
         'CDF n° 100/2025',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Resíduo Classe Quantidade Unidade Tratamento',
         '200108 Resíduos biodegradáveis',
         'Declaração',
@@ -549,7 +547,7 @@ describe('CdfSinirParser', () => {
     it('should handle waste code without dash in bounding-box table', () => {
       const rawText = [
         'CDF n° 100/2025',
-        'RECICLADORA LTDA, CPF/CNPJ 13843890000145 certifica que recebeu',
+        'RECICLADORA LTDA, CPF/CNPJ 44555666000188 certifica que recebeu',
         'Resíduo Classe Quantidade Unidade Tratamento',
         '200108 Resíduos biodegradáveis CLASSE II A 3,0912 Tonelada Compostagem',
         'Declaração',

--- a/libs/shared/document-extractor-transport-manifest/src/mtr-shared.helpers.spec.ts
+++ b/libs/shared/document-extractor-transport-manifest/src/mtr-shared.helpers.spec.ts
@@ -23,8 +23,8 @@ describe('MTR shared helpers', () => {
 
     it('should strip trailing registration number with dash', () => {
       expect(
-        stripTrailingRegistrationNumber('COMPOSTAMAIS LTDA. - 112752'),
-      ).toBe('COMPOSTAMAIS LTDA.');
+        stripTrailingRegistrationNumber('COMPOST VERDE LTDA. - 112752'),
+      ).toBe('COMPOST VERDE LTDA.');
     });
 
     it('should strip trailing registration number with en-dash', () => {
@@ -50,27 +50,27 @@ describe('MTR shared helpers', () => {
     it('should extract address, city, and state from section text', () => {
       const section = [
         'Razao Social: Test Company',
-        'Endereco: Rua Empresario Agenello Senger, nº S/N',
-        'Municipio: Carazinho',
+        'Endereco: Rua Industrial, nº S/N',
+        'Municipio: Cidade Interior',
         'UF: RS',
       ].join('\n');
 
       expect(extractAddressFields(section)).toEqual({
-        address: 'Rua Empresario Agenello Senger, nº S/N',
-        city: 'Carazinho',
+        address: 'Rua Industrial, nº S/N',
+        city: 'Cidade Interior',
         state: 'RS',
       });
     });
 
     it('should handle Estado variant for state', () => {
       const section = [
-        'Endereco: Av. Brasil, 500',
+        'Endereco: Av. Principal, 500',
         'Municipio: Sao Paulo',
         'Estado: SP',
       ].join('\n');
 
       expect(extractAddressFields(section)).toEqual({
-        address: 'Av. Brasil, 500',
+        address: 'Av. Principal, 500',
         city: 'Sao Paulo',
         state: 'SP',
       });
@@ -98,13 +98,13 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'GERSON PEREIRA DA SILVA',
-        'AUP5E49',
+        'CARLOS OLIVEIRA DOS SANTOS',
+        'FKE1A23',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'GERSON PEREIRA DA SILVA',
-        vehiclePlate: 'AUP5E49',
+        driverName: 'CARLOS OLIVEIRA DOS SANTOS',
+        vehiclePlate: 'FKE1A23',
       });
     });
 
@@ -112,13 +112,13 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'NKW1862',
+        'HIJ3K56',
         'Rafael Silva',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
         driverName: 'Rafael Silva',
-        vehiclePlate: 'NKW1862',
+        vehiclePlate: 'HIJ3K56',
       });
     });
 
@@ -126,31 +126,31 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'CARLOS SILVA',
-        'BRA2E19',
+        'PEDRO ALMEIDA',
+        'FKE2B34',
         'nome e assinatura do responsavel',
         'cargo',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'CARLOS SILVA',
-        vehiclePlate: 'BRA2E19',
+        driverName: 'PEDRO ALMEIDA',
+        vehiclePlate: 'FKE2B34',
       });
     });
 
     it('should extract only driver name when only driver label is present', () => {
-      const section = ['Nome do Motorista', 'MARIA SANTOS'].join('\n');
+      const section = ['Nome do Motorista', 'ANA FERREIRA'].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'MARIA SANTOS',
+        driverName: 'ANA FERREIRA',
       });
     });
 
     it('should extract only plate when only plate label is present', () => {
-      const section = ['Placa do Veiculo', 'BRA2E19'].join('\n');
+      const section = ['Placa do Veiculo', 'FKE2B34'].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        vehiclePlate: 'BRA2E19',
+        vehiclePlate: 'FKE2B34',
       });
     });
 
@@ -176,43 +176,43 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'CARLOS SILVA',
-        'NKW 1/62',
+        'PEDRO ALMEIDA',
+        'HIJ 3/56',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'CARLOS SILVA',
-        vehiclePlate: 'NKW 1/62',
+        driverName: 'PEDRO ALMEIDA',
+        vehiclePlate: 'HIJ 3/56',
       });
     });
 
     it('should extract inline values (label: value on same line)', () => {
       const section = [
-        'Motorista: Joao da Silva',
+        'Motorista: Pedro Santos',
         'Placa do Veiculo: ABC1D23',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'Joao da Silva',
+        driverName: 'Pedro Santos',
         vehiclePlate: 'ABC1D23',
       });
     });
 
     it('should extract inline driver with "Motorista" label variant', () => {
-      const section = 'Motorista: Carlos Santos';
+      const section = 'Motorista: Andre Ferreira';
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'Carlos Santos',
+        driverName: 'Andre Ferreira',
       });
     });
 
     it('should extract only plate when both labels present but no name-like value', () => {
-      const section = ['Nome do Motorista', 'Placa do Veiculo', 'BRA2E19'].join(
+      const section = ['Nome do Motorista', 'Placa do Veiculo', 'FKE2B34'].join(
         '\n',
       );
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        vehiclePlate: 'BRA2E19',
+        vehiclePlate: 'FKE2B34',
       });
     });
 
@@ -233,10 +233,10 @@ describe('MTR shared helpers', () => {
     });
 
     it('should extract name with trailing quotes', () => {
-      const section = ['Nome do Motorista', "JOAO CARLOS '''"].join('\n');
+      const section = ['Nome do Motorista', "MARCOS ANTONIO '''"].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: "JOAO CARLOS '''",
+        driverName: "MARCOS ANTONIO '''",
       });
     });
 
@@ -253,12 +253,12 @@ describe('MTR shared helpers', () => {
         'Nome do Motorista',
         'Placa do Veiculo',
         'MAX',
-        'HHK3820',
+        'LMN4P78',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
         driverName: 'MAX',
-        vehiclePlate: 'HHK3820',
+        vehiclePlate: 'LMN4P78',
       });
     });
 
@@ -266,13 +266,13 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'LUIZ CLAUDIO DOS REIS,',
-        'GXM5293',
+        'MARCOS ANTONIO DOS SANTOS,',
+        'PQR5S12',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'LUIZ CLAUDIO DOS REIS,',
-        vehiclePlate: 'GXM5293',
+        driverName: 'MARCOS ANTONIO DOS SANTOS,',
+        vehiclePlate: 'PQR5S12',
       });
     });
 
@@ -281,12 +281,12 @@ describe('MTR shared helpers', () => {
         'Nome do Motorista',
         'Placa do Veiculo',
         'motoristateste',
-        'OOE4A25',
+        'TUV6W34',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
         driverName: 'motoristateste',
-        vehiclePlate: 'OOE4A25',
+        vehiclePlate: 'TUV6W34',
       });
     });
 
@@ -294,13 +294,13 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'Lourival Ribeiro Santos CPF: 640.160.486-72',
-        'LQS9J37',
+        'Marcos Pereira Lima CPF: 111.222.333-44',
+        'WXY7Z56',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'Lourival Ribeiro Santos CPF: 640.160.486-72',
-        vehiclePlate: 'LQS9J37',
+        driverName: 'Marcos Pereira Lima CPF: 111.222.333-44',
+        vehiclePlate: 'WXY7Z56',
       });
     });
 
@@ -308,13 +308,13 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'OOE4A25Fabiano Campolin de Souza',
-        'OOE4A25',
+        'TUV6W34Fernando Mendes Oliveira',
+        'TUV6W34',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'OOE4A25Fabiano Campolin de Souza',
-        vehiclePlate: 'OOE4A25',
+        driverName: 'TUV6W34Fernando Mendes Oliveira',
+        vehiclePlate: 'TUV6W34',
       });
     });
 
@@ -323,23 +323,23 @@ describe('MTR shared helpers', () => {
         'Nome do Motorista',
         'Placa do Veiculo',
         '224133585',
-        'FDB0D87',
+        'JKL8M90',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
         driverName: '224133585',
-        vehiclePlate: 'FDB0D87',
+        vehiclePlate: 'JKL8M90',
       });
     });
 
     it('should fallback to first value line when only driver label present and findNameLine fails', () => {
       const section = [
         'Nome do Motorista',
-        'Lourival Ribeiro Santos CPF: 640.160.486-72',
+        'Marcos Pereira Lima CPF: 111.222.333-44',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'Lourival Ribeiro Santos CPF: 640.160.486-72',
+        driverName: 'Marcos Pereira Lima CPF: 111.222.333-44',
       });
     });
 
@@ -355,11 +355,11 @@ describe('MTR shared helpers', () => {
       const section = [
         'Nome do Motorista',
         'Placa do Veiculo',
-        'CARLOS SILVA',
+        'PEDRO ALMEIDA',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
-        driverName: 'CARLOS SILVA',
+        driverName: 'PEDRO ALMEIDA',
       });
     });
 
@@ -380,12 +380,12 @@ describe('MTR shared helpers', () => {
         'Placa do Veiculo',
         'assinatura do responsavel',
         '411022658160',
-        'HBU5B80',
+        'NOP9Q12',
       ].join('\n');
 
       expect(extractDriverAndVehicle(section)).toEqual({
         driverName: '411022658160',
-        vehiclePlate: 'HBU5B80',
+        vehiclePlate: 'NOP9Q12',
       });
     });
   });
@@ -406,7 +406,7 @@ describe('MTR shared helpers', () => {
         'EMPRESA GERADORA LTDA 262960',
         'CNPJ: 12.345.678/0001-90',
         'Endereco: Rua Test, 100',
-        'Municipio: Carazinho',
+        'Municipio: Cidade Interior',
         'UF: RS',
         '',
         'Transportador',
@@ -423,7 +423,7 @@ describe('MTR shared helpers', () => {
       expect(result.name.confidence).toBe('high');
       expect(result.taxId.parsed).toBe('12.345.678/0001-90');
       expect(result.address.parsed).toBe('Rua Test, 100');
-      expect(result.city.parsed).toBe('Carazinho');
+      expect(result.city.parsed).toBe('Cidade Interior');
       expect(result.state.parsed).toBe('RS');
     });
 
@@ -444,9 +444,9 @@ describe('MTR shared helpers', () => {
       const text = [
         'Gerador',
         'EMPRESA GERADORA LTDA',
-        'CNPJ: 20.855. 175/0002-79',
+        'CNPJ: 10.111. 222/0002-55',
         'Endereco: Rua Test, 100',
-        'Municipio: Carazinho',
+        'Municipio: Cidade Interior',
         'UF: RS',
         '',
         'Transportador',
@@ -459,7 +459,7 @@ describe('MTR shared helpers', () => {
         brazilianTaxIdPattern,
       );
 
-      expect(result.taxId.parsed).toBe('20.855.175/0002-79');
+      expect(result.taxId.parsed).toBe('10.111.222/0002-55');
       expect(result.taxId.confidence).toBe('high');
       expect(result.name.parsed).toBe('EMPRESA GERADORA LTDA');
     });

--- a/libs/shared/document-extractor-transport-manifest/src/mtr-sigor.parser.spec.ts
+++ b/libs/shared/document-extractor-transport-manifest/src/mtr-sigor.parser.spec.ts
@@ -27,31 +27,31 @@ describe('MtrSigorParser', () => {
     'CETESB',
     '',
     'Identificação do Gerador',
-    'Razão Social: Ajinomoto do Brasil Indústria e Comércio de Alimentos Ltda 2845',
-    'CPF/CNPJ: 46.344.354/0005-88',
-    'Endereço: Rua Vergueiro, 1855',
-    'Município: Limeira',
+    'Razão Social: Exemplo Indústrias de Alimentos Ltda 2845',
+    'CPF/CNPJ: 11.222.333/0004-55',
+    'Endereço: Rua Modelo, 1855',
+    'Município: Cidade Nova',
     'UF: SP',
     'Data da emissão: 08/07/2024',
     'Data do transporte: 09/07/2024',
     'Data do recebimento: 10/07/2024',
     '',
     'Identificação do Transportador',
-    'Razão Social: RECICLADOS LIMEIRA LTDA 5193',
-    'CPF/CNPJ: 04.359.529/0001-57',
-    'Endereço: Av. Paulista, 1000',
+    'Razão Social: RECICLADOS MODELO LTDA 5193',
+    'CPF/CNPJ: 22.333.444/0001-66',
+    'Endereço: Av. Principal, 1000',
     'Município: São Paulo',
     'Estado: SP',
     'Nome do Motorista',
     'Placa do Veículo',
-    'GERSON PEREIRA DA SILVA',
-    'AUP5E49',
+    'CARLOS OLIVEIRA DOS SANTOS',
+    'FKE1A23',
     '',
     'Identificação do Destinador',
-    'Razão Social: TERA AMBIENTAL LTDA. - 596',
-    'CPF/CNPJ: 59.591.115/0003-02',
-    'Endereço: Rod. SP-101, Km 5',
-    'Município: Paulínia',
+    'Razão Social: DESTINO AMBIENTAL LTDA. - 596',
+    'CPF/CNPJ: 33.444.555/0003-77',
+    'Endereço: Rod. XX-101, Km 5',
+    'Município: Cidade Sul',
     'UF: SP',
     '',
     'Identificação dos Resíduos',
@@ -99,25 +99,25 @@ describe('MtrSigorParser', () => {
       expect(result.data.issueDate?.parsed).toBe('08/07/2024');
       expect(result.data.issueDate?.confidence).toBe('high');
       expect(result.data.generator?.name.parsed).toBe(
-        'Ajinomoto do Brasil Industria e Comercio de Alimentos Ltda',
+        'Exemplo Industrias de Alimentos Ltda',
       );
-      expect(result.data.generator?.taxId.parsed).toBe('46.344.354/0005-88');
-      expect(result.data.generator?.address.parsed).toBe('Rua Vergueiro, 1855');
-      expect(result.data.generator?.city.parsed).toBe('Limeira');
+      expect(result.data.generator?.taxId.parsed).toBe('11.222.333/0004-55');
+      expect(result.data.generator?.address.parsed).toBe('Rua Modelo, 1855');
+      expect(result.data.generator?.city.parsed).toBe('Cidade Nova');
       expect(result.data.generator?.state.parsed).toBe('SP');
       expect(result.data.generator?.name.confidence).toBe('high');
-      expect(result.data.hauler?.name.parsed).toBe('RECICLADOS LIMEIRA LTDA');
-      expect(result.data.hauler?.taxId.parsed).toBe('04.359.529/0001-57');
-      expect(result.data.hauler?.address.parsed).toBe('Av. Paulista, 1000');
+      expect(result.data.hauler?.name.parsed).toBe('RECICLADOS MODELO LTDA');
+      expect(result.data.hauler?.taxId.parsed).toBe('22.333.444/0001-66');
+      expect(result.data.hauler?.address.parsed).toBe('Av. Principal, 1000');
       expect(result.data.hauler?.city.parsed).toBe('Sao Paulo');
       expect(result.data.hauler?.state.parsed).toBe('SP');
-      expect(result.data.receiver?.name.parsed).toBe('TERA AMBIENTAL LTDA.');
-      expect(result.data.receiver?.taxId.parsed).toBe('59.591.115/0003-02');
-      expect(result.data.receiver?.address.parsed).toBe('Rod. SP-101, Km 5');
-      expect(result.data.receiver?.city.parsed).toBe('Paulinia');
+      expect(result.data.receiver?.name.parsed).toBe('DESTINO AMBIENTAL LTDA.');
+      expect(result.data.receiver?.taxId.parsed).toBe('33.444.555/0003-77');
+      expect(result.data.receiver?.address.parsed).toBe('Rod. XX-101, Km 5');
+      expect(result.data.receiver?.city.parsed).toBe('Cidade Sul');
       expect(result.data.receiver?.state.parsed).toBe('SP');
-      expect(result.data.driverName?.parsed).toBe('GERSON PEREIRA DA SILVA');
-      expect(result.data.vehiclePlate?.parsed).toBe('AUP5E49');
+      expect(result.data.driverName?.parsed).toBe('CARLOS OLIVEIRA DOS SANTOS');
+      expect(result.data.vehiclePlate?.parsed).toBe('FKE1A23');
       expect(result.data.wasteTypes?.map(toWasteTypeEntryData)).toEqual([
         {
           classification: 'CLASSE IIA',
@@ -249,8 +249,8 @@ describe('MtrSigorParser', () => {
         'CPF/CNPJ: 98.765.432/0001-10',
         'Nome do Motorista',
         'Placa do Veículo',
-        'CARLOS SILVA',
-        'BRA2E19',
+        'PEDRO ALMEIDA',
+        'FKE2B34',
         '',
         'Identificação do Destinador',
         'Razão Social: Receiver Co',
@@ -259,8 +259,8 @@ describe('MtrSigorParser', () => {
 
       const result = parser.parse(stubTextExtractionResult(labelValueText));
 
-      expect(result.data.driverName?.parsed).toBe('CARLOS SILVA');
-      expect(result.data.vehiclePlate?.parsed).toBe('BRA2E19');
+      expect(result.data.driverName?.parsed).toBe('PEDRO ALMEIDA');
+      expect(result.data.vehiclePlate?.parsed).toBe('FKE2B34');
     });
 
     it('should not extract driver name when labels have no following values', () => {
@@ -296,7 +296,7 @@ describe('MtrSigorParser', () => {
         'CPF/CNPJ: 98.765.432/0001-10',
         'Nome do Motorista',
         'Placa do Veículo',
-        'CARLOS SILVA',
+        'PEDRO ALMEIDA',
         'NKW 1/62',
       ].join('\n');
 
@@ -304,7 +304,7 @@ describe('MtrSigorParser', () => {
         stubTextExtractionResult(ocrMangledPlateText),
       );
 
-      expect(result.data.driverName?.parsed).toBe('CARLOS SILVA');
+      expect(result.data.driverName?.parsed).toBe('PEDRO ALMEIDA');
       expect(result.data.vehiclePlate?.parsed).toBe('NKW 1/62');
       expect(result.data.vehiclePlate?.confidence).toBe('high');
     });
@@ -319,12 +319,12 @@ describe('MtrSigorParser', () => {
         'Razão Social: Transport Co',
         'CPF/CNPJ: 98.765.432/0001-10',
         'Nome do Motorista',
-        'MARIA SANTOS',
+        'ANA FERREIRA',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(onlyDriverText));
 
-      expect(result.data.driverName?.parsed).toBe('MARIA SANTOS');
+      expect(result.data.driverName?.parsed).toBe('ANA FERREIRA');
     });
 
     it('should extract vehicle plate when only plate label is present', () => {
@@ -337,12 +337,12 @@ describe('MtrSigorParser', () => {
         'Razão Social: Transport Co',
         'CPF/CNPJ: 98.765.432/0001-10',
         'Placa do Veículo',
-        'BRA2E19',
+        'FKE2B34',
       ].join('\n');
 
       const result = parser.parse(stubTextExtractionResult(onlyPlateText));
 
-      expect(result.data.vehiclePlate?.parsed).toBe('BRA2E19');
+      expect(result.data.vehiclePlate?.parsed).toBe('FKE2B34');
       expect(result.data.driverName).toBeUndefined();
     });
 

--- a/libs/shared/document-extractor-transport-manifest/src/mtr-sinfat.parser.spec.ts
+++ b/libs/shared/document-extractor-transport-manifest/src/mtr-sinfat.parser.spec.ts
@@ -24,8 +24,8 @@ Data de Recebimento: 18/03/2024
 Gerador
 EMPRESA GERADORA LTDA
 CNPJ: 12.345.678/0001-90
-Endereço: Rua Empresário Agenello Senger, nº S/N
-Município: Carazinho
+Endereço: Rua Industrial, nº S/N
+Município: Cidade Interior
 UF: RS
 
 Transportador
@@ -35,7 +35,7 @@ Endereço: Av. Brasil, 500
 Município: Porto Alegre
 Estado: RS
 Placa do Veículo: ABC-1D23
-Motorista: João da Silva
+Motorista: Pedro Santos
 
 Destinatário
 RECICLAGEM SUSTENTÁVEL LTDA
@@ -69,9 +69,9 @@ Compostagem`;
       expect(result.data.generator?.name.parsed).toBe('EMPRESA GERADORA LTDA');
       expect(result.data.generator?.taxId.parsed).toBe('12.345.678/0001-90');
       expect(result.data.generator?.address.parsed).toBe(
-        'Rua Empresario Agenello Senger, nº S/N',
+        'Rua Industrial, nº S/N',
       );
-      expect(result.data.generator?.city.parsed).toBe('Carazinho');
+      expect(result.data.generator?.city.parsed).toBe('Cidade Interior');
       expect(result.data.generator?.state.parsed).toBe('RS');
       expect(result.data.hauler?.name.parsed).toBe(
         'TRANSPORTES AMBIENTAIS S.A.',
@@ -82,7 +82,7 @@ Compostagem`;
       );
       expect(result.data.receiver?.taxId.parsed).toBe('11.222.333/0001-44');
       expect(result.data.vehiclePlate?.parsed).toBe('ABC-1D23');
-      expect(result.data.driverName?.parsed).toBe('Joao da Silva');
+      expect(result.data.driverName?.parsed).toBe('Pedro Santos');
       expect(result.data.transportDate?.parsed).toBe('16/03/2024');
       expect(result.data.receivingDate?.parsed).toBe('18/03/2024');
       expect(result.data.documentType).toBe('transportManifest');
@@ -148,11 +148,11 @@ Data de Emissão: 15/03/2024
 
 Gerador
 BODY FOOD FABRICANTES 262960
-CNPJ: 28324667000169
+CNPJ: 88999000000133
 
 Transportador
-COMPOSTAMAIS LTDA. - 112752
-CNPJ: 33545743000104
+COMPOST VERDE LTDA. - 112752
+CNPJ: 77888999000122
 
 Destinatário
 RECICLAGEM VERDE LTDA
@@ -161,7 +161,7 @@ CNPJ: 11222333000144`;
       const result = parser.parse(stubTextExtractionResult(text));
 
       expect(result.data.generator?.name.parsed).toBe('BODY FOOD FABRICANTES');
-      expect(result.data.hauler?.name.parsed).toBe('COMPOSTAMAIS LTDA.');
+      expect(result.data.hauler?.name.parsed).toBe('COMPOST VERDE LTDA.');
     });
 
     it('should extract driver and plate from multi-line section layout', () => {
@@ -175,8 +175,8 @@ TRANSPORTES AMBIENTAIS S.A.
 CNPJ: 98.765.432/0001-10
 Nome do Motorista
 Placa do Veículo
-Rafael Silva
-NKW1862
+Lucas Ferreira
+HIJ3K56
 nome e assinatura do responsável
 
 Destinatário
@@ -186,9 +186,9 @@ Tecnologia: Compostagem`;
 
       const result = parser.parse(stubTextExtractionResult(text));
 
-      expect(result.data.driverName?.parsed).toBe('Rafael Silva');
+      expect(result.data.driverName?.parsed).toBe('Lucas Ferreira');
       expect(result.data.driverName?.confidence).toBe('high');
-      expect(result.data.vehiclePlate?.parsed).toBe('NKW1862');
+      expect(result.data.vehiclePlate?.parsed).toBe('HIJ3K56');
       expect(result.data.vehiclePlate?.confidence).toBe('high');
     });
 

--- a/libs/shared/document-extractor-transport-manifest/src/mtr-sinir.parser.spec.ts
+++ b/libs/shared/document-extractor-transport-manifest/src/mtr-sinir.parser.spec.ts
@@ -20,8 +20,8 @@ Data de Recebimento: 18/03/2024
 Gerador
 Razão Social: EMPRESA GERADORA LTDA
 CNPJ: 12.345.678/0001-90
-Endereço: Rua Empresário Agenello Senger, nº S/N
-Município: Carazinho
+Endereço: Rua Industrial, nº S/N
+Município: Cidade Interior
 UF: RS
 
 Transportador
@@ -31,7 +31,7 @@ Endereço: Av. Brasil, 500
 Município: São Paulo
 Estado: SP
 Placa do Veículo: ABC-1D23
-Motorista: João da Silva
+Motorista: Pedro Santos
 
 Destinatário
 RECICLAGEM SUSTENTÁVEL LTDA
@@ -56,9 +56,9 @@ IBAMA - Instituto Brasileiro do Meio Ambiente`;
       expect(result.data.generator?.name.parsed).toBe('EMPRESA GERADORA LTDA');
       expect(result.data.generator?.taxId.parsed).toBe('12.345.678/0001-90');
       expect(result.data.generator?.address.parsed).toBe(
-        'Rua Empresario Agenello Senger, nº S/N',
+        'Rua Industrial, nº S/N',
       );
-      expect(result.data.generator?.city.parsed).toBe('Carazinho');
+      expect(result.data.generator?.city.parsed).toBe('Cidade Interior');
       expect(result.data.generator?.state.parsed).toBe('RS');
       expect(result.data.hauler?.name.parsed).toBe(
         'TRANSPORTES AMBIENTAIS S.A.',
@@ -75,7 +75,7 @@ IBAMA - Instituto Brasileiro do Meio Ambiente`;
       expect(result.data.receiver?.city.parsed).toBe('Curitiba');
       expect(result.data.receiver?.state.parsed).toBe('PR');
       expect(result.data.vehiclePlate?.parsed).toBe('ABC-1D23');
-      expect(result.data.driverName?.parsed).toBe('Joao da Silva');
+      expect(result.data.driverName?.parsed).toBe('Pedro Santos');
       expect(result.data.wasteTypes?.map(toWasteTypeEntryData)).toEqual([
         {
           classification: 'II - Nao Perigoso',
@@ -274,12 +274,12 @@ MTR Nº: 987654321
 Data de Emissão: 10/06/2025
 
 Gerador
-BODY FOOD FABRICANTES DE ALIMENTOS SAUDAVEIS
-CNPJ: 28324667000169
+ALIMENTOS NATURAIS FABRICANTES DE PRODUTOS SAUDAVEIS
+CNPJ: 88999000000133
 
 Transportador
-COMPOSTAMAIS INDUSTRIA E COMERCIO DE COMPOSTAGEM LTDA.
-CNPJ: 33545743000104
+COMPOST VERDE INDUSTRIA E COMERCIO DE COMPOSTAGEM LTDA.
+CNPJ: 77888999000122
 
 Destinatário
 RECICLAGEM VERDE LTDA
@@ -291,12 +291,12 @@ IBAMA - Instituto Brasileiro do Meio Ambiente`;
         stubTextExtractionResult(unformattedCnpjText),
       );
 
-      expect(result.data.generator?.taxId.parsed).toBe('28324667000169');
+      expect(result.data.generator?.taxId.parsed).toBe('88999000000133');
       expect(result.data.generator?.name.parsed).toBe(
-        'BODY FOOD FABRICANTES DE ALIMENTOS SAUDAVEIS',
+        'ALIMENTOS NATURAIS FABRICANTES DE PRODUTOS SAUDAVEIS',
       );
       expect(result.data.generator?.name.confidence).toBe('high');
-      expect(result.data.hauler?.taxId.parsed).toBe('33545743000104');
+      expect(result.data.hauler?.taxId.parsed).toBe('77888999000122');
       expect(result.data.hauler?.name.confidence).toBe('high');
       expect(result.data.receiver?.taxId.parsed).toBe('11222333000144');
       expect(result.data.receiver?.name.confidence).toBe('high');
@@ -384,12 +384,12 @@ MTR Nº: 123456789
 Data de Emissão: 15/03/2024
 
 Gerador
-BODY FOOD FABRICANTES DE ALIMENTOS SAUDÁVEIS 262960
-CNPJ: 28324667000169
+ALIMENTOS NATURAIS FABRICANTES DE PRODUTOS SAUDAVEIS 262960
+CNPJ: 88999000000133
 
 Transportador
-COMPOSTAMAIS LTDA. - 112752
-CNPJ: 33545743000104
+COMPOST VERDE LTDA. - 112752
+CNPJ: 77888999000122
 
 Destinatário
 RECICLAGEM VERDE LTDA
@@ -400,9 +400,9 @@ IBAMA`;
       const result = parser.parse(stubTextExtractionResult(text));
 
       expect(result.data.generator?.name.parsed).toBe(
-        'BODY FOOD FABRICANTES DE ALIMENTOS SAUDAVEIS',
+        'ALIMENTOS NATURAIS FABRICANTES DE PRODUTOS SAUDAVEIS',
       );
-      expect(result.data.hauler?.name.parsed).toBe('COMPOSTAMAIS LTDA.');
+      expect(result.data.hauler?.name.parsed).toBe('COMPOST VERDE LTDA.');
     });
 
     it('should mark fields as low confidence when label is present but value is empty', () => {
@@ -463,8 +463,8 @@ TRANSPORTES AMBIENTAIS S.A.
 CNPJ: 98.765.432/0001-10
 Nome do Motorista
 Placa do Veículo
-Rafael Silva
-NKW1862
+Lucas Ferreira
+HIJ3K56
 nome e assinatura do responsável
 
 Destinatário
@@ -474,9 +474,9 @@ IBAMA`;
 
       const result = parser.parse(stubTextExtractionResult(text));
 
-      expect(result.data.driverName?.parsed).toBe('Rafael Silva');
+      expect(result.data.driverName?.parsed).toBe('Lucas Ferreira');
       expect(result.data.driverName?.confidence).toBe('high');
-      expect(result.data.vehiclePlate?.parsed).toBe('NKW1862');
+      expect(result.data.vehiclePlate?.parsed).toBe('HIJ3K56');
       expect(result.data.vehiclePlate?.confidence).toBe('high');
     });
 

--- a/libs/shared/helpers/src/string-comparison.helpers.spec.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   diceCoefficient,
   isAddressMatch,
   isNameMatch,
+  isOcrPlausiblePlateMatch,
   normalizeAddress,
   normalizeDateToISO,
   normalizeVehiclePlate,
@@ -398,6 +399,56 @@ describe('string-comparison.helpers', () => {
       );
 
       expect(result.isMatch).toBe(true);
+    });
+  });
+
+  describe('isOcrPlausiblePlateMatch', () => {
+    it('should return true for I/1 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('XYZ1I23', 'XYZ1123')).toBe(true);
+    });
+
+    it('should return true for B/8 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('FAK3B99', 'FAK3899')).toBe(true);
+    });
+
+    it('should return true for O/0 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('ABC0D23', 'ABCOD23')).toBe(true);
+    });
+
+    it('should return true for S/5 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('AB5CD23', 'ABSCD23')).toBe(true);
+    });
+
+    it('should return true for Z/2 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('ABZ1D23', 'AB21D23')).toBe(true);
+    });
+
+    it('should return true for D/0 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('ABC1D23', 'ABC1023')).toBe(true);
+    });
+
+    it('should return true for G/6 OCR confusion', () => {
+      expect(isOcrPlausiblePlateMatch('ABG1D23', 'AB61D23')).toBe(true);
+    });
+
+    it('should return true for exact match after normalization', () => {
+      expect(isOcrPlausiblePlateMatch('ABC-1D23', 'abc 1d23')).toBe(true);
+    });
+
+    it('should return false for non-OCR single char difference', () => {
+      expect(isOcrPlausiblePlateMatch('ABC1D23', 'ABC1D24')).toBe(false);
+    });
+
+    it('should return false when more than 1 character differs', () => {
+      expect(isOcrPlausiblePlateMatch('ABC1D23', 'XYZ1D23')).toBe(false);
+    });
+
+    it('should return false for different length plates', () => {
+      expect(isOcrPlausiblePlateMatch('ABC1D23', 'ABC1D234')).toBe(false);
+    });
+
+    it('should return false when two OCR-confusable chars differ', () => {
+      expect(isOcrPlausiblePlateMatch('XYZ1I23', 'X1Z1123')).toBe(false);
     });
   });
 

--- a/libs/shared/helpers/src/string-comparison.helpers.spec.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.spec.ts
@@ -298,6 +298,16 @@ describe('string-comparison.helpers', () => {
     it('should handle empty string', () => {
       expect(normalizeAddress('')).toBe('');
     });
+
+    it('should split digit sequences separated by punctuation', () => {
+      expect(normalizeAddress('BR-116,2007 Bairro')).toBe('br 116 2007 bairro');
+    });
+
+    it('should split route and street number joined by comma', () => {
+      expect(normalizeAddress('BR-376,22591 Miringuava')).toBe(
+        'br 376 22591 miringuava',
+      );
+    });
   });
 
   describe('isAddressMatch', () => {
@@ -396,6 +406,24 @@ describe('string-comparison.helpers', () => {
       const result = isAddressMatch(
         'Rua Exemplo, Complemento Lote B, 100, Cidade Grande, Estado, SP',
         'R Exemplo, 100, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match when extracted address has route and number joined by comma', () => {
+      const result = isAddressMatch(
+        'BR-376,22591 Miringuava, Sao Jose dos Pinhais, PR',
+        'Rod Br-376, 22591, São José dos Pinhais, PR',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match when source document has duplicated street number', () => {
+      const result = isAddressMatch(
+        'RUA Exemplo, 210210 Bairro Norte, Cidade, SP',
+        'RUA Exemplo, 210, Cidade, SP',
       );
 
       expect(result.isMatch).toBe(true);

--- a/libs/shared/helpers/src/string-comparison.helpers.spec.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.spec.ts
@@ -109,8 +109,8 @@ describe('string-comparison.helpers', () => {
 
     it('should not match when names differ only by extra business-type words and token subset is disabled', () => {
       const result = isNameMatch(
-        'ROYAL CANIN DO BRASIL INDUSTRIA E COMERCIO LTDA',
-        'ROYAL CANIN DO BRASIL LTDA',
+        'VERDE CAMPO DO BRASIL INDUSTRIA E COMERCIO LTDA',
+        'VERDE CAMPO DO BRASIL LTDA',
       );
 
       expect(result.isMatch).toBe(false);
@@ -121,8 +121,8 @@ describe('string-comparison.helpers', () => {
     describe('with token subset enabled', () => {
       it('should match when one name has extra business-type words not present in the other', () => {
         const result = isNameMatch(
-          'ROYAL CANIN DO BRASIL INDUSTRIA E COMERCIO LTDA',
-          'ROYAL CANIN DO BRASIL LTDA',
+          'VERDE CAMPO DO BRASIL INDUSTRIA E COMERCIO LTDA',
+          'VERDE CAMPO DO BRASIL LTDA',
           DEFAULT_NAME_MATCH_THRESHOLD,
           true,
         );
@@ -165,8 +165,8 @@ describe('string-comparison.helpers', () => {
 
       it('should match regardless of which argument has the extra words', () => {
         const result = isNameMatch(
-          'ROYAL CANIN DO BRASIL LTDA',
-          'ROYAL CANIN DO BRASIL INDUSTRIA E COMERCIO LTDA',
+          'VERDE CAMPO DO BRASIL LTDA',
+          'VERDE CAMPO DO BRASIL INDUSTRIA E COMERCIO LTDA',
           DEFAULT_NAME_MATCH_THRESHOLD,
           true,
         );
@@ -177,7 +177,7 @@ describe('string-comparison.helpers', () => {
       it('should not match when the shorter name has fewer than 2 meaningful tokens', () => {
         const result = isNameMatch(
           'LTDA',
-          'ROYAL CANIN DO BRASIL LTDA',
+          'VERDE CAMPO DO BRASIL LTDA',
           DEFAULT_NAME_MATCH_THRESHOLD,
           true,
         );
@@ -209,8 +209,8 @@ describe('string-comparison.helpers', () => {
 
       it('should match when tokens have minor spelling differences', () => {
         const result = isNameMatch(
-          'Rua Luis Franceshi, 2045, Cidade, PR',
-          'Rua Luiz Francheshi,2045 Bairro Norte, Cidade, PR',
+          'Rua Flores Amarelas, 2045, Cidade, PR',
+          'Rua Florez Amarellas,2045 Bairro Norte, Cidade, PR',
           DEFAULT_NAME_MATCH_THRESHOLD,
           true,
         );
@@ -220,8 +220,8 @@ describe('string-comparison.helpers', () => {
 
       it('should match when one side omits a street prefix token', () => {
         const result = isNameMatch(
-          'Rua Rosa Neuman, 125, Cidade, PR',
-          'Rosa Neumann, 125 Bairro Central, Cidade, PR',
+          'Rua Girassol Dourado, 125, Cidade, PR',
+          'Girassol Douraddo, 125 Bairro Central, Cidade, PR',
           DEFAULT_NAME_MATCH_THRESHOLD,
           true,
         );

--- a/libs/shared/helpers/src/string-comparison.helpers.spec.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.spec.ts
@@ -3,6 +3,7 @@ import {
   dateDifferenceInDays,
   DEFAULT_NAME_MATCH_THRESHOLD,
   diceCoefficient,
+  isAddressMatch,
   isNameMatch,
   normalizeAddress,
   normalizeDateToISO,
@@ -295,6 +296,108 @@ describe('string-comparison.helpers', () => {
 
     it('should handle empty string', () => {
       expect(normalizeAddress('')).toBe('');
+    });
+  });
+
+  describe('isAddressMatch', () => {
+    it('should match when one side uses street abbreviation and other uses full name', () => {
+      const result = isAddressMatch(
+        'Al Jacaranda, 1, Cidade dos Pinheiros, SP',
+        'Alameda Jacaranda, 01 Bairro Norte, Cidade dos Pinheiros, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match when OCR produces duplicate tokens', () => {
+      const result = isAddressMatch(
+        'Rod Exemplo, 423, Cidade Nova, PR',
+        'RODOVIA EXEMPLO 423KM,S/N SN,KM 24,3 KM 24,3 JARDIM, Cidade Nova, PR',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match identical addresses', () => {
+      const result = isAddressMatch(
+        'Rua Exemplo, 100, Cidade, SP',
+        'Rua Exemplo, 100, Cidade, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
+      expect(result.score).toBe(1);
+    });
+
+    it('should not match truly different addresses', () => {
+      const result = isAddressMatch(
+        'Avenida Alpha, 100, Cidade, SP',
+        'Rua Beta, 200, Cidade, SP',
+      );
+
+      expect(result.isMatch).toBe(false);
+    });
+
+    it('should not match addresses with different street numbers', () => {
+      const result = isAddressMatch(
+        'Rua Exemplo, 100, Cidade, SP',
+        'Rua Exemplo, 200, Cidade, SP',
+      );
+
+      expect(result.isMatch).toBe(false);
+    });
+
+    it('should match when "Rod" abbreviation is used for "Rodovia"', () => {
+      const result = isAddressMatch(
+        'Rod Brasil, 100, Cidade, PR',
+        'Rodovia Brasil, 100, Cidade, PR',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should not match addresses with same number but completely different names', () => {
+      const result = isAddressMatch(
+        'Rua Alpha, 100, Cidade, SP',
+        'Avenida Beta, 100, Metropole, RJ',
+      );
+
+      expect(result.isMatch).toBe(false);
+    });
+
+    it('should match addresses where street number has leading zeros', () => {
+      const result = isAddressMatch(
+        'Rua Exemplo, 001, Cidade, SP',
+        'Rua Exemplo, 1, Cidade, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match addresses where street number is all zeros', () => {
+      const result = isAddressMatch(
+        'Rua Exemplo, 000, Cidade, SP',
+        'Rua Exemplo, 0, Cidade, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match when first address has more numeric tokens than the second', () => {
+      const result = isAddressMatch(
+        'Rua Exemplo, 100, Lote 50, Cidade, SP',
+        'Rua Exemplo, 100, Cidade, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
+    });
+
+    it('should match via token subset when first address has more tokens and dice score is low', () => {
+      const result = isAddressMatch(
+        'Rua Exemplo, Complemento Lote B, 100, Cidade Grande, Estado, SP',
+        'R Exemplo, 100, SP',
+      );
+
+      expect(result.isMatch).toBe(true);
     });
   });
 

--- a/libs/shared/helpers/src/string-comparison.helpers.spec.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.spec.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_NAME_MATCH_THRESHOLD,
   diceCoefficient,
   isNameMatch,
+  normalizeAddress,
   normalizeDateToISO,
   normalizeVehiclePlate,
 } from './string-comparison.helpers';
@@ -250,6 +251,50 @@ describe('string-comparison.helpers', () => {
 
         expect(result.isMatch).toBe(false);
       });
+    });
+  });
+
+  describe('normalizeAddress', () => {
+    it('should expand "al" to "alameda"', () => {
+      expect(normalizeAddress('Al Jacaranda, 1')).toBe('alameda jacaranda 1');
+    });
+
+    it('should expand "rod" to "rodovia"', () => {
+      expect(normalizeAddress('Rod Exemplo, 100')).toBe('rodovia exemplo 100');
+    });
+
+    it('should expand "av" to "avenida"', () => {
+      expect(normalizeAddress('Av Brasil, 500')).toBe('avenida brasil 500');
+    });
+
+    it('should expand "r" to "rua" only as standalone token', () => {
+      expect(normalizeAddress('R Exemplo, 10')).toBe('rua exemplo 10');
+    });
+
+    it('should not expand tokens that are not abbreviations', () => {
+      expect(normalizeAddress('Alameda Jacaranda, 1')).toBe(
+        'alameda jacaranda 1',
+      );
+    });
+
+    it('should deduplicate consecutive identical tokens', () => {
+      expect(normalizeAddress('KM 5 KM 5 Bairro')).toBe('km 5 bairro');
+    });
+
+    it('should deduplicate longer consecutive runs', () => {
+      expect(normalizeAddress('RODOVIA PR 423KM KM 24 3 KM 24 3 JARDIM')).toBe(
+        'rodovia pr 423 km 24 3 jardim',
+      );
+    });
+
+    it('should handle accents and punctuation like aggressiveNormalize', () => {
+      expect(normalizeAddress('Av. São Paulo, 100')).toBe(
+        'avenida sao paulo 100',
+      );
+    });
+
+    it('should handle empty string', () => {
+      expect(normalizeAddress('')).toBe('');
     });
   });
 

--- a/libs/shared/helpers/src/string-comparison.helpers.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.ts
@@ -83,7 +83,8 @@ const deduplicateConsecutiveTokens = (tokens: string[]): string[] => {
  * and deduplicates consecutive identical tokens (OCR noise).
  */
 export const normalizeAddress = (value: string): string => {
-  const normalized = aggressiveNormalize(value);
+  const withDigitSpaces = value.replaceAll(/(?<=\d)[^\d\sa-zA-Z]+(?=\d)/g, ' ');
+  const normalized = aggressiveNormalize(withDigitSpaces);
 
   if (normalized === '') {
     return '';
@@ -253,6 +254,11 @@ const extractNumericTokens = (tokens: string[]): string[] =>
  * the longer list. Street numbers are critical in address comparison and must
  * not be fuzzily matched.
  */
+const isRepeatedNumber = (long: string, short: string): boolean =>
+  long.length > short.length &&
+  long.length % short.length === 0 &&
+  long === short.repeat(long.length / short.length);
+
 const numericTokensMatch = (
   shorterNums: string[],
   longerNums: string[],
@@ -263,10 +269,18 @@ const numericTokensMatch = (
     const index = pool.indexOf(number_);
 
     if (index === -1) {
-      return false;
-    }
+      const repIndex = pool.findIndex(
+        (p) => isRepeatedNumber(p, number_) || isRepeatedNumber(number_, p),
+      );
 
-    pool.splice(index, 1);
+      if (repIndex === -1) {
+        return false;
+      }
+
+      pool.splice(repIndex, 1);
+    } else {
+      pool.splice(index, 1);
+    }
   }
 
   return true;

--- a/libs/shared/helpers/src/string-comparison.helpers.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.ts
@@ -15,6 +15,87 @@ export const aggressiveNormalize = (value: string): string =>
     .replaceAll(/\s+/g, ' ')
     .trim();
 
+const BRAZILIAN_ADDRESS_ABBREVIATIONS = new Map<string, string>([
+  ['al', 'alameda'],
+  ['alam', 'alameda'],
+  ['av', 'avenida'],
+  ['cj', 'conjunto'],
+  ['cond', 'condominio'],
+  ['est', 'estrada'],
+  ['pc', 'praca'],
+  ['pca', 'praca'],
+  ['r', 'rua'],
+  ['res', 'residencial'],
+  ['rod', 'rodovia'],
+  ['trav', 'travessa'],
+]);
+
+const expandAddressAbbreviations = (tokens: string[]): string[] =>
+  tokens.map((t) => BRAZILIAN_ADDRESS_ABBREVIATIONS.get(t) ?? t);
+
+const findRepeatedRunLength = (
+  result: string[],
+  tokens: string[],
+  index: number,
+): number => {
+  for (let runLength = result.length; runLength >= 1; runLength--) {
+    if (index + runLength > tokens.length || result.length < runLength) {
+      continue;
+    }
+
+    const tail = result.slice(-runLength);
+    const next = tokens.slice(index, index + runLength);
+
+    if (tail.every((t, index_) => t === next.at(index_))) {
+      return runLength;
+    }
+  }
+
+  return 0;
+};
+
+const deduplicateConsecutiveTokens = (tokens: string[]): string[] => {
+  const result: string[] = [];
+  let index = 0;
+
+  while (index < tokens.length) {
+    const runLength = findRepeatedRunLength(result, tokens, index);
+
+    if (runLength > 0) {
+      index += runLength;
+    } else {
+      const token = tokens.at(index);
+
+      if (token !== undefined) {
+        result.push(token);
+      }
+
+      index++;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Normalizes an address string for comparison.
+ * Applies aggressiveNormalize, then expands Brazilian street abbreviations
+ * and deduplicates consecutive identical tokens (OCR noise).
+ */
+export const normalizeAddress = (value: string): string => {
+  const normalized = aggressiveNormalize(value);
+
+  if (normalized === '') {
+    return '';
+  }
+
+  const tokens = normalized.split(' ');
+  const expanded = expandAddressAbbreviations(tokens);
+  const deduped = deduplicateConsecutiveTokens(expanded);
+
+  return deduped.join(' ');
+};
+
 /**
  * Computes the Sorensen-Dice coefficient between two strings.
  * Returns a value between 0 (completely different) and 1 (identical).

--- a/libs/shared/helpers/src/string-comparison.helpers.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.ts
@@ -236,6 +236,82 @@ export const isNameMatch = (
 };
 
 /**
+ * Strips leading zeros from a numeric string, preserving at least one digit.
+ */
+const stripLeadingZeros = (value: string): string =>
+  value.replace(/^0+/, '') || '0';
+
+/**
+ * Extracts numeric tokens (street numbers, km markers) from token list,
+ * normalizing away leading zeros so that "01" matches "1".
+ */
+const extractNumericTokens = (tokens: string[]): string[] =>
+  tokens.filter((t) => isNumericToken(t)).map((t) => stripLeadingZeros(t));
+
+/**
+ * Checks that every numeric token in the shorter list has an exact match in
+ * the longer list. Street numbers are critical in address comparison and must
+ * not be fuzzily matched.
+ */
+const numericTokensMatch = (
+  shorterNums: string[],
+  longerNums: string[],
+): boolean => {
+  const pool = [...longerNums];
+
+  for (const number_ of shorterNums) {
+    const index = pool.indexOf(number_);
+
+    if (index === -1) {
+      return false;
+    }
+
+    pool.splice(index, 1);
+  }
+
+  return true;
+};
+
+/**
+ * Checks whether two addresses match using address-specific normalization
+ * (abbreviation expansion + OCR dedup) followed by Dice coefficient and
+ * token subset matching. Numeric tokens (street numbers) must match exactly.
+ */
+export const isAddressMatch = (
+  a: string,
+  b: string,
+  threshold = DEFAULT_NAME_MATCH_THRESHOLD,
+): { isMatch: boolean; score: number } => {
+  const normalizedA = normalizeAddress(a);
+  const normalizedB = normalizeAddress(b);
+  const tokensA = normalizedA.split(' ');
+  const tokensB = normalizedB.split(' ');
+  const score = diceCoefficient(normalizedA, normalizedB);
+
+  const numsA = extractNumericTokens(tokensA);
+  const numsB = extractNumericTokens(tokensB);
+  const [shorterNums, longerNums] =
+    numsA.length <= numsB.length ? [numsA, numsB] : [numsB, numsA];
+
+  if (shorterNums.length > 0 && !numericTokensMatch(shorterNums, longerNums)) {
+    return { isMatch: false, score };
+  }
+
+  if (score >= threshold) {
+    return { isMatch: true, score };
+  }
+
+  const [shorter, longer] =
+    tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA];
+
+  if (fuzzyTokenSubset(shorter, longer)) {
+    return { isMatch: true, score };
+  }
+
+  return { isMatch: false, score };
+};
+
+/**
  * Normalizes a vehicle license plate by removing dashes, spaces, and uppercasing.
  */
 export const normalizeVehiclePlate = (plate: string): string =>

--- a/libs/shared/helpers/src/string-comparison.helpers.ts
+++ b/libs/shared/helpers/src/string-comparison.helpers.ts
@@ -317,6 +317,60 @@ export const isAddressMatch = (
 export const normalizeVehiclePlate = (plate: string): string =>
   plate.replaceAll(/[-\s]/g, '').toUpperCase();
 
+const OCR_CONFUSABLE_PAIRS: ReadonlySet<string> = new Set([
+  '0D',
+  '0O',
+  '1I',
+  '2Z',
+  '5S',
+  '6G',
+  '8B',
+  'B8',
+  'D0',
+  'G6',
+  'I1',
+  'O0',
+  'S5',
+  'Z2',
+]);
+
+export const isOcrPlausiblePlateMatch = (
+  plateA: string,
+  plateB: string,
+): boolean => {
+  const a = normalizeVehiclePlate(plateA);
+  const b = normalizeVehiclePlate(plateB);
+
+  if (a === b) {
+    return true;
+  }
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let diffCount = 0;
+  let isOcrDiff = true;
+
+  for (const [index, charA] of [...a].entries()) {
+    const charB = b[index];
+
+    if (charA !== charB) {
+      diffCount++;
+
+      if (diffCount > 1) {
+        return false;
+      }
+
+      if (!OCR_CONFUSABLE_PAIRS.has(`${charA}${charB}`)) {
+        isOcrDiff = false;
+      }
+    }
+  }
+
+  return diffCount === 1 && isOcrDiff;
+};
+
 const BRAZILIAN_DATE_FORMATS = ['dd/MM/yyyy', 'dd-MM-yyyy'];
 
 /**


### PR DESCRIPTION
## Summary

- Add `normalizeAddress()` with Brazilian street abbreviation expansion (R→Rua, Av→Avenida, Rod→Rodovia, etc.) and OCR duplicate token deduplication
- Add `isAddressMatch()` for address-specific comparison using Dice coefficient, fuzzy token subset matching, and exact numeric token (street number) validation
- Add `isOcrPlausiblePlateMatch()` for OCR-aware vehicle plate comparison that tolerates common OCR confusions (0/O, 1/I, 2/Z, 5/S, 8/B)
- Fix floating-point tolerance in waste quantity weight comparison (`isAlmostEqual` with 1e-6 epsilon)
- Integrate `isAddressMatch` into cross-validation field comparators and transport manifest helpers
- Full test coverage across all new and modified code (100% statements, branches, functions, lines)

## Test Plan

- [x] `shared-helpers` tests pass (261 tests, 100% coverage)
- [x] `document-manifest-data` tests pass (265 tests)
- [x] Lint passes for affected projects
- [x] No regressions in existing comparators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weight comparisons with ±0.01 kg tolerance to avoid false mismatches.
  * Broadened vehicle plate matching to accept OCR-plausible single-character substitutions.

* **New Features**
  * Added robust address matching with aggressive normalization and numeric-token checks.
  * Field comparisons may include an observation note describing accepted discrepancies.

* **Tests**
  * Expanded tests for addresses, OCR-plate scenarios, weight tolerance, and many parser fixtures.

* **Documentation**
  * Guidance added to avoid real data in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->