### PR TITLE
Remove vehicle license plate sensitive validation from weighing rule

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.constants.ts
@@ -98,7 +98,6 @@ export const INVALID_RESULT_COMMENTS = {
   }) =>
     `The first weighing "${String(attributeName)}" value "${String(firstValue)}" does not match the second weighing "${String(attributeName)}" value "${String(secondValue)}"`,
   VEHICLE_LICENSE_PLATE_FORMAT: `The "${VEHICLE_LICENSE_PLATE}" format is invalid.`,
-  VEHICLE_LICENSE_PLATE_SENSITIVE: `The "${VEHICLE_LICENSE_PLATE}" attribute should be marked as sensitive.`,
   WEIGHING_CAPTURE_METHOD: (captureMethod: unknown) =>
     `The "${WEIGHING_CAPTURE_METHOD}" "${String(captureMethod)}" is not supported by the methodology.`,
 } as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
@@ -488,10 +488,6 @@ const validators: Record<string, Validator> = {
       errors.push(INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_FORMAT);
     }
 
-    if (attribute?.sensitive !== true) {
-      errors.push(INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_SENSITIVE);
-    }
-
     return { errors };
   },
 

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -446,9 +446,9 @@ export const weighingTestCases = [
         ]),
       ),
     },
-    resultComment: `${INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_FORMAT} ${INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_SENSITIVE}`,
+    resultComment: INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_FORMAT,
     resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${VEHICLE_LICENSE_PLATE} attribute is missing and is not sensitive`,
+    scenario: `the ${VEHICLE_LICENSE_PLATE} attribute is missing`,
   },
   {
     accreditationDocuments: stubBaseAccreditationDocuments(),


### PR DESCRIPTION
### 🧾 Summary

Remove the `sensitive` flag validation for the `Vehicle License Plate` attribute in the Weighing rule processor.

### 🧩 Context

The Weighing rule validates that the `Vehicle License Plate` attribute has `sensitive: true`. However, the platform's document assembly process strips the `sensitive` property from metadata attributes before storing the document in S3. The integrator correctly sends `sensitive: true` on the attribute, but by the time the rule processor reads the assembled document from S3, the flag is gone.

This was discovered while investigating MassID `653e0e8b-7e84-4f86-a66e-d362c0899418`, where the rule failed with: _"The Vehicle License Plate attribute should be marked as sensitive."_

Verified by comparing the `document-part-snapshot` in MongoDB (which has `sensitive: true`) against the actual S3 document snapshot (where `sensitive` is absent). The Weighing event has `preserveSensitiveData: false`, which causes the platform to strip the field during assembly.

### 🧱 Scope of this PR

**Included:**
- Removed the `sensitive` check from the `vehicleLicensePlate` validator in `weighing.helpers.ts`
- Removed the `VEHICLE_LICENSE_PLATE_SENSITIVE` constant from `weighing.constants.ts`
- Updated the related test case in `weighing.test-cases.ts`

**Not included:**
- Changes to the platform's document assembly process (separate concern)

### 🧪 How to test

```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-weighing
```

All 95 tests pass.

### 🧠 Considerations for Review

- The `sensitive` flag is a platform-level concern (data privacy), not a methodology rule concern. The integrator sends it correctly — the platform just doesn't preserve it in the S3 snapshot.
- The license plate format validation (`isValidLicensePlate`) remains in place.

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**
