### PR TITLE
feat(rule): move baselines from waste generator to recycler accreditation

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.errors.ts
@@ -3,12 +3,12 @@ import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/proc
 export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
   override readonly ERROR_MESSAGE = {
     FAILED_BY_ERROR: 'Unable to validate the prevented-emissions process.',
+    INVALID_BASELINES:
+      'The "Recycler accreditation" document has no valid baselines.',
     INVALID_CLASSIFICATION_ID:
       'The "Local Waste Classification ID" does not match the local waste classification code accepted by the methodology.',
     INVALID_MASS_ID_DOCUMENT_SUBTYPE:
       'The "MassID" document has an invalid subtype.',
-    INVALID_WASTE_GENERATOR_BASELINES:
-      'The "Waste Generator accreditation" document has no valid baselines.',
     MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE: (
       normalizedLocalWasteClassificationId: string,
     ) =>
@@ -18,8 +18,6 @@ export class PreventedEmissionsProcessorErrors extends BaseProcessorErrors {
     MISSING_MASS_ID_DOCUMENT: 'The "MassID" document was not found.',
     MISSING_RECYCLER_ACCREDITATION_DOCUMENT:
       'The "Recycler accreditation" document was not found.',
-    MISSING_WASTE_GENERATOR_VERIFICATION_DOCUMENT:
-      'The "Waste Generator accreditation" document was not found.',
     SUBTYPE_CDM_CODE_MISMATCH:
       'The "Local Waste Classification ID" does not correspond to CDM code 8.7D (Others if organic).',
   } as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.spec.ts
@@ -1,8 +1,4 @@
-import {
-  stubBoldEmissionAndCompostingMetricsEvent,
-  stubBoldRecyclingBaselinesEvent,
-  stubDocument,
-} from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubBoldEmissionAndCompostingMetricsEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
   MassIDOrganicSubtype,
@@ -14,9 +10,9 @@ import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors'
 import {
   calculatePreventedEmissions,
   formatNumber,
+  getBaselineByWasteSubtype,
   getGasTypeFromEvent,
   getPreventedEmissionsFactor,
-  getWasteGeneratorBaselineByWasteSubtype,
   throwIfMissing,
 } from './prevented-emissions.helpers';
 
@@ -125,28 +121,24 @@ describe('PreventedEmissionsHelpers', () => {
     });
   });
 
-  describe('getWasteGeneratorBaselineByWasteSubtype', () => {
+  describe('getBaselineByWasteSubtype', () => {
     it('should return the baseline for the specified waste subtype', () => {
-      const document = stubDocument({
-        externalEvents: [
-          stubBoldRecyclingBaselinesEvent({
-            metadataAttributes: [
-              [
-                BASELINES,
-                {
-                  [MassIDOrganicSubtype.DOMESTIC_SLUDGE]:
-                    MethodologyBaseline.OPEN_AIR_DUMP,
-                  [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
-                    MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
-                },
-              ],
-            ],
-          }),
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [
+          [
+            BASELINES,
+            {
+              [MassIDOrganicSubtype.DOMESTIC_SLUDGE]:
+                MethodologyBaseline.OPEN_AIR_DUMP,
+              [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+                MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+            },
+          ],
         ],
       });
 
-      const result = getWasteGeneratorBaselineByWasteSubtype(
-        document,
+      const result = getBaselineByWasteSubtype(
+        event,
         MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
         processorErrors,
       );
@@ -157,24 +149,20 @@ describe('PreventedEmissionsHelpers', () => {
     });
 
     it('should return undefined when baseline for waste subtype is not available', () => {
-      const document = stubDocument({
-        externalEvents: [
-          stubBoldRecyclingBaselinesEvent({
-            metadataAttributes: [
-              [
-                BASELINES,
-                {
-                  [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
-                    MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
-                },
-              ],
-            ],
-          }),
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [
+          [
+            BASELINES,
+            {
+              [MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES]:
+                MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
+            },
+          ],
         ],
       });
 
-      const result = getWasteGeneratorBaselineByWasteSubtype(
-        document,
+      const result = getBaselineByWasteSubtype(
+        event,
         MassIDOrganicSubtype.DOMESTIC_SLUDGE,
         processorErrors,
       );
@@ -183,79 +171,55 @@ describe('PreventedEmissionsHelpers', () => {
     });
 
     it('should throw an error when baselines are invalid', () => {
-      const document = stubDocument({
-        externalEvents: [
-          stubBoldRecyclingBaselinesEvent({
-            metadataAttributes: [[BASELINES, 'invalid_baselines']],
-          }),
-        ],
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [[BASELINES, 'invalid_baselines']],
       });
 
       expect(() =>
-        getWasteGeneratorBaselineByWasteSubtype(
-          document,
+        getBaselineByWasteSubtype(
+          event,
           MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
-      ).toThrow(
-        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
-      );
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_BASELINES);
     });
 
     it('should throw an error when baselines are null', () => {
-      const document = stubDocument({
-        externalEvents: [
-          stubBoldRecyclingBaselinesEvent({
-            metadataAttributes: [[BASELINES, null]],
-          }),
-        ],
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [[BASELINES, null]],
       });
 
       expect(() =>
-        getWasteGeneratorBaselineByWasteSubtype(
-          document,
+        getBaselineByWasteSubtype(
+          event,
           MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
-      ).toThrow(
-        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
-      );
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_BASELINES);
     });
 
     it('should throw an error when baselines are undefined', () => {
-      const document = stubDocument({
-        externalEvents: [
-          stubBoldRecyclingBaselinesEvent({
-            metadataAttributes: [[BASELINES, undefined]],
-          }),
-        ],
+      const event = stubBoldEmissionAndCompostingMetricsEvent({
+        metadataAttributes: [[BASELINES, undefined]],
       });
 
       expect(() =>
-        getWasteGeneratorBaselineByWasteSubtype(
-          document,
+        getBaselineByWasteSubtype(
+          event,
           MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
-      ).toThrow(
-        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
-      );
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_BASELINES);
     });
 
-    it('should throw an error when recycling baselines event is not found', () => {
-      const document = stubDocument({
-        externalEvents: [],
-      });
-
+    it('should throw an error when event is undefined', () => {
       expect(() =>
-        getWasteGeneratorBaselineByWasteSubtype(
-          document,
+        getBaselineByWasteSubtype(
+          undefined,
           MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
           processorErrors,
         ),
-      ).toThrow(
-        processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
-      );
+      ).toThrow(processorErrors.ERROR_MESSAGE.INVALID_BASELINES);
     });
   });
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.helpers.ts
@@ -1,10 +1,8 @@
 import { isNil, isNonEmptyString } from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
-  type Document,
   type DocumentEvent,
   DocumentEventAttributeName,
-  DocumentEventName,
   MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -21,7 +19,6 @@ import {
 import { isWasteGeneratorBaselineValues } from './prevented-emissions.typia';
 
 const { BASELINES } = DocumentEventAttributeName;
-const { RECYCLING_BASELINES } = DocumentEventName;
 
 const formatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 3,
@@ -31,14 +28,14 @@ const formatter = new Intl.NumberFormat('en-US', {
 
 export const getPreventedEmissionsFactor = (
   wasteSubtype: MassIDOrganicSubtype,
-  wasteGeneratorBaseline: MethodologyBaseline,
+  baseline: MethodologyBaseline,
   processorErrors: PreventedEmissionsProcessorErrors,
   othersIfOrganicContext?: OthersIfOrganicContext,
 ): number => {
   if (wasteSubtype !== MassIDOrganicSubtype.OTHERS_IF_ORGANIC) {
     return PREVENTED_EMISSIONS_BY_WASTE_SUBTYPE_AND_BASELINE_PER_TON[
       wasteSubtype
-    ][wasteGeneratorBaseline];
+    ][baseline];
   }
 
   const carbonFraction = getCarbonFractionForOthersIfOrganic(
@@ -46,7 +43,7 @@ export const getPreventedEmissionsFactor = (
     processorErrors,
   );
 
-  return calculateOthersIfOrganicFactor(wasteGeneratorBaseline, carbonFraction);
+  return calculateOthersIfOrganicFactor(baseline, carbonFraction);
 };
 
 export const calculatePreventedEmissions = (
@@ -61,21 +58,19 @@ export const calculatePreventedEmissions = (
   return Math.max(0, computedValue);
 };
 
-export const getWasteGeneratorBaselineByWasteSubtype = (
-  wasteGeneratorAccreditationDocument: Document,
+export const getBaselineByWasteSubtype = (
+  emissionAndCompostingMetricsEvent: DocumentEvent | undefined,
   wasteSubtype: MassIDOrganicSubtype,
   processorErrors: PreventedEmissionsProcessorErrors,
 ): MethodologyBaseline | undefined => {
-  const recyclingBaselineEvent =
-    wasteGeneratorAccreditationDocument.externalEvents?.find(
-      (event) => event.name === RECYCLING_BASELINES.toString(),
-    );
-
-  const baselines = getEventAttributeValue(recyclingBaselineEvent, BASELINES);
+  const baselines = getEventAttributeValue(
+    emissionAndCompostingMetricsEvent,
+    BASELINES,
+  );
 
   if (!isWasteGeneratorBaselineValues(baselines)) {
     throw processorErrors.getKnownError(
-      processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
+      processorErrors.ERROR_MESSAGE.INVALID_BASELINES,
     );
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -40,9 +40,9 @@ import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors'
 import {
   calculatePreventedEmissions,
   formatNumber,
+  getBaselineByWasteSubtype,
   getGasTypeFromEvent,
   getPreventedEmissionsFactor,
-  getWasteGeneratorBaselineByWasteSubtype,
   throwIfMissing,
 } from './prevented-emissions.helpers';
 import {
@@ -61,7 +61,7 @@ export const RESULT_COMMENTS = {
   MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE: (
     wasteSubtype: MassIDOrganicSubtype,
   ) =>
-    `The "${BASELINES}" was not found in the "Waste Generator Accreditation" document for the waste subtype "${wasteSubtype}" or it is invalid.`,
+    `The "${BASELINES}" was not found in the "Recycler Accreditation" document for the waste subtype "${wasteSubtype}" or it is invalid.`,
   PASSED: (
     preventedEmissions: number,
     preventedEmissionsByWasteSubtypeAndBaselinePerTon: number,
@@ -74,7 +74,6 @@ export const RESULT_COMMENTS = {
 interface Documents {
   massIDDocument: Document;
   recyclerAccreditationDocument: Document;
-  wasteGeneratorVerificationDocument: Document;
 }
 
 export class PreventedEmissionsProcessor extends RuleDataProcessor {
@@ -105,9 +104,9 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
 
   protected evaluateResult(ruleSubject: RuleSubject): EvaluateResultOutput {
     const {
+      baseline,
       exceedingEmissionCoefficient,
       massIDDocumentValue,
-      wasteGeneratorBaseline,
       wasteSubtype,
     } = ruleSubject;
 
@@ -118,7 +117,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       };
     }
 
-    if (isNil(wasteGeneratorBaseline)) {
+    if (isNil(baseline)) {
       return {
         resultComment:
           RESULT_COMMENTS.MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE(
@@ -133,7 +132,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     const preventedEmissionsByWasteSubtypeAndBaselinePerTon =
       getPreventedEmissionsFactor(
         wasteSubtype,
-        wasteGeneratorBaseline,
+        baseline,
         this.processorErrors,
         othersIfOrganicContext,
       );
@@ -152,7 +151,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
     ) {
       othersIfOrganicAudit = getOthersIfOrganicAuditDetails(
         ruleSubject.normalizedLocalWasteClassificationId,
-        wasteGeneratorBaseline,
+        baseline,
       );
     }
 
@@ -192,7 +191,6 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
   protected getRuleSubject({
     massIDDocument,
     recyclerAccreditationDocument,
-    wasteGeneratorVerificationDocument,
   }: Documents): RuleSubject {
     const lastEmissionAndCompostingMetricsEvent =
       getLastYearEmissionAndCompostingMetricsEvent({
@@ -209,8 +207,8 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       );
     }
 
-    const wasteGeneratorBaseline = getWasteGeneratorBaselineByWasteSubtype(
-      wasteGeneratorVerificationDocument,
+    const baseline = getBaselineByWasteSubtype(
+      lastEmissionAndCompostingMetricsEvent,
       massIDDocument.subtype,
       this.processorErrors,
     );
@@ -231,7 +229,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       ...(!isNil(normalizedLocalWasteClassificationId) && {
         normalizedLocalWasteClassificationId,
       }),
-      wasteGeneratorBaseline,
+      baseline,
       wasteSubtype: massIDDocument.subtype,
     };
   }
@@ -241,7 +239,6 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
   ): Promise<Documents> {
     let recyclerAccreditationDocument: Document | undefined;
     let massIDDocument: Document | undefined;
-    let wasteGeneratorVerificationDocument: Document | undefined;
 
     await documentQuery?.iterator().each(({ document }) => {
       const documentRelation = mapDocumentRelation(document);
@@ -251,13 +248,6 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         documentRelation.subtype === DocumentSubtype.RECYCLER.toString()
       ) {
         recyclerAccreditationDocument = document;
-      }
-
-      if (
-        PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.matches(documentRelation) &&
-        documentRelation.subtype === DocumentSubtype.WASTE_GENERATOR.toString()
-      ) {
-        wasteGeneratorVerificationDocument = document;
       }
 
       if (MASS_ID.matches(documentRelation)) {
@@ -278,18 +268,9 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       this.processorErrors,
     );
 
-    throwIfMissing(
-      wasteGeneratorVerificationDocument,
-      this.processorErrors.ERROR_MESSAGE
-        .MISSING_WASTE_GENERATOR_VERIFICATION_DOCUMENT,
-      this.processorErrors,
-    );
-
     return {
       massIDDocument: massIDDocument as Document,
       recyclerAccreditationDocument: recyclerAccreditationDocument as Document,
-      wasteGeneratorVerificationDocument:
-        wasteGeneratorVerificationDocument as Document,
     };
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -4,7 +4,6 @@ import {
   type StubBoldDocumentParameters,
   stubBoldEmissionAndCompostingMetricsEvent,
   stubBoldMassIDPickUpEvent,
-  stubBoldRecyclingBaselinesEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   Document,
@@ -40,9 +39,8 @@ const {
   GREENHOUSE_GAS_TYPE,
   LOCAL_WASTE_CLASSIFICATION_ID,
 } = DocumentEventAttributeName;
-const { RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
-const { EMISSION_AND_COMPOSTING_METRICS, PICK_UP, RECYCLING_BASELINES } =
-  DocumentEventName;
+const { RECYCLER } = MassIDDocumentActorType;
+const { EMISSION_AND_COMPOSTING_METRICS, PICK_UP } = DocumentEventName;
 
 const subtype = MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES;
 const baseline = MethodologyBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS;
@@ -111,29 +109,11 @@ const makeRecyclerAccreditationParameters = (
   },
 });
 
-const makeWasteGeneratorAccreditationParameters = (
-  baselinesValue: Record<string, MethodologyBaseline> | undefined,
-): StubBoldDocumentParameters => ({
-  externalEventsMap: {
-    [RECYCLING_BASELINES]: stubBoldRecyclingBaselinesEvent({
-      metadataAttributes: [[BASELINES, baselinesValue]],
-    }),
-  },
-});
-
-const makeAccreditationDocuments = ({
-  recyclerMetadataAttributes,
-  wasteGeneratorBaselinesValue,
-}: {
-  recyclerMetadataAttributes: MetadataAttributeParameter[];
-  wasteGeneratorBaselinesValue: Record<string, MethodologyBaseline> | undefined;
-}): Map<string, StubBoldDocumentParameters> =>
+const makeAccreditationDocuments = (
+  recyclerMetadataAttributes: MetadataAttributeParameter[],
+): Map<string, StubBoldDocumentParameters> =>
   new Map([
     [RECYCLER, makeRecyclerAccreditationParameters(recyclerMetadataAttributes)],
-    [
-      WASTE_GENERATOR,
-      makeWasteGeneratorAccreditationParameters(wasteGeneratorBaselinesValue),
-    ],
   ]);
 
 const makeMassIdPickUpParametersWithLocalWasteClassificationCode = (
@@ -165,21 +145,19 @@ const {
 
 export const preventedEmissionsTestCases = [
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [EXCEEDING_EMISSION_COEFFICIENT, undefined],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-      ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+    accreditationDocuments: makeAccreditationDocuments([
+      [EXCEEDING_EMISSION_COEFFICIENT, undefined],
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
+        baseline,
         exceedingEmissionCoefficient: undefined,
         gasType: 'Methane (CH4)',
         massIDDocumentValue: 1,
-        wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
     },
@@ -188,16 +166,14 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [
-          EXCEEDING_EMISSION_COEFFICIENT,
-          exceedingEmissionCoefficientExceedingBaseline,
-        ],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+    accreditationDocuments: makeAccreditationDocuments([
+      [
+        EXCEEDING_EMISSION_COEFFICIENT,
+        exceedingEmissionCoefficientExceedingBaseline,
       ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.PASSED(
@@ -210,11 +186,11 @@ export const preventedEmissionsTestCases = [
       gasType: 'Methane (CH4)',
       preventedCo2e: 0,
       ruleSubject: {
+        baseline,
         exceedingEmissionCoefficient:
           exceedingEmissionCoefficientExceedingBaseline,
         gasType: 'Methane (CH4)',
         massIDDocumentValue,
-        wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
     },
@@ -224,21 +200,19 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [EXCEEDING_EMISSION_COEFFICIENT, null],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-      ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+    accreditationDocuments: makeAccreditationDocuments([
+      [EXCEEDING_EMISSION_COEFFICIENT, null],
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
+        baseline,
         exceedingEmissionCoefficient: null,
         gasType: 'Methane (CH4)',
         massIDDocumentValue: 1,
-        wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
     },
@@ -247,13 +221,11 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-      ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+    accreditationDocuments: makeAccreditationDocuments([
+      [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.PASSED(
@@ -266,10 +238,10 @@ export const preventedEmissionsTestCases = [
       gasType: 'Methane (CH4)',
       preventedCo2e: expectedPreventedEmissionsValue,
       ruleSubject: {
+        baseline,
         exceedingEmissionCoefficient,
         gasType: 'Methane (CH4)',
         massIDDocumentValue,
-        wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
     },
@@ -290,15 +262,14 @@ export const preventedEmissionsTestCases = [
     const formulaCoeffs = getOthersIfOrganicFormulaCoeffs(othersBaseline);
 
     return {
-      accreditationDocuments: makeAccreditationDocuments({
-        recyclerMetadataAttributes: [
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      accreditationDocuments: makeAccreditationDocuments([
+        [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+        [
+          BASELINES,
+          { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: othersBaseline },
         ],
-        wasteGeneratorBaselinesValue: {
-          [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: othersBaseline,
-        },
-      }),
+      ]),
       externalCreatedAt: massIDDocument.externalCreatedAt,
       massIDDocumentsParams:
         makeMassIdPickUpParametersWithLocalWasteClassificationCode(
@@ -322,6 +293,7 @@ export const preventedEmissionsTestCases = [
         },
         preventedCo2e: expectedOthersPreventedEmissions,
         ruleSubject: {
+          baseline: othersBaseline,
           exceedingEmissionCoefficient,
           gasType: 'Methane (CH4)',
           localWasteClassificationId:
@@ -329,7 +301,6 @@ export const preventedEmissionsTestCases = [
           massIDDocumentValue,
           normalizedLocalWasteClassificationId:
             othersIfOrganicLocalWasteClassificationCode,
-          wasteGeneratorBaseline: othersBaseline,
           wasteSubtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
         },
       },
@@ -339,13 +310,11 @@ export const preventedEmissionsTestCases = [
     };
   }),
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-      ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+    accreditationDocuments: makeAccreditationDocuments([
+      [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE(
@@ -353,34 +322,32 @@ export const preventedEmissionsTestCases = [
     ),
     resultContent: {
       ruleSubject: {
+        baseline: undefined,
         exceedingEmissionCoefficient,
         gasType: 'Methane (CH4)',
         massIDDocumentValue,
-        wasteGeneratorBaseline: undefined,
         wasteSubtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
       },
     },
     resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the Waste Generator verification document does not have the "${BASELINES}" info for the waste subtype "${MassIDOrganicSubtype.DOMESTIC_SLUDGE}"`,
+    scenario: `the Recycler Accreditation document does not have the "${BASELINES}" info for the waste subtype "${MassIDOrganicSubtype.DOMESTIC_SLUDGE}"`,
     subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
   },
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [EXCEEDING_EMISSION_COEFFICIENT, 0],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-      ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+    accreditationDocuments: makeAccreditationDocuments([
+      [EXCEEDING_EMISSION_COEFFICIENT, 0],
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
+        baseline,
         exceedingEmissionCoefficient: 0,
         gasType: 'Methane (CH4)',
         massIDDocumentValue,
-        wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
     },
@@ -389,22 +356,20 @@ export const preventedEmissionsTestCases = [
     subtype,
   },
   {
-    accreditationDocuments: makeAccreditationDocuments({
-      recyclerMetadataAttributes: [
-        [EXCEEDING_EMISSION_COEFFICIENT, -0.5],
-        [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-      ],
-      wasteGeneratorBaselinesValue: { [subtype]: baseline },
-    }),
+    accreditationDocuments: makeAccreditationDocuments([
+      [EXCEEDING_EMISSION_COEFFICIENT, -0.5],
+      [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+      [BASELINES, { [subtype]: baseline }],
+    ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
     resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
     resultContent: {
       ruleSubject: {
+        baseline,
         exceedingEmissionCoefficient: -0.5,
         gasType: 'Methane (CH4)',
         massIDDocumentValue,
-        wasteGeneratorBaseline: baseline,
         wasteSubtype: subtype,
       },
     },
@@ -414,21 +379,14 @@ export const preventedEmissionsTestCases = [
   },
 ];
 
-const wasteGeneratorVerificationDocument =
-  participantsAccreditationDocuments.get(WASTE_GENERATOR) as Document;
-
 const mapParticipantAccreditationDocuments = ({
   excludeActorTypes = [],
   recyclerExternalEvents,
   recyclerRemoveEventName,
-  wasteGeneratorExternalEvents,
-  wasteGeneratorRemoveEventName,
 }: {
   excludeActorTypes?: string[];
   recyclerExternalEvents?: Document['externalEvents'];
   recyclerRemoveEventName?: string;
-  wasteGeneratorExternalEvents?: Document['externalEvents'];
-  wasteGeneratorRemoveEventName?: string;
 }): Document[] =>
   [...participantsAccreditationDocuments.values()]
     .filter(
@@ -452,24 +410,6 @@ const mapParticipantAccreditationDocuments = ({
         };
       }
 
-      if (
-        document.subtype === WASTE_GENERATOR &&
-        wasteGeneratorExternalEvents
-      ) {
-        return {
-          ...document,
-          externalEvents:
-            wasteGeneratorRemoveEventName === undefined
-              ? wasteGeneratorExternalEvents
-              : [
-                  ...(document.externalEvents?.filter(
-                    (event) => event.name !== wasteGeneratorRemoveEventName,
-                  ) ?? []),
-                  ...wasteGeneratorExternalEvents,
-                ],
-        };
-      }
-
       return document;
     });
 
@@ -477,14 +417,6 @@ const makeRecyclerEmissionAndCompostingMetricsEvents = (
   metadataAttributes: MetadataAttributeParameter[],
 ): Document['externalEvents'] => [
   stubBoldEmissionAndCompostingMetricsEvent({ metadataAttributes }),
-];
-
-const makeWasteGeneratorRecyclingBaselinesEvents = (
-  baselinesValue: Record<string, MethodologyBaseline> | undefined,
-): Document['externalEvents'] => [
-  stubBoldRecyclingBaselinesEvent({
-    metadataAttributes: [[BASELINES, baselinesValue]],
-  }),
 ];
 
 export const preventedEmissionsErrorTestCases = [
@@ -498,12 +430,8 @@ export const preventedEmissionsErrorTestCases = [
         recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
           [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
           [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+          [BASELINES, { [subtype]: baseline }],
         ]),
-        wasteGeneratorExternalEvents:
-          makeWasteGeneratorRecyclingBaselinesEvents({
-            [subtype]: baseline,
-          }),
-        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
       }),
     ],
     massIDAuditDocument,
@@ -547,46 +475,17 @@ export const preventedEmissionsErrorTestCases = [
     documents: [
       massIDDocument,
       ...mapParticipantAccreditationDocuments({
-        excludeActorTypes: [WASTE_GENERATOR],
         recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
           [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
           [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+          [BASELINES, undefined],
         ]),
-        recyclerRemoveEventName: EMISSION_AND_COMPOSTING_METRICS.toString(),
       }),
     ],
     massIDAuditDocument,
-    resultComment:
-      processorErrors.ERROR_MESSAGE
-        .MISSING_WASTE_GENERATOR_VERIFICATION_DOCUMENT,
+    resultComment: processorErrors.ERROR_MESSAGE.INVALID_BASELINES,
     resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the Waste Generator Accreditation document was not found',
-  },
-  {
-    documents: [
-      massIDDocument,
-      ...mapParticipantAccreditationDocuments({
-        excludeActorTypes: [WASTE_GENERATOR],
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-        ]),
-      }),
-      {
-        ...wasteGeneratorVerificationDocument,
-        externalEvents: [
-          stubBoldRecyclingBaselinesEvent({
-            metadataAttributes: [[BASELINES, undefined]],
-          }),
-        ],
-      },
-    ],
-    massIDAuditDocument,
-    resultComment:
-      processorErrors.ERROR_MESSAGE.INVALID_WASTE_GENERATOR_BASELINES,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the Waste Generator Accreditation document has no valid baselines',
+    scenario: 'the Recycler Accreditation document has no valid baselines',
   },
   {
     documents: [
@@ -606,12 +505,8 @@ export const preventedEmissionsErrorTestCases = [
         recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
           [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
           [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+          [BASELINES, { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline }],
         ]),
-        wasteGeneratorExternalEvents:
-          makeWasteGeneratorRecyclingBaselinesEvents({
-            [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline,
-          }),
-        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
       }),
     ],
     massIDAuditDocument,
@@ -638,12 +533,8 @@ export const preventedEmissionsErrorTestCases = [
         recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
           [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
           [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+          [BASELINES, { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline }],
         ]),
-        wasteGeneratorExternalEvents:
-          makeWasteGeneratorRecyclingBaselinesEvents({
-            [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline,
-          }),
-        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
       }),
     ],
     massIDAuditDocument,
@@ -670,12 +561,8 @@ export const preventedEmissionsErrorTestCases = [
         recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
           [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
           [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+          [BASELINES, { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline }],
         ]),
-        wasteGeneratorExternalEvents:
-          makeWasteGeneratorRecyclingBaselinesEvents({
-            [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline,
-          }),
-        wasteGeneratorRemoveEventName: RECYCLING_BASELINES.toString(),
       }),
     ],
     massIDAuditDocument,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.types.ts
@@ -19,12 +19,12 @@ export type OthersIfOrganicRuleSubjectIds = {
 };
 
 export interface RuleSubject extends OthersIfOrganicRuleSubjectIds {
+  baseline: MethodologyBaseline | undefined;
   exceedingEmissionCoefficient:
     | MethodologyDocumentEventAttributeValue
     | undefined;
   gasType: NonEmptyString;
   massIDDocumentValue: NonNegativeFloat;
-  wasteGeneratorBaseline: MethodologyBaseline | undefined;
   wasteSubtype: MassIDOrganicSubtype;
 }
 


### PR DESCRIPTION
### 🧾 Summary

Move baselines reading from the Waste Generator verification document to the Recycler accreditation's `Emissions & Composting Metrics` event in the prevented-emissions rule processor.

### 🧩 Context

Baselines are being relocated from the Waste Generator to the Recycler accreditation document as part of a broader initiative to consolidate emission-related data. This PR covers Phase 2 — updating the rule processor to read baselines from the new source. Phase 1 (accreditation document updates in palantir) is tracked separately.

### 🧱 Scope of this PR

**Included:**
- Read `BASELINES` attribute from the `Emissions & Composting Metrics` event (same event that already holds `EXCEEDING_EMISSION_COEFFICIENT` and `GREENHOUSE_GAS_TYPE`)
- Remove waste generator document dependency entirely from the processor
- Rename helpers and types to reflect the new data source (`getWasteGeneratorBaselineByWasteSubtype` → `getBaselineByWasteSubtype`, `wasteGeneratorBaseline` → `baseline`)
- Update all tests and error messages

**Not included:**
- Phase 1: Recycler accreditation document changes (palantir repo)
- Changes to other rule processors that may reference waste generator baselines

### 🧪 How to test

```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-prevented-emissions
pnpm nx lint methodologies-bold-rule-processors-mass-id-prevented-emissions
```

All 104 tests pass. Integration testing requires recycler accreditation documents with `BASELINES` attribute in `Emissions & Composting Metrics` events (Phase 1 dependency).

### 🧠 Considerations for Review

- `getBaselineByWasteSubtype` now accepts a `DocumentEvent | undefined` instead of a full `Document` — this simplifies the interface since the caller already resolves the correct event via `getLastYearEmissionAndCompostingMetricsEvent()`
- The waste generator document collection and validation were completely removed, reducing the processor's document query scope
- Error messages updated to reference "Recycler accreditation" instead of "Waste Generator"

### 🔗 Related Links

- ClickUp task: https://app.clickup.com/t/86afxnbk9
- Plan: Phase 1 (palantir) + Phase 2 (this PR) documented in `~/.claude/plans/move-baselines-to-recycler.md`

---

- [ ] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated prevented emissions validation to reference Recycler Accreditation documents instead of Waste Generator Accreditation.
  * Improved baseline retrieval by sourcing directly from emission and composting metrics events.

* **Refactor**
  * Simplified baseline validation and calculation logic.
  * Reduced system dependencies on separate accreditation document types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->