### PR TITLE
refactor(rule): standardize error files for all rule processors

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class CompostingCycleTimeframeProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the composting-cycle-timeframe process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class DocumentManifestDataProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the document-manifest-data process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class DriverIdentificationProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the driver-identification process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class DropOffAtRecyclerProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the drop-off-at-recycler process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class HaulerIdentificationProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the hauler-identification process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class ProcessorIdentificationProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the processor-identification process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class ProjectBoundaryProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the project-boundary process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class ProjectPeriodLimitProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the project-period-limit process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class RecyclerIdentificationProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the recycler-identification process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class VehicleIdentificationProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the vehicle-identification process.',
+  } as const;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.errors.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.errors.ts
@@ -1,0 +1,8 @@
+import { BaseProcessorErrors } from '@carrot-fndn/shared/methodologies/bold/processors';
+
+export class WasteOriginIdentificationProcessorErrors extends BaseProcessorErrors {
+  override readonly ERROR_MESSAGE = {
+    FAILED_BY_ERROR:
+      'Unable to validate the waste-origin-identification process.',
+  } as const;
+}


### PR DESCRIPTION
### 🧾 Summary

- Add `errors.ts` with `BaseProcessorErrors` to 11 rules missing them
- All 22 rule processors now have consistent error file structure

### 🧩 Context

**PR 4 of 8** in Rule Structure Standardization & Manifest Generation.

The manifest generator needs to import error messages from errors.ts
files. This PR ensures all rules have them.

### 🧱 Scope of this PR

**Included:**
- 11 new `<slug>.errors.ts` files with `FAILED_BY_ERROR` message

**Not included:**
- Processor refactoring to use error classes (future enhancement)
- RESULT_COMMENTS standardization (PR 5)

### 🧪 How to test

```bash
pnpm ts:all  # 79 projects pass
```

Note: 3 pre-existing test failures exist on main (composting-cycle-
timeframe boundary condition, waste-mass-is-unique, rewards-
distribution) — not introduced by this PR.

### 🧠 Considerations for Review

- Minimal errors.ts files with `FAILED_BY_ERROR` only
- Processors not yet refactored to use these error classes
- Validation failure messages remain as RESULT_COMMENTS
  (standardized in PR 5)

### 🔗 Related Links

- Depends on: #345

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized error handling for validation processes across multiple workflow modules, including composting-cycle-timeframe, document-manifest-data, driver-identification, drop-off-at-recycler, hauler-identification, processor-identification, project-boundary, project-period-limit, recycler-identification, vehicle-identification, and waste-origin-identification. Users will now receive consistent, descriptive error messages when validation fails in these processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->