### PR TITLE
fix(rule): accept zero as valid exceeding emission coefficient

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -6,7 +6,7 @@ import {
   getOrUndefined,
   isNil,
   isNonEmptyString,
-  isNonZeroPositive,
+  isNonNegative,
 } from '@carrot-fndn/shared/helpers';
 import {
   getEventAttributeValue,
@@ -110,7 +110,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       wasteSubtype,
     } = ruleSubject;
 
-    if (!isNonZeroPositive(exceedingEmissionCoefficient)) {
+    if (!isNonNegative(exceedingEmissionCoefficient)) {
       return {
         resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
         resultStatus: RuleOutputStatus.FAILED,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -341,8 +341,15 @@ export const preventedEmissionsTestCases = [
     ]),
     externalCreatedAt: massIDDocument.externalCreatedAt,
     massIDDocumentValue,
-    resultComment: RESULT_COMMENTS.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
+    resultComment: RESULT_COMMENTS.PASSED(
+      massIDDocumentValue * baselineValue,
+      baselineValue,
+      0,
+      massIDDocumentValue,
+    ),
     resultContent: {
+      gasType: 'Methane (CH4)',
+      preventedCo2e: massIDDocumentValue * baselineValue,
       ruleSubject: {
         baseline,
         exceedingEmissionCoefficient: 0,
@@ -351,8 +358,8 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the exceeding emission coefficient is zero (non-positive)`,
+    resultStatus: RuleOutputStatus.PASSED,
+    scenario: `the exceeding emission coefficient is zero (no exceeding emissions)`,
     subtype,
   },
   {

--- a/libs/shared/helpers/src/is.typia.spec.ts
+++ b/libs/shared/helpers/src/is.typia.spec.ts
@@ -1,5 +1,6 @@
 import {
   isBigNumber,
+  isNonNegative,
   isNonZeroPositive,
   isNonZeroPositiveInt,
   isNumber,
@@ -69,6 +70,34 @@ describe('is.typia', () => {
         [],
       ])('should validate %s as false', (input) => {
         expect(isValidLicensePlate(input)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('isNonNegative', () => {
+    describe('valid values', () => {
+      it.each([0, 0.1, 1, 1.5, 100, Number.MAX_SAFE_INTEGER])(
+        'should validate %s as true',
+        (input) => {
+          expect(isNonNegative(input)).toBeTruthy();
+        },
+      );
+    });
+
+    describe('invalid values', () => {
+      it.each([
+        -1,
+        -0.1,
+        Number.NaN,
+        null,
+        undefined,
+        '',
+        'abc',
+        [],
+        {},
+        Number.NEGATIVE_INFINITY,
+      ])('should validate %s as false', (input) => {
+        expect(isNonNegative(input)).toBeFalsy();
       });
     });
   });

--- a/libs/shared/helpers/src/is.typia.ts
+++ b/libs/shared/helpers/src/is.typia.ts
@@ -1,5 +1,6 @@
 import type {
   LicensePlate,
+  NonNegativeFloat,
   NonZeroPositive,
   NonZeroPositiveInt,
   Uri,
@@ -8,6 +9,7 @@ import type BigNumber from 'bignumber.js';
 
 import { createIs } from 'typia';
 
+export const isNonNegative = createIs<NonNegativeFloat>();
 export const isNonZeroPositive = createIs<NonZeroPositive>();
 export const isNonZeroPositiveInt = createIs<NonZeroPositiveInt>();
 export const isNumber = createIs<number>();


### PR DESCRIPTION
## Summary
- The `prevented-emissions` rule rejected an exceeding emission coefficient of `0`, treating it as invalid. A value of `0` is legitimate — it means the recycler has no exceeding emissions.
- Added a new `isNonNegative` shared helper (using the existing `NonNegativeFloat` type) to validate `>= 0` values.
- Replaced `isNonZeroPositive` with `isNonNegative` in the coefficient validation.

## Test plan
- [x] Updated existing test case for zero coefficient: now expects `PASSED` instead of `FAILED`
- [x] Added unit tests for the new `isNonNegative` helper (valid/invalid values)
- [x] All 104 prevented-emissions tests pass
- [x] All 139 shared-helpers is.typia tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation utility for non-negative numeric values.

* **Bug Fixes**
  * Updated prevented emissions processing to accept zero as a valid exceeding emission coefficient value, allowing calculations to proceed instead of failing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->