### PR TITLE
Fix deducted weight formula in mass-id-sorting rule

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -51,7 +51,7 @@ export const SORTING_TOLERANCE = 0.1;
 
 export const RESULT_COMMENTS = {
   DEDUCTED_WEIGHT_MISMATCH: (deducted: number, expected: number) =>
-    `The "${DEDUCTED_WEIGHT}" (${deducted} kg) must equal ${GROSS_WEIGHT} × (1 - ${SORTING_FACTOR}) (${expected} kg) within ${SORTING_TOLERANCE} kg.`,
+    `The "${DEDUCTED_WEIGHT}" (${deducted} kg) must equal ${GROSS_WEIGHT} × ${SORTING_FACTOR} (${expected} kg) within ${SORTING_TOLERANCE} kg.`,
   DOCUMENT_VALUE_MISMATCH: (documentValue: number, sortingValue: number) =>
     `The MassID document current value (${documentValue} kg) must equal the sorting event value (${sortingValue} kg).`,
   FAILED: (sortingValueCalculationDifference: number) =>
@@ -114,7 +114,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
     }
 
     const expectedDeducted =
-      sortingData.grossWeight * (1 - Number(sortingData.sortingFactor));
+      sortingData.grossWeight * Number(sortingData.sortingFactor);
     const deductedDiff = Math.abs(
       sortingData.deductedWeight - expectedDeducted,
     );

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -155,7 +155,7 @@ const createWeightAttributesWithFormat = (
 const sortingFactor = faker.number.float({ max: 1, min: 0 });
 const valueBeforeSorting = faker.number.float({ min: 1 });
 const grossWeight = valueBeforeSorting;
-const expectedDeductedWeight = grossWeight * (1 - sortingFactor);
+const expectedDeductedWeight = grossWeight * sortingFactor;
 const deductedWeight = expectedDeductedWeight;
 const calculatedSortingValue = grossWeight - expectedDeductedWeight;
 const wrongSortingValue = calculatedSortingValue + 0.15;
@@ -299,7 +299,7 @@ export const massIDSortingTestCases = [
     },
     resultComment: RESULT_COMMENTS.DEDUCTED_WEIGHT_MISMATCH(
       mismatchedDeductedWeight,
-      Number((grossWeight * (1 - sortingFactor)).toFixed(3)),
+      Number((grossWeight * sortingFactor).toFixed(3)),
     ),
     resultStatus: RuleOutputStatus.FAILED,
     scenario:
@@ -311,7 +311,7 @@ export const massIDSortingTestCases = [
     massIDEvents: createMassIDEvents(
       valueBeforeSorting,
       grossWeight + 0.2,
-      (grossWeight + 0.2) * (1 - sortingFactor),
+      (grossWeight + 0.2) * sortingFactor,
       calculatedSortingValue,
     ),
     partialDocument: {


### PR DESCRIPTION
### 🧾 Summary

Fix the deducted weight validation formula in the `mass-id-sorting` rule processor. The formula was computing the **remaining weight** (`Gross Weight × (1 - Sorting Factor)`) instead of the **deducted weight** (`Gross Weight × Sorting Factor`), causing all MassIDs to fail the sorting validation.

### 🧩 Context

The `mass-id-sorting` rule validates that the Sorting event attributes are consistent with the Sorting Factor defined in the Recycler Accreditation. The deducted weight check was comparing the actual deducted weight (e.g., `1.96 kg` for a `140 kg` mass with `0.014` sorting factor) against the remaining weight (`138.04 kg`), which always produces a massive mismatch.

This was discovered while investigating MassID `653e0e8b-7e84-4f86-a66e-d362c0899418` which failed with: _"The Deducted Weight (1.9599999999999997 kg) must equal Gross Weight × (1 - Sorting Factor) (138.04 kg) within 0.1 kg."_

### 🧱 Scope of this PR

**Included:**
- Fixed the formula in `mass-id-sorting.processor.ts` from `grossWeight * (1 - sortingFactor)` to `grossWeight * sortingFactor`
- Updated the error message to reflect the correct formula
- Updated all related test cases in `mass-id-sorting.test-cases.ts`

**Not included:**
- Data inconsistency in the specific MassID mentioned above (the integrator needs to fix the Sorting event value: `138.6 kg` vs expected `138.04 kg`)

### 🧪 How to test

```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-mass-id-sorting
```

All 46 tests pass.

### 🧠 Considerations for Review

- The formula change is semantically significant: `Deducted Weight` represents the weight **removed** during sorting, not the weight **remaining**. The fix aligns the formula with this meaning.
- The specific MassID that triggered this investigation also has a data inconsistency (Sorting event value doesn't match `Gross Weight - Deducted Weight`), which needs to be addressed by the integrator separately.

### 🔗 Related Links

- MassID: `653e0e8b-7e84-4f86-a66e-d362c0899418`
- Recycler Accreditation: `97f43bb8-4fc7-4de5-8107-df466e193ed9`

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mass ID sorting weight deduction calculation formula to properly assess the impact of sorting factors on total deductions, which may affect validation outcomes.

* **Tests**
  * Updated test cases to align with the revised deduction calculation logic and validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->