### PR TITLE
refactor(shared): rename MethodologyAdditionalVerification properties to match API format

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/scale-ticket-verification/scale-ticket-verification.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/scale-ticket-verification/scale-ticket-verification.helpers.spec.ts
@@ -39,8 +39,8 @@ describe('scale-ticket-verification', () => {
 
     const result = await verifyScaleTicketNetWeight({
       config: {
-        layoutIds: ['layout-1'],
-        verificationType: 'scaleTicket',
+        'Layout IDs': ['layout-1'],
+        'Verification Type': 'Scale Ticket',
       },
       expectedNetWeight,
       textExtractorInput,
@@ -52,7 +52,7 @@ describe('scale-ticket-verification', () => {
   it('should return no errors when config verificationType is not scaleTicket', async () => {
     const result = await verifyScaleTicketNetWeight({
       config: {
-        verificationType: 'otherType',
+        'Verification Type': 'otherType',
       } as MethodologyAdditionalVerification,
       expectedNetWeight: 100,
       textExtractorInput: undefined,
@@ -64,12 +64,9 @@ describe('scale-ticket-verification', () => {
   it('should return no errors when verificationType is not scaleTicket', async () => {
     const result = await verifyScaleTicketNetWeight({
       config: {
-        layoutIds: ['layout-1'],
-        verificationType: 'otherType',
-      } as unknown as {
-        layoutIds: ['layout-1'];
-        verificationType: 'scaleTicket';
-      },
+        'Layout IDs': ['layout-1'],
+        'Verification Type': 'otherType',
+      } as MethodologyAdditionalVerification,
       expectedNetWeight: 100,
       textExtractorInput: { filePath: 'dummy-path' },
     });
@@ -79,8 +76,8 @@ describe('scale-ticket-verification', () => {
 
   it('should return no errors when expected net weight is zero and matches the ticket net weight', async () => {
     const baseConfig: MethodologyAdditionalVerification = {
-      layoutIds: ['layout-1'],
-      verificationType: 'scaleTicket',
+      'Layout IDs': ['layout-1'],
+      'Verification Type': 'Scale Ticket',
     };
 
     jest.spyOn(textExtractor, 'extractText').mockResolvedValue({
@@ -112,8 +109,8 @@ describe('scale-ticket-verification', () => {
   it('should return an error when textract input is missing but config is provided', async () => {
     const result = await verifyScaleTicketNetWeight({
       config: {
-        layoutIds: ['layout-1'],
-        verificationType: 'scaleTicket',
+        'Layout IDs': ['layout-1'],
+        'Verification Type': 'Scale Ticket',
       },
       expectedNetWeight: 100,
       textExtractorInput: undefined,
@@ -125,10 +122,10 @@ describe('scale-ticket-verification', () => {
   it('should return an error when layoutIds is missing or empty', async () => {
     const result = await verifyScaleTicketNetWeight({
       config: {
-        verificationType: 'scaleTicket',
+        'Verification Type': 'Scale Ticket',
       } as unknown as {
-        layoutIds: ['layout-1'];
-        verificationType: 'scaleTicket';
+        'Layout IDs': ['layout-1'];
+        'Verification Type': 'Scale Ticket';
       },
       expectedNetWeight: 100,
       textExtractorInput: { filePath: 'dummy-path' },
@@ -158,8 +155,8 @@ describe('scale-ticket-verification', () => {
 
     const result = await verifyScaleTicketNetWeight({
       config: {
-        layoutIds: ['layout-1'],
-        verificationType: 'scaleTicket',
+        'Layout IDs': ['layout-1'],
+        'Verification Type': 'Scale Ticket',
       },
       expectedNetWeight: 100,
       textExtractorInput: { filePath: 'dummy-path' },
@@ -176,8 +173,8 @@ describe('scale-ticket-verification', () => {
 
     const result = await verifyScaleTicketNetWeight({
       config: {
-        layoutIds: ['layout-1'],
-        verificationType: 'scaleTicket',
+        'Layout IDs': ['layout-1'],
+        'Verification Type': 'Scale Ticket',
       },
       expectedNetWeight: 100,
       textExtractorInput: { filePath: 'dummy-path' },
@@ -189,8 +186,8 @@ describe('scale-ticket-verification', () => {
 
   it('should build a scale ticket verification context', () => {
     const config: MethodologyAdditionalVerification = {
-      layoutIds: ['layout-1'],
-      verificationType: 'scaleTicket',
+      'Layout IDs': ['layout-1'],
+      'Verification Type': 'Scale Ticket',
     };
 
     const context = buildScaleTicketVerificationContext({
@@ -212,8 +209,8 @@ describe('scale-ticket-verification', () => {
 
     const result = await verifyScaleTicketNetWeight({
       config: {
-        layoutIds: ['layout-unsupported'],
-        verificationType: 'scaleTicket',
+        'Layout IDs': ['layout-unsupported'],
+        'Verification Type': 'Scale Ticket',
       },
       expectedNetWeight: 100,
       textExtractorInput: { filePath: 'dummy-path' },

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/scale-ticket-verification/scale-ticket-verification.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/scale-ticket-verification/scale-ticket-verification.helpers.ts
@@ -25,7 +25,7 @@ const documentExtractor: DocumentExtractorService =
 
 export const isScaleTicketVerificationConfig = (
   config: MethodologyAdditionalVerification,
-): boolean => config.verificationType === 'scaleTicket';
+): boolean => config['Verification Type'] === 'Scale Ticket';
 
 export const verifyScaleTicketNetWeight = async ({
   config,
@@ -46,7 +46,7 @@ export const verifyScaleTicketNetWeight = async ({
     };
   }
 
-  const layoutIds = config.layoutIds;
+  const layoutIds = config['Layout IDs'];
 
   if (!isNonEmptyArray(layoutIds)) {
     return {

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -110,8 +110,8 @@ const stubBaseAccreditationDocuments = ({
 
   if (withScaleTicketVerification) {
     additionalVerifications.push({
-      layoutIds: ['layout-1'],
-      verificationType: 'scaleTicket',
+      'Layout IDs': ['layout-1'],
+      'Verification Type': 'Scale Ticket',
     });
   }
 

--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -31,8 +31,8 @@ export interface ApprovedException {
 export type ApprovedExceptionAttributeValue = ApprovedException[];
 
 export interface MethodologyAdditionalVerification {
-  layoutIds?: NonEmptyString[];
-  verificationType: MethodologyVerificationType | NonEmptyString;
+  'Layout IDs'?: NonEmptyString[];
+  'Verification Type': MethodologyVerificationType | NonEmptyString;
 }
 
 export type MethodologyAdditionalVerificationAttributeValue =
@@ -106,4 +106,4 @@ export interface MethodologyDocumentRelation {
   type?: string | undefined;
 }
 
-export type MethodologyVerificationType = 'cdf' | 'mtr' | 'scaleTicket';
+export type MethodologyVerificationType = 'CDF' | 'MTR' | 'Scale Ticket';


### PR DESCRIPTION
## Summary
- Rename `MethodologyAdditionalVerification` interface properties from camelCase (`layoutIds`, `verificationType`) to display-name format (`Layout IDs`, `Verification Type`) to match the external API contract
- Update `MethodologyVerificationType` values from lowercase (`cdf`, `mtr`, `scaleTicket`) to human-readable (`CDF`, `MTR`, `Scale Ticket`)
- Update all usages in scale-ticket-verification helpers and test cases

## Test plan
- [x] All 93 tests pass in `methodologies-bold-rule-processors-mass-id-weighing`
- [x] Lint passes
- [x] Type check passes for `shared-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated methodology verification configuration with new property names for improved consistency ('Layout IDs', 'Verification Type').
  * Standardized verification type values to title-case formatting ('Scale Ticket', 'CDF', 'MTR') throughout the system.
  * Updated validation and test infrastructure to align with revised configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->