### PR TITLE
Make tare exception container-type agnostic

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
@@ -99,15 +99,11 @@ const isAttributeOmitted = (
 const shouldSkipValidationWithTareException = (
   values: WeighingValues,
   isOmitted: boolean,
-): boolean =>
-  isTruckContainer(values) &&
-  isExceptionValid(values.tareException) &&
-  isOmitted;
+): boolean => isExceptionValid(values.tareException) && isOmitted;
 
 const shouldSkipNetWeightCalculationWithTareException = (
   values: WeighingValues,
 ): boolean =>
-  isTruckContainer(values) &&
   isExceptionValid(values.tareException) &&
   (isAttributeOmitted(values.grossWeight) || isAttributeOmitted(values.tare));
 

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -695,9 +695,11 @@ export const weighingTestCases = [
         [TARE, undefined],
       ]),
     },
-    resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined')} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${WEIGHING} event fails for non-TRUCK (BIN) container with tareException and missing Tare`,
+    resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
+      PASSED_RESULT_COMMENTS.SINGLE_STEP,
+    ),
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `the ${WEIGHING} event is valid for non-TRUCK (BIN) container with tareException and missing Tare`,
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments({
@@ -724,7 +726,7 @@ export const weighingTestCases = [
       tare: 1,
     }),
     resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${WEIGHING} event fails for non-TRUCK (BIN) container with tareException when net weight calculation fails (tare exception does not apply to non-TRUCK containers)`,
+    scenario: `the ${WEIGHING} event fails for non-TRUCK (BIN) container with tareException when net weight calculation fails`,
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments({


### PR DESCRIPTION
### Summary

Make the weighing rule's tare exception apply to all container types instead of only TRUCK. Recyclers with an approved tare exception were still getting validation failures for MassIDs using other container types (Drum, Bin, Bag, etc.).

### Context

The `shouldSkipValidationWithTareException` and `shouldSkipNetWeightCalculationWithTareException` helpers had a `isTruckContainer` guard that restricted the tare exception to TRUCK containers only. Since the exception is granted at the recycler accreditation level and is not container-specific, this gate was incorrect.

### Scope of this PR

**Included:**
- Removed the `isTruckContainer` check from both tare exception helper functions in `weighing.helpers.ts`
- Updated test cases in `weighing.test-cases.ts` to reflect the new behavior (BIN container with tare exception + missing Tare now passes)

**Not included:**
- No changes to the `isTruckContainer` helper itself — it is still used elsewhere for other validations

### How to test

```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-weighing
```

All 93 tests pass (5 suites).

### Considerations for Review

- The `isTruckContainer` function remains in use at line 278 of `weighing.helpers.ts` for unrelated container-type logic — it was not removed
- The BIN + tare exception + net weight mismatch test case stays as FAILED because the failure comes from net weight math, not the tare exception gate

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Expanded Tare Exception Support**: Tare exception validation and net weight calculations now apply consistently across all container types, no longer limited to trucks. This enables proper handling of weighing scenarios with containers such as bins when tare exceptions are valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->