### PR TITLE
refactor(rule): add RuleTestCase base type to all test case files

### DIFF
--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -1,3 +1,4 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 import type { AnyObject, NonEmptyArray } from '@carrot-fndn/shared/types';
 
 import {
@@ -40,21 +41,17 @@ type ActorResult = {
 type CertificateDocument = Document;
 type CreditOrderDocument = Document;
 
-type ErrorTestCase = {
+type ErrorTestCase = RuleTestCase & {
   creditOrderDocument: CreditOrderDocument | undefined;
   massIDCertificateDocuments: CertificateDocument[];
-  resultComment: string;
-  resultStatus: RuleOutputStatus;
-  scenario: string;
 };
 
-type TestCase = {
+type TestCase = Omit<RuleTestCase, 'resultComment'> & {
   creditOrderDocument: CreditOrderDocument;
   expectedActorsResult: ActorResult[];
   expectedCertificateTotalValue: number;
   massIDCertificateDocuments: CertificateDocument[];
-  resultStatus: RuleOutputStatus;
-  scenario: string;
+  resultComment?: string;
   unitPrice: number;
 };
 

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -1,3 +1,4 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 import type { PartialDeep } from 'type-fest';
 
 import {
@@ -151,99 +152,102 @@ const EXPECTED_REWARDS = {
   },
 };
 
-export const rewardsDistributionProcessorTestCases: Array<{
+interface RewardsDistributionTestCase
+  extends Omit<RuleTestCase, 'resultComment'> {
   expectedRewards: Record<string, string>;
   massIDDocumentEvents?: BoldExternalEventsObject | undefined;
   massIDPartialDocument: PartialDeep<Document>;
-  resultStatus: RuleOutputStatus;
-  scenario: string;
+  resultComment?: string;
   wasteGeneratorVerificationDocument?: Document | undefined;
-}> = [
-  ...Object.entries(REWARDS_DISTRIBUTION_BY_WASTE_TYPE).map(
-    ([wasteType, expectedRewards]) => ({
-      // eslint-disable-next-line security/detect-object-injection
-      expectedRewards: EXPECTED_REWARDS[expectedRewards],
-      massIDDocumentEvents: {},
+}
+
+export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[] =
+  [
+    ...Object.entries(REWARDS_DISTRIBUTION_BY_WASTE_TYPE).map(
+      ([wasteType, expectedRewards]) => ({
+        // eslint-disable-next-line security/detect-object-injection
+        expectedRewards: EXPECTED_REWARDS[expectedRewards],
+        massIDDocumentEvents: {},
+        massIDPartialDocument: {
+          subtype: wasteType,
+        },
+        resultStatus: RuleOutputStatus.PASSED,
+        scenario: `the massRewards is calculated successfully for ${wasteType} waste type and ${expectedRewards} rewards`,
+      }),
+    ),
+    {
+      expectedRewards: EXPECTED_REWARDS.WITHOUT_WASTE_GENERATOR.WITHOUT_HAULER,
+      massIDDocumentEvents: {
+        [`ACTOR-${HAULER}`]: undefined,
+        [`ACTOR-${WASTE_GENERATOR}`]: undefined,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
+        }),
+      },
       massIDPartialDocument: {
-        subtype: wasteType,
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
       resultStatus: RuleOutputStatus.PASSED,
-      scenario: `the massRewards is calculated successfully for ${wasteType} waste type and ${expectedRewards} rewards`,
-    }),
-  ),
-  {
-    expectedRewards: EXPECTED_REWARDS.WITHOUT_WASTE_GENERATOR.WITHOUT_HAULER,
-    massIDDocumentEvents: {
-      [`ACTOR-${HAULER}`]: undefined,
-      [`ACTOR-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
-      }),
+      scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is not present`,
     },
-    massIDPartialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    {
+      expectedRewards: EXPECTED_REWARDS.WITHOUT_WASTE_GENERATOR.WITH_HAULER,
+      massIDDocumentEvents: {
+        [`ACTOR-${WASTE_GENERATOR}`]: undefined,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
+        }),
+      },
+      massIDPartialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is present`,
     },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is not present`,
-  },
-  {
-    expectedRewards: EXPECTED_REWARDS.WITHOUT_WASTE_GENERATOR.WITH_HAULER,
-    massIDDocumentEvents: {
-      [`ACTOR-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
-      }),
+    {
+      expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
+      massIDDocumentEvents: {},
+      massIDPartialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `all rewards are applied for the ${REWARDS_DISTRIBUTION_BY_WASTE_TYPE['Food, Food Waste and Beverages']}`,
     },
-    massIDPartialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    {
+      expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
+      massIDDocumentEvents: {},
+      massIDPartialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `Large Business discount is applied when Waste Generator Verification Document is missing (defaults to Large Business)`,
     },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is present`,
-  },
-  {
-    expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
-    massIDDocumentEvents: {},
-    massIDPartialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    {
+      expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
+      massIDDocumentEvents: {},
+      massIDPartialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `Large Business discount is applied when Waste Generator Verification Document indicates Large Business`,
+      wasteGeneratorVerificationDocument:
+        createWasteGeneratorVerificationDocument(LARGE_BUSINESS),
     },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `all rewards are applied for the ${REWARDS_DISTRIBUTION_BY_WASTE_TYPE['Food, Food Waste and Beverages']}`,
-  },
-  {
-    expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
-    massIDDocumentEvents: {},
-    massIDPartialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+    {
+      expectedRewards:
+        EXPECTED_REWARDS.SMALL_BUSINESS[
+          RewardsDistributionWasteType.MIXED_ORGANIC_WASTE
+        ],
+      massIDDocumentEvents: {},
+      massIDPartialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `no discount is applied when Waste Generator Verification Document indicates Small Business`,
+      wasteGeneratorVerificationDocument:
+        createWasteGeneratorVerificationDocument(SMALL_BUSINESS),
     },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `Large Business discount is applied when Waste Generator Verification Document is missing (defaults to Large Business)`,
-  },
-  {
-    expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
-    massIDDocumentEvents: {},
-    massIDPartialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `Large Business discount is applied when Waste Generator Verification Document indicates Large Business`,
-    wasteGeneratorVerificationDocument:
-      createWasteGeneratorVerificationDocument(LARGE_BUSINESS),
-  },
-  {
-    expectedRewards:
-      EXPECTED_REWARDS.SMALL_BUSINESS[
-        RewardsDistributionWasteType.MIXED_ORGANIC_WASTE
-      ],
-    massIDDocumentEvents: {},
-    massIDPartialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `no discount is applied when Waste Generator Verification Document indicates Small Business`,
-    wasteGeneratorVerificationDocument:
-      createWasteGeneratorVerificationDocument(SMALL_BUSINESS),
-  },
-];
+  ];
 
 const { massIDAuditDocument, massIDDocument, methodologyDocument } =
   new BoldStubsBuilder()
@@ -252,92 +256,100 @@ const { massIDAuditDocument, massIDDocument, methodologyDocument } =
     .createMethodologyDocument()
     .build();
 
-export const rewardsDistributionProcessorErrors = [
-  {
-    documents: [],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.MASS_ID_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `${MASS_ID} document is not found`,
-  },
-  {
-    documents: [massIDDocument],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.METHODOLOGY_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `${METHODOLOGY} document is not found`,
-  },
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        externalEvents: massIDDocument.externalEvents?.filter(
-          ({ label }) => label !== RewardsDistributionActorType.INTEGRATOR,
-        ),
-      },
-      methodologyDocument as Document,
-    ],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.MISSING_REQUIRED_ACTORS(massIDDocument.id, [
-      RewardsDistributionActorType.INTEGRATOR,
-    ]),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${MASS_ID} document does not have the required actors`,
-  },
-  {
-    documents: [
-      {
-        ...methodologyDocument,
-        externalEvents: [],
-      } as Document,
-      massIDDocument,
-    ],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${METHODOLOGY} document does not have the required actors`,
-  },
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        externalEvents: [],
-      } as Document,
-      methodologyDocument as Document,
-    ],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.EXTERNAL_EVENTS_NOT_FOUND(massIDDocument.id),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${MASS_ID} document does not have external events`,
-  },
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        subtype: 'unknown',
-      } as Document,
-      methodologyDocument as Document,
-    ],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.UNEXPECTED_DOCUMENT_SUBTYPE('unknown'),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${MASS_ID} document has an unexpected subtype`,
-  },
-  {
-    documents: [
-      massIDDocument,
-      {
-        ...methodologyDocument,
-        externalEvents: methodologyDocument?.externalEvents?.map((event) =>
-          event.name === String(DocumentEventName.ACTOR)
-            ? { ...event, address: undefined }
-            : event,
-        ),
-      } as Document,
-    ],
-    massIDAuditDocument,
-    resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `the ${METHODOLOGY} document does not have the required address in actors`,
-  },
-];
+interface RewardsDistributionErrorTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document;
+}
+
+export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCase[] =
+  [
+    {
+      documents: [],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.MASS_ID_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `${MASS_ID} document is not found`,
+    },
+    {
+      documents: [massIDDocument],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.METHODOLOGY_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `${METHODOLOGY} document is not found`,
+    },
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          externalEvents: massIDDocument.externalEvents?.filter(
+            ({ label }) => label !== RewardsDistributionActorType.INTEGRATOR,
+          ),
+        },
+        methodologyDocument as Document,
+      ],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.MISSING_REQUIRED_ACTORS(massIDDocument.id, [
+        RewardsDistributionActorType.INTEGRATOR,
+      ]),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `the ${MASS_ID} document does not have the required actors`,
+    },
+    {
+      documents: [
+        {
+          ...methodologyDocument,
+          externalEvents: [],
+        } as Document,
+        massIDDocument,
+      ],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `the ${METHODOLOGY} document does not have the required actors`,
+    },
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          externalEvents: [],
+        } as Document,
+        methodologyDocument as Document,
+      ],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.EXTERNAL_EVENTS_NOT_FOUND(
+        massIDDocument.id,
+      ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `the ${MASS_ID} document does not have external events`,
+    },
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          subtype: 'unknown',
+        } as Document,
+        methodologyDocument as Document,
+      ],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.UNEXPECTED_DOCUMENT_SUBTYPE('unknown'),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `the ${MASS_ID} document has an unexpected subtype`,
+    },
+    {
+      documents: [
+        massIDDocument,
+        {
+          ...methodologyDocument,
+          externalEvents: methodologyDocument?.externalEvents?.map((event) =>
+            event.name === String(DocumentEventName.ACTOR)
+              ? { ...event, address: undefined }
+              : event,
+          ),
+        } as Document,
+      ],
+      massIDAuditDocument,
+      resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `the ${METHODOLOGY} document does not have the required address in actors`,
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
@@ -1,4 +1,13 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+
+interface CompostingCycleTimeframeTestCase
+  extends Omit<RuleTestCase, 'resultComment'> {
+  dropOffEventDate: string | undefined;
+  recycledEventDate: string | undefined;
+  resultComment?: string;
+}
 
 const RECYCLED_DATE = '2024-02-27T12:00:00.000Z';
 const RECYCLED_DATE_EARLIER = '2024-02-27T11:00:00.000Z';
@@ -9,53 +18,54 @@ const DROP_OFF_DATE_59_DAYS = '2023-12-30T12:00:00.000Z';
 const DROP_OFF_DATE_180_DAYS = '2023-08-31T12:00:00.000Z';
 const DROP_OFF_DATE_181_DAYS = '2023-08-30T12:00:00.000Z';
 
-export const compostingCycleTimeframeTestCases = [
-  {
-    dropOffEventDate: DROP_OFF_DATE_RECENT,
-    recycledEventDate: RECYCLED_DATE_EARLIER,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'Time interval is less than 60 days (2 days)',
-  },
-  {
-    dropOffEventDate: undefined,
-    recycledEventDate: RECYCLED_DATE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'Drop off event date is missing',
-  },
-  {
-    dropOffEventDate: DROP_OFF_DATE_94_DAYS,
-    recycledEventDate: RECYCLED_DATE_EARLIER,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'Time interval is within range (94 days)',
-  },
-  {
-    dropOffEventDate: DROP_OFF_DATE_60_DAYS,
-    recycledEventDate: RECYCLED_DATE,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'Edge case: Exactly 60 days (minimum allowed)',
-  },
-  {
-    dropOffEventDate: DROP_OFF_DATE_180_DAYS,
-    recycledEventDate: RECYCLED_DATE,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'Edge case: Exactly 180 days (maximum allowed)',
-  },
-  {
-    dropOffEventDate: DROP_OFF_DATE_59_DAYS,
-    recycledEventDate: RECYCLED_DATE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'Edge case: 59 days (just below minimum)',
-  },
-  {
-    dropOffEventDate: DROP_OFF_DATE_181_DAYS,
-    recycledEventDate: RECYCLED_DATE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'Edge case: 181 days (just above maximum)',
-  },
-  {
-    dropOffEventDate: DROP_OFF_DATE_94_DAYS,
-    recycledEventDate: undefined,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'Recycled event date is missing',
-  },
-];
+export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase[] =
+  [
+    {
+      dropOffEventDate: DROP_OFF_DATE_RECENT,
+      recycledEventDate: RECYCLED_DATE_EARLIER,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'Time interval is less than 60 days (2 days)',
+    },
+    {
+      dropOffEventDate: undefined,
+      recycledEventDate: RECYCLED_DATE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'Drop off event date is missing',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_94_DAYS,
+      recycledEventDate: RECYCLED_DATE_EARLIER,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'Time interval is within range (94 days)',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_60_DAYS,
+      recycledEventDate: RECYCLED_DATE,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'Edge case: Exactly 60 days (minimum allowed)',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_180_DAYS,
+      recycledEventDate: RECYCLED_DATE,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'Edge case: Exactly 180 days (maximum allowed)',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_59_DAYS,
+      recycledEventDate: RECYCLED_DATE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'Edge case: 59 days (just below minimum)',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_181_DAYS,
+      recycledEventDate: RECYCLED_DATE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'Edge case: 181 days (just above maximum)',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_94_DAYS,
+      recycledEventDate: undefined,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'Recycled event date is missing',
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
@@ -21,14 +21,12 @@ import { random } from 'typia';
 import { RESULT_COMMENTS } from './document-manifest-data.constants';
 import { type DocumentManifestType } from './document-manifest-data.processor';
 
-interface DocumentManifestDataTestCase
-  extends Omit<RuleTestCase, 'resultComment'> {
+interface DocumentManifestDataTestCase extends RuleTestCase {
   crossValidationFailMessages?: string[];
   crossValidationPassMessages?: string[];
   crossValidationReviewReasons?: Array<{ code: string; description: string }>;
   documentManifestType: DocumentManifestType;
   events: Record<string, ReturnType<typeof stubDocumentEvent> | undefined>;
-  resultComment?: string | undefined;
 }
 
 const { ACTOR, RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
@@ -83,7 +81,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     // eslint-disable-next-line security/detect-object-injection
-    resultComment: attributeErrorMessages[attribute],
+    resultComment: attributeErrorMessages[attribute]!,
     resultStatus: RuleOutputStatus.FAILED,
     scenario: `the MassID document has a ${documentManifestType} event without a ${attribute}`,
   })),

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   stubAddress,
   stubBoldMassIDRecyclingManifestEvent,
@@ -18,6 +20,16 @@ import { random } from 'typia';
 
 import { RESULT_COMMENTS } from './document-manifest-data.constants';
 import { type DocumentManifestType } from './document-manifest-data.processor';
+
+interface DocumentManifestDataTestCase
+  extends Omit<RuleTestCase, 'resultComment'> {
+  crossValidationFailMessages?: string[];
+  crossValidationPassMessages?: string[];
+  crossValidationReviewReasons?: Array<{ code: string; description: string }>;
+  documentManifestType: DocumentManifestType;
+  events: Record<string, ReturnType<typeof stubDocumentEvent> | undefined>;
+  resultComment?: string | undefined;
+}
 
 const { ACTOR, RECYCLING_MANIFEST, TRANSPORT_MANIFEST } = DocumentEventName;
 
@@ -49,7 +61,7 @@ const defaultEvents = {
   }),
 };
 
-export const documentManifestDataTestCases = [
+export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
   {
     documentManifestType,
     events: {
@@ -341,7 +353,7 @@ export const documentManifestDataTestCases = [
   },
 ];
 
-export const crossValidationTestCases = [
+export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
   {
     crossValidationFailMessages: ['Document number mismatch'],
     documentManifestType: TRANSPORT_MANIFEST as DocumentManifestType,
@@ -473,7 +485,7 @@ export const crossValidationTestCases = [
   },
 ];
 
-export const exceptionTestCases = [
+export const exceptionTestCases: DocumentManifestDataTestCase[] = [
   {
     documentManifestType: RECYCLING_MANIFEST as DocumentManifestType,
     events: {},

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { stubBoldMassIDPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   DocumentEventAttributeName,
@@ -8,6 +10,10 @@ import { faker } from '@faker-js/faker';
 
 import { RESULT_COMMENTS } from './driver-identification.constants';
 
+interface DriverIdentificationTestCase extends RuleTestCase {
+  pickUpEvent: ReturnType<typeof stubBoldMassIDPickUpEvent>;
+}
+
 const {
   DRIVER_IDENTIFIER,
   DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION,
@@ -17,7 +23,7 @@ const { BICYCLE, BOAT, SLUDGE_PIPES, TRUCK } = DocumentEventVehicleType;
 
 const someJustification = faker.lorem.sentence();
 
-export const driverIdentificationTestCases = [
+export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
   {
     pickUpEvent: stubBoldMassIDPickUpEvent({
       metadataAttributes: [

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   stubAddress,
   stubBoldMassIDDropOffEvent,
@@ -12,13 +14,17 @@ import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './drop-off-at-recycler.constants';
 
+interface DropOffAtRecyclerTestCase extends RuleTestCase {
+  events: Record<string, ReturnType<typeof stubDocumentEvent> | undefined>;
+}
+
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { ACTOR, DROP_OFF } = DocumentEventName;
 const { RECEIVING_OPERATOR_IDENTIFIER } = DocumentEventAttributeName;
 
 const sameRecyclerAndDropOffAddress = stubAddress();
 
-export const dropOffAtRecyclerTestCases = [
+export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
   {
     events: { [DROP_OFF]: undefined },
     resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
@@ -7,10 +7,7 @@ import {
   expectRuleOutput,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
-import {
-  type Document,
-  DocumentEventName,
-} from '@carrot-fndn/shared/methodologies/bold/types';
+import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type RuleInput } from '@carrot-fndn/shared/rule/types';
 import { random } from 'typia';
 
@@ -94,23 +91,11 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
   );
 
   describe('GeolocationAndAddressPrecisionProcessorErrors', () => {
-    const allErrorCases = geolocationAndAddressPrecisionErrorTestCases.map(
-      (testCase) => ({
-        ...testCase,
-        hasDocuments: Boolean(
-          testCase.massIDAuditDocument && testCase.documents,
-        ),
-      }),
-    );
-
-    it.each(allErrorCases)(
+    it.each(geolocationAndAddressPrecisionErrorTestCases)(
       'should return $resultStatus when $scenario',
       async (testCase) => {
-        if (testCase.hasDocuments) {
-          const { documents, massIDAuditDocument } = testCase as unknown as {
-            documents: Document[];
-            massIDAuditDocument: Document;
-          };
+        if (testCase.massIDAuditDocument) {
+          const { documents, massIDAuditDocument } = testCase;
 
           spyOnLoadDocument(massIDAuditDocument);
           spyOnDocumentQueryServiceLoad(massIDAuditDocument, [

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { calculateDistance } from '@carrot-fndn/shared/helpers';
 import {
   BoldStubsBuilder,
@@ -13,6 +15,7 @@ import {
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  type Document,
   DocumentCategory,
   DocumentEventAttributeName,
   DocumentEventName,
@@ -27,6 +30,17 @@ import { faker } from '@faker-js/faker';
 
 import { RESULT_COMMENTS } from './geolocation-and-address-precision.constants';
 import { GeolocationAndAddressPrecisionProcessorErrors } from './geolocation-and-address-precision.errors';
+
+interface GeolocationAndAddressPrecisionErrorTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document | undefined;
+}
+
+interface GeolocationAndAddressPrecisionTestCase extends RuleTestCase {
+  accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
+  actorParticipants: Map<string, MethodologyParticipant>;
+  massIDDocumentParameters?: StubBoldDocumentParameters | undefined;
+}
 
 const { RECYCLER, WASTE_GENERATOR } = MassIDDocumentActorType;
 const {
@@ -259,376 +273,370 @@ const wasteGeneratorActorEvent = stubDocumentEvent({
   participant: wasteGeneratorParticipant,
 });
 
-export const geolocationAndAddressPrecisionTestCases: Array<{
-  accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
-  actorParticipants: Map<string, MethodologyParticipant>;
-  massIDDocumentParameters?: StubBoldDocumentParameters | undefined;
-  resultComment: string;
-  resultStatus: RuleOutputStatus;
-  scenario: string;
-}> = [
-  {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        {
-          externalEventsMap: {
-            [ACCREDITATION_CONTEXT]: undefined,
+export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPrecisionTestCase[] =
+  [
+    {
+      accreditationDocuments: new Map([
+        [
+          RECYCLER,
+          {
+            externalEventsMap: {
+              [ACCREDITATION_CONTEXT]: undefined,
+            },
           },
-        },
-      ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [ACCREDITATION_CONTEXT]: undefined,
+        ],
+        [
+          WASTE_GENERATOR,
+          {
+            externalEventsMap: {
+              [ACCREDITATION_CONTEXT]: undefined,
+            },
           },
+        ],
+      ]),
+      actorParticipants,
+      resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.failed.MISSING_ACCREDITATION_ADDRESS(RECYCLER)}`,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the accredited address is not set',
+    },
+    {
+      accreditationDocuments: validAccreditationDocuments,
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            nearbyRecyclerAddress.latitude,
+            nearbyRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            nearbyWasteGeneratorAddress,
+            wasteGeneratorParticipant,
+            nearbyWasteGeneratorAddress.latitude,
+            nearbyWasteGeneratorAddress.longitude,
+          ),
         },
-      ],
-    ]),
-    actorParticipants,
-    resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.failed.MISSING_ACCREDITATION_ADDRESS(RECYCLER)}`,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the accredited address is not set',
-  },
-  {
-    accreditationDocuments: validAccreditationDocuments,
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          nearbyRecyclerAddress.latitude,
-          nearbyRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          nearbyWasteGeneratorAddress,
-          wasteGeneratorParticipant,
-          nearbyWasteGeneratorAddress.latitude,
-          nearbyWasteGeneratorAddress.longitude,
-        ),
       },
+      resultComment: `${RESULT_COMMENTS.passed.PASSED_WITH_GPS(WASTE_GENERATOR, nearbyWasteGeneratorAddressDistance, nearbyWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS(RECYCLER, nearbyRecyclerAddressDistance, nearbyRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the gps is set and both gps geolocation and event address are valid but nearby',
     },
-    resultComment: `${RESULT_COMMENTS.passed.PASSED_WITH_GPS(WASTE_GENERATOR, nearbyWasteGeneratorAddressDistance, nearbyWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS(RECYCLER, nearbyRecyclerAddressDistance, nearbyRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the gps is set and both gps geolocation and event address are valid but nearby',
-  },
-  {
-    accreditationDocuments: validAccreditationDocuments,
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          invalidRecyclerAddress.latitude,
-          invalidRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          nearbyWasteGeneratorAddress,
-          wasteGeneratorParticipant,
-          invalidWasteGeneratorAddress.latitude,
-          invalidWasteGeneratorAddress.longitude,
-        ),
+    {
+      accreditationDocuments: validAccreditationDocuments,
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            invalidRecyclerAddress.latitude,
+            invalidRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            nearbyWasteGeneratorAddress,
+            wasteGeneratorParticipant,
+            invalidWasteGeneratorAddress.latitude,
+            invalidWasteGeneratorAddress.longitude,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the address is valid but the gps geolocation is invalid',
     },
-    resultComment: `${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the address is valid but the gps geolocation is invalid',
-  },
-  {
-    accreditationDocuments: validAccreditationDocuments,
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          invalidRecyclerAddress.latitude,
-          invalidRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: undefined,
+    {
+      accreditationDocuments: validAccreditationDocuments,
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            invalidRecyclerAddress.latitude,
+            invalidRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: undefined,
+        },
       },
+      resultComment: RESULT_COMMENTS.failed.INVALID_ACTOR_TYPE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the processor cannot extract the actor type',
     },
-    resultComment: RESULT_COMMENTS.failed.INVALID_ACTOR_TYPE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the processor cannot extract the actor type',
-  },
-  {
-    accreditationDocuments: validAccreditationDocuments,
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          recyclerAddress,
-          recyclerParticipant,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
+    {
+      accreditationDocuments: validAccreditationDocuments,
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            recyclerAddress,
+            recyclerParticipant,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the gps is not set, but the accredited address is set and is valid',
     },
-    resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the gps is not set, but the accredited address is set and is valid',
-  },
-  {
-    accreditationDocuments: validAccreditationDocuments,
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          invalidRecyclerAddress,
-          recyclerParticipant,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          invalidWasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
+    {
+      accreditationDocuments: validAccreditationDocuments,
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            invalidRecyclerAddress,
+            recyclerParticipant,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            invalidWasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the gps is not set, but the accredited address is set and not valid',
     },
-    resultComment: `${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the gps is not set, but the accredited address is set and not valid',
-  },
-  {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        createAccreditationDocumentWithAddress(
-          recyclerAddress,
-          recyclerParticipant,
-        ),
-      ],
-      [
-        WASTE_GENERATOR,
-        {
-          externalEventsMap: {
-            [ACCREDITATION_CONTEXT]: undefined,
+    {
+      accreditationDocuments: new Map([
+        [
+          RECYCLER,
+          createAccreditationDocumentWithAddress(
+            recyclerAddress,
+            recyclerParticipant,
+          ),
+        ],
+        [
+          WASTE_GENERATOR,
+          {
+            externalEventsMap: {
+              [ACCREDITATION_CONTEXT]: undefined,
+            },
           },
+        ],
+      ]),
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            recyclerAddress,
+            recyclerParticipant,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
         },
-      ],
-    ]),
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          recyclerAddress,
-          recyclerParticipant,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
       },
+      resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the Waste Generator verification document is missing (should pass, not fail)',
     },
-    resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the Waste Generator verification document is missing (should pass, not fail)',
-  },
-  {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        createAccreditationDocumentWithGpsExceptions(
-          recyclerAddress,
-          recyclerParticipant,
-          DROP_OFF,
-        ),
-      ],
-      [
-        WASTE_GENERATOR,
-        createAccreditationDocumentWithAddress(
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
-      ],
-    ]),
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          invalidRecyclerAddress.latitude,
-          invalidRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
+    {
+      accreditationDocuments: new Map([
+        [
+          RECYCLER,
+          createAccreditationDocumentWithGpsExceptions(
+            recyclerAddress,
+            recyclerParticipant,
+            DROP_OFF,
+          ),
+        ],
+        [
+          WASTE_GENERATOR,
+          createAccreditationDocumentWithAddress(
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        ],
+      ]),
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            invalidRecyclerAddress.latitude,
+            invalidRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped for Recycler on DROP_OFF)',
     },
-    resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped for Recycler on DROP_OFF)',
-  },
-  {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        createAccreditationDocumentWithGpsExceptions(
-          recyclerAddress,
-          recyclerParticipant,
-          DROP_OFF,
-        ),
-      ],
-      [
-        WASTE_GENERATOR,
-        createAccreditationDocumentWithAddress(
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
-      ],
-    ]),
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          invalidRecyclerAddress.latitude,
-          invalidRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
+    {
+      accreditationDocuments: new Map([
+        [
+          RECYCLER,
+          createAccreditationDocumentWithGpsExceptions(
+            recyclerAddress,
+            recyclerParticipant,
+            DROP_OFF,
+          ),
+        ],
+        [
+          WASTE_GENERATOR,
+          createAccreditationDocumentWithAddress(
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        ],
+      ]),
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            invalidRecyclerAddress.latitude,
+            invalidRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped)',
     },
-    resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped)',
-  },
-  {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        createAccreditationDocumentWithGpsExceptions(
-          recyclerAddress,
-          recyclerParticipant,
-          DROP_OFF,
-          true, // includeLatitude
-          false, // includeLongitude - missing longitude exception
-        ),
-      ],
-      [
-        WASTE_GENERATOR,
-        createAccreditationDocumentWithAddress(
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
-      ],
-    ]),
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          invalidRecyclerAddress.latitude,
-          invalidRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
+    {
+      accreditationDocuments: new Map([
+        [
+          RECYCLER,
+          createAccreditationDocumentWithGpsExceptions(
+            recyclerAddress,
+            recyclerParticipant,
+            DROP_OFF,
+            true, // includeLatitude
+            false, // includeLongitude - missing longitude exception
+          ),
+        ],
+        [
+          WASTE_GENERATOR,
+          createAccreditationDocumentWithAddress(
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        ],
+      ]),
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            invalidRecyclerAddress.latitude,
+            invalidRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the Recycler has only latitude GPS exception (should NOT skip GPS validation)',
     },
-    resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the Recycler has only latitude GPS exception (should NOT skip GPS validation)',
-  },
-  {
-    accreditationDocuments: new Map([
-      [
-        RECYCLER,
-        createAccreditationDocumentWithGpsExceptions(
-          recyclerAddress,
-          recyclerParticipant,
-          DROP_OFF,
-          true, // includeLatitude
-          true, // includeLongitude
-          '2020-01-01', // validUntil - expired exception
-        ),
-      ],
-      [
-        WASTE_GENERATOR,
-        createAccreditationDocumentWithAddress(
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
-      ],
-    ]),
-    actorParticipants,
-    massIDDocumentParameters: {
-      externalEventsMap: {
-        [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
-        [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
-        [DROP_OFF]: createMassIDEvent(
-          DROP_OFF,
-          nearbyRecyclerAddress,
-          recyclerParticipant,
-          invalidRecyclerAddress.latitude,
-          invalidRecyclerAddress.longitude,
-        ),
-        [PICK_UP]: createMassIDEvent(
-          PICK_UP,
-          wasteGeneratorAddress,
-          wasteGeneratorParticipant,
-        ),
+    {
+      accreditationDocuments: new Map([
+        [
+          RECYCLER,
+          createAccreditationDocumentWithGpsExceptions(
+            recyclerAddress,
+            recyclerParticipant,
+            DROP_OFF,
+            true, // includeLatitude
+            true, // includeLongitude
+            '2020-01-01', // validUntil - expired exception
+          ),
+        ],
+        [
+          WASTE_GENERATOR,
+          createAccreditationDocumentWithAddress(
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        ],
+      ]),
+      actorParticipants,
+      massIDDocumentParameters: {
+        externalEventsMap: {
+          [`${ACTOR}-${RECYCLER}`]: recyclerActorEvent,
+          [`${ACTOR}-${WASTE_GENERATOR}`]: wasteGeneratorActorEvent,
+          [DROP_OFF]: createMassIDEvent(
+            DROP_OFF,
+            nearbyRecyclerAddress,
+            recyclerParticipant,
+            invalidRecyclerAddress.latitude,
+            invalidRecyclerAddress.longitude,
+          ),
+          [PICK_UP]: createMassIDEvent(
+            PICK_UP,
+            wasteGeneratorAddress,
+            wasteGeneratorParticipant,
+          ),
+        },
       },
+      resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the Recycler has expired GPS exceptions (should NOT skip GPS validation)',
     },
-    resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the Recycler has expired GPS exceptions (should NOT skip GPS validation)',
-  },
-];
+  ];
 
 const errorMessage = new GeolocationAndAddressPrecisionProcessorErrors();
 
@@ -648,45 +656,48 @@ const {
   .createParticipantAccreditationDocuments()
   .build();
 
-export const geolocationAndAddressPrecisionErrorTestCases = [
-  {
-    documents: [
+export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddressPrecisionErrorTestCase[] =
+  [
+    {
+      documents: [
+        massIDAuditDocument,
+        ...participantsAccreditationDocuments.values(),
+      ],
       massIDAuditDocument,
-      ...participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument,
-    resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the MassID document does not exist',
-  },
-  {
-    documents: [
-      massIDDocument,
+      resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the MassID document does not exist',
+    },
+    {
+      documents: [
+        massIDDocument,
+        massIDAuditDocument,
+        ...participantsAccreditationDocuments.values(),
+      ],
       massIDAuditDocument,
-      ...participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument,
-    resultComment:
-      errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_REQUIRED_EVENTS(
-        massIDDocument.id,
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the MassID document does not contain a DROP_OFF or PICK_UP event',
-  },
-  {
-    documents: [massIDDocument, massIDAuditDocument],
-    massIDAuditDocument,
-    resultComment:
-      errorMessage.ERROR_MESSAGE.PARTICIPANT_ACCREDITATION_DOCUMENTS_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the accreditation documents are not found',
-  },
-  {
-    documents: [],
-    massIDAuditDocument: undefined,
-    resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_AUDIT_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the MassID Audit document does not exist',
-  },
-];
+      resultComment:
+        errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_REQUIRED_EVENTS(
+          massIDDocument.id,
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the MassID document does not contain a DROP_OFF or PICK_UP event',
+    },
+    {
+      documents: [massIDDocument, massIDAuditDocument],
+      massIDAuditDocument,
+      resultComment:
+        errorMessage.ERROR_MESSAGE
+          .PARTICIPANT_ACCREDITATION_DOCUMENTS_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the accreditation documents are not found',
+    },
+    {
+      documents: [],
+      massIDAuditDocument: undefined,
+      resultComment:
+        errorMessage.ERROR_MESSAGE.MASS_ID_AUDIT_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the MassID Audit document does not exist',
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
@@ -13,12 +15,16 @@ import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 import { RESULT_COMMENTS } from './hauler-identification.constants';
 import { OPTIONAL_HAULER_VEHICLE_TYPES } from './hauler-identification.processor';
 
+interface HaulerIdentificationTestCase extends RuleTestCase {
+  events: Map<string, ReturnType<typeof stubDocumentEvent> | undefined>;
+}
+
 const { ACTOR, PICK_UP } = DocumentEventName;
 const { HAULER } = MethodologyDocumentEventLabel;
 const { VEHICLE_TYPE } = DocumentEventAttributeName;
 const { TRUCK } = DocumentEventVehicleType;
 
-export const haulerIdentificationTestCases = [
+export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
   {
     events: new Map([
       [

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
@@ -1,4 +1,7 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './mass-id-qualifications.constants';
@@ -10,7 +13,11 @@ const massIDStubs = new BoldStubsBuilder()
   .build();
 const processorErrors = new MassIDQualificationsProcessorErrors();
 
-export const massIDQualificationsTestCases = [
+interface MassIDQualificationsTestCase extends RuleTestCase {
+  massIDDocument: Document;
+}
+
+export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
   {
     massIDDocument: massIDStubs.massIDDocument,
     resultComment: RESULT_COMMENTS.passed.PASSED,

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -1,7 +1,12 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+import type { PartialDeep } from 'type-fest';
+
 import { eventNameIsAnyOf } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import {
+  type BoldExternalEventsObject,
   BoldStubsBuilder,
   MASS_ID_ACTOR_PARTICIPANTS,
+  type StubBoldDocumentParameters,
   stubBoldEmissionAndCompostingMetricsEvent,
   stubBoldMassIDDropOffEvent,
   stubBoldMassIDSortingEvent,
@@ -19,6 +24,7 @@ import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyDocumentEventAttributeFormat,
   MethodologyDocumentEventLabel,
+  type MethodologyParticipant,
 } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 import { addYears } from 'date-fns';
@@ -211,7 +217,14 @@ const {
   .createParticipantAccreditationDocuments()
   .build();
 
-export const massIDSortingTestCases = [
+interface MassIDSortingTestCase extends RuleTestCase {
+  accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
+  actorParticipants: Map<string, MethodologyParticipant>;
+  massIDEvents: BoldExternalEventsObject;
+  partialDocument: PartialDeep<Document>;
+}
+
+export const massIDSortingTestCases: MassIDSortingTestCase[] = [
   {
     actorParticipants,
     massIDEvents: createMassIDEvents(
@@ -357,7 +370,12 @@ const invalidSortingValue = new BoldStubsBuilder()
   .createParticipantAccreditationDocuments()
   .build();
 
-export const massIDSortingErrorTestCases = [
+interface MassIDSortingErrorTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document;
+}
+
+export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
   createErrorTestCase(
     'the MassID document does not exist',
     [...participantsAccreditationDocuments.values()],

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   BoldStubsBuilder,
   stubDocumentEvent,
@@ -96,120 +98,127 @@ const massIDWithAuditDocumentsForDifferentMethodologies: Document = {
   ],
 };
 
-export const noConflictingCertificateOrCreditTestCases = [
-  {
-    documents: [simpleMassIDStubs.massIDDocument],
-    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'no Credit is linked to the MassID',
-  },
-  {
-    documents: [
-      massIDWithTwoAuditDocuments,
-      simpleMassIDStubs.massIDAuditDocument,
-      duplicatedMassIDAuditDocument,
-    ],
-    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
-        BoldMethodologyName.RECYCLING,
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'has an approved MassID audit document for the same methodology name',
-  },
-  {
-    documents: [
-      massIDWithTwoAuditDocuments,
-      simpleMassIDStubs.massIDAuditDocument,
-      {
-        ...duplicatedMassIDAuditDocument,
-        externalEvents: [
-          ...(duplicatedMassIDAuditDocument.externalEvents?.filter(
-            (event) => !event.name.includes(RuleOutputStatus.PASSED),
-          ) ?? []),
-        ],
-      },
-    ],
-    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
-        BoldMethodologyName.RECYCLING,
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'has an in-progress MassID audit document for the same methodology name',
-  },
-  {
-    documents: [
-      massIDAuditForOtherMethodology,
-      simpleMassIDStubs.massIDAuditDocument,
-      massIDWithAuditDocumentsForDifferentMethodologies,
-    ],
-    massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'has an approved MassID Audit document for a different methodology',
-  },
-  {
-    documents: [
-      massIDWithAuditStubs.massIDDocument,
-      massIDWithAuditStubs.massIDAuditDocument,
-      massIDWithAuditStubs.massIDCertificateDocument,
-    ],
-    massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CERTIFICATE_DOCUMENT(
-        DocumentType.RECYCLED_ID,
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'has a valid certificate document of the specified type',
-  },
-  {
-    documents: [
-      massIDWithCreditsStubs.massIDDocument,
-      massIDWithCreditsStubs.massIDAuditDocument,
-      massIDWithCreditsStubs.massIDCertificateDocument,
-      massIDWithCreditsStubs.creditOrderDocument,
-    ],
-    massIDAuditDocument: massIDWithCreditsStubs.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'has a valid credit document',
-  },
-  {
-    documents: [
-      massIDWithAuditStubs.massIDDocument,
-      massIDWithAuditStubs.massIDAuditDocument,
-      {
-        ...massIDWithAuditStubs.massIDCertificateDocument,
-        status: MethodologyDocumentStatus.CANCELLED,
-      },
-    ],
-    massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'has cancelled certificate document',
-  },
-  {
-    documents: [
-      massIDWithAuditStubs.massIDDocument,
-      massIDWithAuditStubs.massIDAuditDocument,
-      {
-        ...massIDWithAuditStubs.massIDCertificateDocument,
-        status: MethodologyDocumentStatus.CANCELLED,
-      },
-      {
-        ...massIDWithCreditsStubs.creditOrderDocument,
-        status: MethodologyDocumentStatus.CANCELLED,
-      },
-    ],
-    massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'has cancelled credit document',
-  },
-];
+interface NoConflictingCertificateOrCreditTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document;
+}
+
+export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificateOrCreditTestCase[] =
+  [
+    {
+      documents: [simpleMassIDStubs.massIDDocument],
+      massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'no Credit is linked to the MassID',
+    },
+    {
+      documents: [
+        massIDWithTwoAuditDocuments,
+        simpleMassIDStubs.massIDAuditDocument,
+        duplicatedMassIDAuditDocument,
+      ],
+      massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
+          BoldMethodologyName.RECYCLING,
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'has an approved MassID audit document for the same methodology name',
+    },
+    {
+      documents: [
+        massIDWithTwoAuditDocuments,
+        simpleMassIDStubs.massIDAuditDocument,
+        {
+          ...duplicatedMassIDAuditDocument,
+          externalEvents: [
+            ...(duplicatedMassIDAuditDocument.externalEvents?.filter(
+              (event) => !event.name.includes(RuleOutputStatus.PASSED),
+            ) ?? []),
+          ],
+        },
+      ],
+      massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
+          BoldMethodologyName.RECYCLING,
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'has an in-progress MassID audit document for the same methodology name',
+    },
+    {
+      documents: [
+        massIDAuditForOtherMethodology,
+        simpleMassIDStubs.massIDAuditDocument,
+        massIDWithAuditDocumentsForDifferentMethodologies,
+      ],
+      massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'has an approved MassID Audit document for a different methodology',
+    },
+    {
+      documents: [
+        massIDWithAuditStubs.massIDDocument,
+        massIDWithAuditStubs.massIDAuditDocument,
+        massIDWithAuditStubs.massIDCertificateDocument,
+      ],
+      massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CERTIFICATE_DOCUMENT(
+          DocumentType.RECYCLED_ID,
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'has a valid certificate document of the specified type',
+    },
+    {
+      documents: [
+        massIDWithCreditsStubs.massIDDocument,
+        massIDWithCreditsStubs.massIDAuditDocument,
+        massIDWithCreditsStubs.massIDCertificateDocument,
+        massIDWithCreditsStubs.creditOrderDocument,
+      ],
+      massIDAuditDocument: massIDWithCreditsStubs.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE
+          .MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'has a valid credit document',
+    },
+    {
+      documents: [
+        massIDWithAuditStubs.massIDDocument,
+        massIDWithAuditStubs.massIDAuditDocument,
+        {
+          ...massIDWithAuditStubs.massIDCertificateDocument,
+          status: MethodologyDocumentStatus.CANCELLED,
+        },
+      ],
+      massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'has cancelled certificate document',
+    },
+    {
+      documents: [
+        massIDWithAuditStubs.massIDDocument,
+        massIDWithAuditStubs.massIDAuditDocument,
+        {
+          ...massIDWithAuditStubs.massIDCertificateDocument,
+          status: MethodologyDocumentStatus.CANCELLED,
+        },
+        {
+          ...massIDWithCreditsStubs.creditOrderDocument,
+          status: MethodologyDocumentStatus.CANCELLED,
+        },
+      ],
+      massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'has cancelled credit document',
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   BoldStubsBuilder,
   stubBoldAccreditationResultEvent,
@@ -6,6 +8,7 @@ import {
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  type Document,
   DocumentCategory,
   DocumentEventAccreditationStatus,
   DocumentEventAttributeName,
@@ -294,174 +297,181 @@ const massIDWithWasteGeneratorButNoAccreditation =
     ]),
   );
 
-export const participantAccreditationsAndVerificationsRequirementsTestCases = [
-  {
-    documents: [
-      massIDAuditWithAccreditationsAndVerifications.massIDDocument,
-      ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument:
-      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the participants accreditation documents are found and the accreditation is active',
-  },
-  {
-    documents: [massIDAuditWithAccreditationsAndVerifications.massIDDocument],
-    massIDAuditDocument:
-      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the participants accreditation documents are not found',
-  },
-  {
-    documents: [
-      massIDAuditWithAccreditationsAndVerifications.massIDDocument,
-      ...[
+interface ParticipantAccreditationsTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document;
+}
+
+export const participantAccreditationsAndVerificationsRequirementsTestCases: ParticipantAccreditationsTestCase[] =
+  [
+    {
+      documents: [
+        massIDAuditWithAccreditationsAndVerifications.massIDDocument,
         ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
-      ].filter((document) => document.subtype !== INTEGRATOR),
-    ],
-    massIDAuditDocument:
-      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
-        [INTEGRATOR],
+      ],
+      massIDAuditDocument:
+        massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the participants accreditation documents are found and the accreditation is active',
+    },
+    {
+      documents: [massIDAuditWithAccreditationsAndVerifications.massIDDocument],
+      massIDAuditDocument:
+        massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the participants accreditation documents are not found',
+    },
+    {
+      documents: [
+        massIDAuditWithAccreditationsAndVerifications.massIDDocument,
+        ...[
+          ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+        ].filter((document) => document.subtype !== INTEGRATOR),
+      ],
+      massIDAuditDocument:
+        massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
+          [INTEGRATOR],
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'some participants accreditation documents are not found',
+    },
+    {
+      documents: [
+        ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument:
+        massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
+      resultComment: processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the mass document does not exist',
+    },
+    {
+      documents: [
+        {
+          ...massIDAuditWithAccreditationsAndVerifications.massIDDocument,
+          externalEvents: [],
+        },
+        ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument:
+        massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
+          massIDAuditWithAccreditationsAndVerifications.massIDDocument.id,
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the mass document does not contain events',
+    },
+    {
+      documents: [
+        massIDWithExpiredAccreditation.massIDDocument,
+        ...massIDWithExpiredAccreditation.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument: massIDWithExpiredAccreditation.massIDAuditDocument,
+      resultComment:
+        processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
+          [INTEGRATOR],
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the participants accreditation documents are found and the accreditation is not active',
+    },
+    {
+      documents: [
+        massIDWithWasteGeneratorNoResult.massIDDocument,
+        ...massIDWithWasteGeneratorNoResult.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument: massIDWithWasteGeneratorNoResult.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'WASTE_GENERATOR has accreditation document without result event (should pass - Waste Generator is ignored)',
+    },
+    {
+      documents: [
+        massIDWithWasteGeneratorValidResult.massIDDocument,
+        ...massIDWithWasteGeneratorValidResult.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument:
+        massIDWithWasteGeneratorValidResult.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'WASTE_GENERATOR has valid accreditation result event (should pass - Waste Generator is ignored)',
+    },
+    {
+      documents: [
+        massIDWithWasteGeneratorInvalidResult.massIDDocument,
+        ...massIDWithWasteGeneratorInvalidResult.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument:
+        massIDWithWasteGeneratorInvalidResult.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'WASTE_GENERATOR has invalid accreditation result event (expired) (should pass - Waste Generator is ignored)',
+    },
+    {
+      documents: [
+        massIDWithWasteGeneratorMultipleValid.massIDDocument,
+        ...massIDWithWasteGeneratorMultipleValid.participantsAccreditationDocuments.values(),
+        wasteGeneratorSecondAccreditation,
+      ],
+      massIDAuditDocument: createMassIDAuditWithLinkEvent(
+        massIDWithWasteGeneratorMultipleValid.massIDAuditDocument,
+        wasteGeneratorSecondAccreditation,
       ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'some participants accreditation documents are not found',
-  },
-  {
-    documents: [
-      ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument:
-      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
-    resultComment: processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the mass document does not exist',
-  },
-  {
-    documents: [
-      {
-        ...massIDAuditWithAccreditationsAndVerifications.massIDDocument,
-        externalEvents: [],
-      },
-      ...massIDAuditWithAccreditationsAndVerifications.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument:
-      massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
-        massIDAuditWithAccreditationsAndVerifications.massIDDocument.id,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'WASTE_GENERATOR has multiple valid accreditations (should pass - Waste Generator is ignored)',
+    },
+    {
+      documents: [
+        massIDWithParticipantMultipleRoles.massIDDocument,
+        ...massIDWithParticipantMultipleRoles.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument:
+        massIDWithParticipantMultipleRoles.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'participant has one valid accreditation as PROCESSOR and one as RECYCLER (should pass)',
+    },
+    {
+      documents: [
+        massIDWithWasteGeneratorButNoAccreditation.massIDDocument,
+        ...massIDWithWasteGeneratorButNoAccreditation.participantsAccreditationDocuments.values(),
+      ],
+      massIDAuditDocument:
+        massIDWithWasteGeneratorButNoAccreditation.massIDAuditDocument,
+      resultComment: RESULT_COMMENTS.passed.PASSED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'WASTE_GENERATOR event exists but no accreditation document provided (should pass - Waste Generator is ignored)',
+    },
+    {
+      documents: [
+        massIDWithProcessorMultipleValid.massIDDocument,
+        ...massIDWithProcessorMultipleValid.participantsAccreditationDocuments.values(),
+        processorSecondAccreditation,
+      ],
+      massIDAuditDocument: createMassIDAuditWithLinkEvent(
+        massIDWithProcessorMultipleValid.massIDAuditDocument,
+        processorSecondAccreditation,
       ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the mass document does not contain events',
-  },
-  {
-    documents: [
-      massIDWithExpiredAccreditation.massIDDocument,
-      ...massIDWithExpiredAccreditation.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument: massIDWithExpiredAccreditation.massIDAuditDocument,
-    resultComment:
-      processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
-        [INTEGRATOR],
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the participants accreditation documents are found and the accreditation is not active',
-  },
-  {
-    documents: [
-      massIDWithWasteGeneratorNoResult.massIDDocument,
-      ...massIDWithWasteGeneratorNoResult.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument: massIDWithWasteGeneratorNoResult.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'WASTE_GENERATOR has accreditation document without result event (should pass - Waste Generator is ignored)',
-  },
-  {
-    documents: [
-      massIDWithWasteGeneratorValidResult.massIDDocument,
-      ...massIDWithWasteGeneratorValidResult.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument:
-      massIDWithWasteGeneratorValidResult.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'WASTE_GENERATOR has valid accreditation result event (should pass - Waste Generator is ignored)',
-  },
-  {
-    documents: [
-      massIDWithWasteGeneratorInvalidResult.massIDDocument,
-      ...massIDWithWasteGeneratorInvalidResult.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument:
-      massIDWithWasteGeneratorInvalidResult.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'WASTE_GENERATOR has invalid accreditation result event (expired) (should pass - Waste Generator is ignored)',
-  },
-  {
-    documents: [
-      massIDWithWasteGeneratorMultipleValid.massIDDocument,
-      ...massIDWithWasteGeneratorMultipleValid.participantsAccreditationDocuments.values(),
-      wasteGeneratorSecondAccreditation,
-    ],
-    massIDAuditDocument: createMassIDAuditWithLinkEvent(
-      massIDWithWasteGeneratorMultipleValid.massIDAuditDocument,
-      wasteGeneratorSecondAccreditation,
-    ),
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'WASTE_GENERATOR has multiple valid accreditations (should pass - Waste Generator is ignored)',
-  },
-  {
-    documents: [
-      massIDWithParticipantMultipleRoles.massIDDocument,
-      ...massIDWithParticipantMultipleRoles.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument: massIDWithParticipantMultipleRoles.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'participant has one valid accreditation as PROCESSOR and one as RECYCLER (should pass)',
-  },
-  {
-    documents: [
-      massIDWithWasteGeneratorButNoAccreditation.massIDDocument,
-      ...massIDWithWasteGeneratorButNoAccreditation.participantsAccreditationDocuments.values(),
-    ],
-    massIDAuditDocument:
-      massIDWithWasteGeneratorButNoAccreditation.massIDAuditDocument,
-    resultComment: RESULT_COMMENTS.passed.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'WASTE_GENERATOR event exists but no accreditation document provided (should pass - Waste Generator is ignored)',
-  },
-  {
-    documents: [
-      massIDWithProcessorMultipleValid.massIDDocument,
-      ...massIDWithProcessorMultipleValid.participantsAccreditationDocuments.values(),
-      processorSecondAccreditation,
-    ],
-    massIDAuditDocument: createMassIDAuditWithLinkEvent(
-      massIDWithProcessorMultipleValid.massIDAuditDocument,
-      processorSecondAccreditation,
-    ),
-    resultComment:
-      processorError.ERROR_MESSAGE.MULTIPLE_VALID_ACCREDITATIONS_FOR_PARTICIPANT(
-        processorOriginalAccreditation.primaryParticipant.id,
-        PROCESSOR,
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'PROCESSOR has multiple valid accreditations (should fail)',
-  },
-];
+      resultComment:
+        processorError.ERROR_MESSAGE.MULTIPLE_VALID_ACCREDITATIONS_FOR_PARTICIPANT(
+          processorOriginalAccreditation.primaryParticipant.id,
+          PROCESSOR,
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'PROCESSOR has multiple valid accreditations (should fail)',
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   BoldStubsBuilder,
   type MetadataAttributeParameter,
@@ -23,15 +25,12 @@ import {
 } from './prevented-emissions.constants';
 import { PreventedEmissionsProcessorErrors } from './prevented-emissions.errors';
 
-export interface PreventedEmissionsTestCase {
+export interface PreventedEmissionsTestCase extends RuleTestCase {
   accreditationDocuments: Map<string, StubBoldDocumentParameters>;
   externalCreatedAt: string;
   massIDDocumentsParams?: StubBoldDocumentParameters;
   massIDDocumentValue?: number;
-  resultComment: string;
   resultContent: AnyObject | undefined;
-  resultStatus: RuleOutputStatus;
-  scenario: string;
   subtype: MassIDOrganicSubtype;
 }
 
@@ -432,159 +431,180 @@ const makeRecyclerEmissionAndCompostingMetricsEvents = (
   stubBoldEmissionAndCompostingMetricsEvent({ metadataAttributes }),
 ];
 
-export const preventedEmissionsErrorTestCases = [
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        subtype: 'INVALID_SUBTYPE' as MassIDOrganicSubtype,
-      },
-      ...mapParticipantAccreditationDocuments({
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-          [BASELINES, { [subtype]: baseline }],
-        ]),
-      }),
-    ],
-    massIDAuditDocument,
-    resultComment:
-      processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the MassID document has an invalid subtype',
-  },
-  {
-    documents: [
-      massIDDocument,
-      ...mapParticipantAccreditationDocuments({
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-        ]),
-        recyclerRemoveEventName: EMISSION_AND_COMPOSTING_METRICS.toString(),
-      }),
-    ],
-    massIDAuditDocument,
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the Recycler Accreditation document does not have the Greenhouse Gas Type (GHG) attribute',
-  },
-  {
-    documents: [...participantsAccreditationDocuments.values()],
-    massIDAuditDocument,
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_MASS_ID_DOCUMENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the MassID document was not found',
-  },
-  {
-    documents: [massIDDocument],
-    massIDAuditDocument,
-    resultComment:
-      processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the Recycler accreditation document was not found',
-  },
-  {
-    documents: [
-      massIDDocument,
-      ...mapParticipantAccreditationDocuments({
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-          [BASELINES, undefined],
-        ]),
-      }),
-    ],
-    massIDAuditDocument,
-    resultComment: processorErrors.ERROR_MESSAGE.INVALID_BASELINES,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the Recycler Accreditation document has no valid baselines',
-  },
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        externalEvents: [
-          ...(massIDDocument.externalEvents?.filter(
-            (event) => event.name !== PICK_UP.toString(),
-          ) ?? []),
-          stubBoldMassIDPickUpEvent({
-            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, undefined]],
-          }),
-        ],
-        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
-      },
-      ...mapParticipantAccreditationDocuments({
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-          [BASELINES, { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline }],
-        ]),
-      }),
-    ],
-    massIDAuditDocument,
-    resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'Others (if organic) does not provide Local Waste Classification ID on PICK_UP',
-  },
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        externalEvents: [
-          ...(massIDDocument.externalEvents?.filter(
-            (event) => event.name !== PICK_UP.toString(),
-          ) ?? []),
-          stubBoldMassIDPickUpEvent({
-            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '00 00 00']],
-          }),
-        ],
-        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
-      },
-      ...mapParticipantAccreditationDocuments({
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-          [BASELINES, { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline }],
-        ]),
-      }),
-    ],
-    massIDAuditDocument,
-    resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'Others (if organic) has an unknown Local Waste Classification ID (not an accepted local waste classification code (Ibama, Brazil))',
-  },
-  {
-    documents: [
-      {
-        ...massIDDocument,
-        externalEvents: [
-          ...(massIDDocument.externalEvents?.filter(
-            (event) => event.name !== PICK_UP.toString(),
-          ) ?? []),
-          stubBoldMassIDPickUpEvent({
-            metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '02 02 99']],
-          }),
-        ],
-        subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
-      },
-      ...mapParticipantAccreditationDocuments({
-        recyclerExternalEvents: makeRecyclerEmissionAndCompostingMetricsEvents([
-          [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
-          [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
-          [BASELINES, { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline }],
-        ]),
-      }),
-    ],
-    massIDAuditDocument,
-    resultComment:
-      processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
-        '02 02 99',
-      ),
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'Others (if organic) has a valid 8.7D local waste classification code (Ibama, Brazil) but carbon fraction is not configured',
-  },
-];
+interface PreventedEmissionsErrorTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document;
+}
+
+export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[] =
+  [
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          subtype: 'INVALID_SUBTYPE' as MassIDOrganicSubtype,
+        },
+        ...mapParticipantAccreditationDocuments({
+          recyclerExternalEvents:
+            makeRecyclerEmissionAndCompostingMetricsEvents([
+              [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+              [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+              [BASELINES, { [subtype]: baseline }],
+            ]),
+        }),
+      ],
+      massIDAuditDocument,
+      resultComment:
+        processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the MassID document has an invalid subtype',
+    },
+    {
+      documents: [
+        massIDDocument,
+        ...mapParticipantAccreditationDocuments({
+          recyclerExternalEvents:
+            makeRecyclerEmissionAndCompostingMetricsEvents([
+              [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+            ]),
+          recyclerRemoveEventName: EMISSION_AND_COMPOSTING_METRICS.toString(),
+        }),
+      ],
+      massIDAuditDocument,
+      resultComment: processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the Recycler Accreditation document does not have the Greenhouse Gas Type (GHG) attribute',
+    },
+    {
+      documents: [...participantsAccreditationDocuments.values()],
+      massIDAuditDocument,
+      resultComment: processorErrors.ERROR_MESSAGE.MISSING_MASS_ID_DOCUMENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the MassID document was not found',
+    },
+    {
+      documents: [massIDDocument],
+      massIDAuditDocument,
+      resultComment:
+        processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the Recycler accreditation document was not found',
+    },
+    {
+      documents: [
+        massIDDocument,
+        ...mapParticipantAccreditationDocuments({
+          recyclerExternalEvents:
+            makeRecyclerEmissionAndCompostingMetricsEvents([
+              [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+              [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+              [BASELINES, undefined],
+            ]),
+        }),
+      ],
+      massIDAuditDocument,
+      resultComment: processorErrors.ERROR_MESSAGE.INVALID_BASELINES,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the Recycler Accreditation document has no valid baselines',
+    },
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          externalEvents: [
+            ...(massIDDocument.externalEvents?.filter(
+              (event) => event.name !== PICK_UP.toString(),
+            ) ?? []),
+            stubBoldMassIDPickUpEvent({
+              metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, undefined]],
+            }),
+          ],
+          subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+        },
+        ...mapParticipantAccreditationDocuments({
+          recyclerExternalEvents:
+            makeRecyclerEmissionAndCompostingMetricsEvents([
+              [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+              [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+              [
+                BASELINES,
+                { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline },
+              ],
+            ]),
+        }),
+      ],
+      massIDAuditDocument,
+      resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'Others (if organic) does not provide Local Waste Classification ID on PICK_UP',
+    },
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          externalEvents: [
+            ...(massIDDocument.externalEvents?.filter(
+              (event) => event.name !== PICK_UP.toString(),
+            ) ?? []),
+            stubBoldMassIDPickUpEvent({
+              metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '00 00 00']],
+            }),
+          ],
+          subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+        },
+        ...mapParticipantAccreditationDocuments({
+          recyclerExternalEvents:
+            makeRecyclerEmissionAndCompostingMetricsEvents([
+              [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+              [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+              [
+                BASELINES,
+                { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline },
+              ],
+            ]),
+        }),
+      ],
+      massIDAuditDocument,
+      resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'Others (if organic) has an unknown Local Waste Classification ID (not an accepted local waste classification code (Ibama, Brazil))',
+    },
+    {
+      documents: [
+        {
+          ...massIDDocument,
+          externalEvents: [
+            ...(massIDDocument.externalEvents?.filter(
+              (event) => event.name !== PICK_UP.toString(),
+            ) ?? []),
+            stubBoldMassIDPickUpEvent({
+              metadataAttributes: [[LOCAL_WASTE_CLASSIFICATION_ID, '02 02 99']],
+            }),
+          ],
+          subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
+        },
+        ...mapParticipantAccreditationDocuments({
+          recyclerExternalEvents:
+            makeRecyclerEmissionAndCompostingMetricsEvents([
+              [EXCEEDING_EMISSION_COEFFICIENT, exceedingEmissionCoefficient],
+              [GREENHOUSE_GAS_TYPE, 'Methane (CH4)'],
+              [
+                BASELINES,
+                { [MassIDOrganicSubtype.OTHERS_IF_ORGANIC]: baseline },
+              ],
+            ]),
+        }),
+      ],
+      massIDAuditDocument,
+      resultComment:
+        processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
+          '02 02 99',
+        ),
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'Others (if organic) has a valid 8.7D local waste classification code (Ibama, Brazil) but carbon fraction is not configured',
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { stubActorEventWithLabel } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -8,28 +10,33 @@ import { RESULT_COMMENTS } from './processor-identification.constants';
 const { PROCESSOR } = MethodologyDocumentEventLabel;
 const { ACTOR } = DocumentEventName;
 
-export const processorIdentificationTestCases = [
-  {
-    events: new Map([[`${ACTOR}-${PROCESSOR}`, undefined]]),
-    resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `no ${PROCESSOR} actor event found`,
-  },
-  {
-    events: new Map([
-      [`${ACTOR}-${PROCESSOR}`, stubActorEventWithLabel(PROCESSOR)],
-    ]),
-    resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `found ${PROCESSOR} actor event`,
-  },
-  {
-    events: new Map([
-      [`${ACTOR}-${PROCESSOR}-1`, stubActorEventWithLabel(PROCESSOR)],
-      [`${ACTOR}-${PROCESSOR}-2`, stubActorEventWithLabel(PROCESSOR)],
-    ]),
-    resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `found multiple ${PROCESSOR} actor events`,
-  },
-];
+interface ProcessorIdentificationTestCase extends RuleTestCase {
+  events: Map<string, ReturnType<typeof stubActorEventWithLabel> | undefined>;
+}
+
+export const processorIdentificationTestCases: ProcessorIdentificationTestCase[] =
+  [
+    {
+      events: new Map([[`${ACTOR}-${PROCESSOR}`, undefined]]),
+      resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `no ${PROCESSOR} actor event found`,
+    },
+    {
+      events: new Map([
+        [`${ACTOR}-${PROCESSOR}`, stubActorEventWithLabel(PROCESSOR)],
+      ]),
+      resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `found ${PROCESSOR} actor event`,
+    },
+    {
+      events: new Map([
+        [`${ACTOR}-${PROCESSOR}-1`, stubActorEventWithLabel(PROCESSOR)],
+        [`${ACTOR}-${PROCESSOR}-2`, stubActorEventWithLabel(PROCESSOR)],
+      ]),
+      resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `found multiple ${PROCESSOR} actor events`,
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
@@ -1,5 +1,8 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { calculateDistance } from '@carrot-fndn/shared/helpers';
 import {
+  type BoldExternalEventsObject,
   generateNearbyCoordinates,
   stubAddress,
   stubBoldMassIDDropOffEvent,
@@ -24,7 +27,12 @@ const actualDistance = calculateDistance(coordinates.base, coordinates.nearby);
 const distanceInKm =
   Math.round(convertDistance(actualDistance, 'km') * 1000) / 1000;
 
-export const projectBoundaryTestCases = [
+interface ProjectBoundaryTestCase extends RuleTestCase {
+  events: BoldExternalEventsObject;
+  resultContent?: { distance: number };
+}
+
+export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
   {
     events: {
       [DROP_OFF]: undefined,

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { addDays, addHours, subDays, subSeconds } from 'date-fns';
 
@@ -21,7 +23,11 @@ const ruleDataProcessor = new TestProjectPeriodLimitProcessor();
 
 const getEligibleDate = () => ruleDataProcessor.getTestEligibleDate();
 
-export const projectPeriodLimitTestCases = [
+interface ProjectPeriodLimitTestCase extends RuleTestCase {
+  externalCreatedAt: string;
+}
+
+export const projectPeriodLimitTestCases: ProjectPeriodLimitTestCase[] = [
   {
     externalCreatedAt: addDays(getEligibleDate(), 1).toISOString(),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import { stubActorEventWithLabel } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -8,28 +10,33 @@ import { RESULT_COMMENTS } from './recycler-identification.constants';
 const { RECYCLER } = MethodologyDocumentEventLabel;
 const { ACTOR } = DocumentEventName;
 
-export const recyclerIdentificationTestCases = [
-  {
-    events: new Map([[`${ACTOR}-${RECYCLER}`, undefined]]),
-    resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `no ${RECYCLER} actor event found`,
-  },
-  {
-    events: new Map([
-      [`${ACTOR}-${RECYCLER}`, stubActorEventWithLabel(RECYCLER)],
-    ]),
-    resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `found ${RECYCLER} actor event`,
-  },
-  {
-    events: new Map([
-      [`${ACTOR}-${RECYCLER}-1`, stubActorEventWithLabel(RECYCLER)],
-      [`${ACTOR}-${RECYCLER}-2`, stubActorEventWithLabel(RECYCLER)],
-    ]),
-    resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `found multiple ${RECYCLER} actor events`,
-  },
-];
+interface RecyclerIdentificationTestCase extends RuleTestCase {
+  events: Map<string, ReturnType<typeof stubActorEventWithLabel> | undefined>;
+}
+
+export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
+  [
+    {
+      events: new Map([[`${ACTOR}-${RECYCLER}`, undefined]]),
+      resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `no ${RECYCLER} actor event found`,
+    },
+    {
+      events: new Map([
+        [`${ACTOR}-${RECYCLER}`, stubActorEventWithLabel(RECYCLER)],
+      ]),
+      resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `found ${RECYCLER} actor event`,
+    },
+    {
+      events: new Map([
+        [`${ACTOR}-${RECYCLER}-1`, stubActorEventWithLabel(RECYCLER)],
+        [`${ACTOR}-${RECYCLER}-2`, stubActorEventWithLabel(RECYCLER)],
+      ]),
+      resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `found multiple ${RECYCLER} actor events`,
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -1,16 +1,24 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+import type { PartialDeep } from 'type-fest';
+
 import {
+  type BoldExternalEventsObject,
   stubAddress,
   stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  type Document,
   DocumentEventAttributeName,
   DocumentEventName,
   MassIDOrganicSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/utils';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
-import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
+import {
+  type AnyObject,
+  MethodologyDocumentEventLabel,
+} from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
 import { RESULT_COMMENTS } from './regional-waste-classification.constants';
@@ -40,387 +48,394 @@ const americanRecyclerEvent = stubDocumentEvent({
   name: ACTOR,
 });
 
-export const regionalWasteClassificationTestCases = [
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+interface RegionalWasteClassificationTestCase extends RuleTestCase {
+  events: BoldExternalEventsObject;
+  partialDocument: PartialDeep<Document>;
+  resultContent: AnyObject | undefined;
+}
+
+export const regionalWasteClassificationTestCases: RegionalWasteClassificationTestCase[] =
+  [
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+        id: '02 01 01',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the local waste classification ID and description match a local waste classification code with matching subtype.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
-      id: '02 01 01',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the local waste classification ID and description match a local waste classification code with matching subtype.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '020101'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '020101'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+        id: '020101',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the local waste classification ID and description match the local waste classification code without spaces with matching subtype.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
-      id: '020101',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the local waste classification ID and description match the local waste classification code without spaces with matching subtype.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            `***${WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description} - (*)`,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              `***${WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description} - (*)`,
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: `***${WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description} - (*)`,
+        id: '02 01 01',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the local waste classification description has leading/trailing special characters but matches after normalization with matching subtype.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: `***${WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description} - (*)`,
-      id: '02 01 01',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the local waste classification description has leading/trailing special characters but matches after normalization with matching subtype.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, undefined],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, undefined],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.failed.CLASSIFICATION_ID_MISSING,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+        id: undefined,
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the local waste classification ID is missing.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.failed.CLASSIFICATION_ID_MISSING,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
-      id: undefined,
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the local waste classification ID is missing.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, undefined],
-        ],
-      }),
-    },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.failed.CLASSIFICATION_DESCRIPTION_MISSING,
-    resultContent: {
-      description: undefined,
-      id: '02 01 01',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the local waste classification description is missing.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 02'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            'Residuos de tecidos animais',
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, undefined],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.failed.CLASSIFICATION_DESCRIPTION_MISSING,
+      resultContent: {
+        description: undefined,
+        id: '02 01 01',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the local waste classification description is missing.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: 'Residuos de tecidos animais',
-      id: '02 01 02',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the local waste classification description matches after aggressive normalization (accent stripped).',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
-        ],
-      }),
-    },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.failed.INVALID_CLASSIFICATION_DESCRIPTION,
-    resultContent: {
-      description: randomDescription,
-      id: '02 01 01',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the local waste classification description does not match the expected local waste classification code.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: americanRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
-        ],
-      }),
-    },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.failed.UNSUPPORTED_COUNTRY('US'),
-    resultContent: {
-      description: randomDescription,
-      id: '02 01 01',
-      recyclerCountryCode: 'US',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the recycler is not from Brazil.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, randomId],
-          [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
-        ],
-      }),
-    },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.failed.INVALID_CLASSIFICATION_ID,
-    resultContent: {
-      description: randomDescription,
-      id: randomId,
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'the local waste classification ID is not valid.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 02'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              'Residuos de tecidos animais',
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: 'Residuos de tecidos animais',
+        id: '02 01 02',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the local waste classification description matches after aggressive normalization (accent stripped).',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultComment: RESULT_COMMENTS.failed.INVALID_SUBTYPE_CDM_CODE_MISMATCH,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
-      id: '02 01 01',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the subtype does not match the CDM_CODE for the provided classification ID.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 02'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 02'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.failed.INVALID_CLASSIFICATION_DESCRIPTION,
+      resultContent: {
+        description: randomDescription,
+        id: '02 01 01',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the local waste classification description does not match the expected local waste classification code.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 02'].description,
-      id: '02 01 02',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the subtype matches the CDM_CODE for the provided classification ID.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 07'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 07'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: americanRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.failed.UNSUPPORTED_COUNTRY('US'),
+      resultContent: {
+        description: randomDescription,
+        id: '02 01 01',
+        recyclerCountryCode: 'US',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the recycler is not from Brazil.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 07'].description,
-      id: '02 01 07',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario:
-      'the subtype matches the CDM_CODE 8.1 for Wood and Wood Products.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 02 04'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 02 04'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, randomId],
+            [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, randomDescription],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.failed.INVALID_CLASSIFICATION_ID,
+      resultContent: {
+        description: randomDescription,
+        id: randomId,
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'the local waste classification ID is not valid.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
-    },
-    resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 02 04'].description,
-      id: '02 02 04',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
-    },
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'the subtype matches the CDM_CODE 8.7C for Domestic Sludge.',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultComment: RESULT_COMMENTS.failed.INVALID_SUBTYPE_CDM_CODE_MISMATCH,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+        id: '02 01 01',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the subtype does not match the CDM_CODE for the provided classification ID.',
     },
-    partialDocument: {
-      subtype: MassIDOrganicSubtype.TOBACCO,
-    },
-    resultComment: RESULT_COMMENTS.failed.INVALID_SUBTYPE_MAPPING,
-    resultContent: {
-      description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
-      id: '02 01 01',
-      recyclerCountryCode: 'BR',
-      subtype: MassIDOrganicSubtype.TOBACCO,
-    },
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario:
-      'the subtype does not map to a valid CDM_CODE (TOBACCO has no mapping).',
-  },
-  {
-    events: {
-      [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [
-          [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
-          [
-            LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
-            WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 02'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 02'].description,
+            ],
           ],
-        ],
-      }),
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 02'].description,
+        id: '02 01 02',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the subtype matches the CDM_CODE for the provided classification ID.',
     },
-    partialDocument: {
-      subtype: undefined,
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 07'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 07'].description,
+            ],
+          ],
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 07'].description,
+        id: '02 01 07',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario:
+        'the subtype matches the CDM_CODE 8.1 for Wood and Wood Products.',
     },
-    resultComment: 'Rule not applicable',
-    resultContent: undefined,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: 'the document does not have a subtype (rule not applicable).',
-  },
-];
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 02 04'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 02 04'].description,
+            ],
+          ],
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 02 04'].description,
+        id: '02 02 04',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
+      },
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'the subtype matches the CDM_CODE 8.7C for Domestic Sludge.',
+    },
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+            ],
+          ],
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.TOBACCO,
+      },
+      resultComment: RESULT_COMMENTS.failed.INVALID_SUBTYPE_MAPPING,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+        id: '02 01 01',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.TOBACCO,
+      },
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario:
+        'the subtype does not map to a valid CDM_CODE (TOBACCO has no mapping).',
+    },
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '02 01 01'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['02 01 01'].description,
+            ],
+          ],
+        }),
+      },
+      partialDocument: {
+        subtype: undefined,
+      },
+      resultComment: 'Rule not applicable',
+      resultContent: undefined,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: 'the document does not have a subtype (rule not applicable).',
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
@@ -1,3 +1,4 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 import type { LicensePlate } from '@carrot-fndn/shared/types';
 
 import { stubBoldMassIDPickUpEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
@@ -17,7 +18,11 @@ const { VEHICLE_DESCRIPTION, VEHICLE_LICENSE_PLATE, VEHICLE_TYPE } =
 const { PICK_UP } = DocumentEventName;
 const { OTHERS, TRUCK } = DocumentEventVehicleType;
 
-export const vehicleIdentificationTestCases = [
+interface VehicleIdentificationTestCase extends RuleTestCase {
+  events: Map<string, ReturnType<typeof stubBoldMassIDPickUpEvent> | undefined>;
+}
+
+export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
   {
     events: new Map([
       [

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
@@ -1,8 +1,11 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   BoldStubsBuilder,
   stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  type Document,
   DocumentEventAttributeName,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -20,7 +23,12 @@ const { DROP_OFF, PICK_UP } = DocumentEventName;
 const { RECYCLER, WASTE_GENERATOR } = MethodologyDocumentEventLabel;
 const { VEHICLE_LICENSE_PLATE } = DocumentEventAttributeName;
 
-export const wasteMassIsUniqueTestCases = [
+interface WasteMassIsUniqueTestCase extends RuleTestCase {
+  newDuplicateDocuments: Array<{ status: MethodologyDocumentStatus }>;
+  oldDuplicateDocuments: Array<{ status: MethodologyDocumentStatus }>;
+}
+
+export const wasteMassIsUniqueTestCases: WasteMassIsUniqueTestCase[] = [
   {
     newDuplicateDocuments: [],
     oldDuplicateDocuments: [],
@@ -69,77 +77,85 @@ const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
   .createMassIDAuditDocuments()
   .build();
 
-export const wasteMassIsUniqueErrorTestCases = [
-  {
-    massIDAuditDocument,
-    massIDDocument: undefined,
-    resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: 'when the MassID document is missing',
-  },
-  {
-    massIDAuditDocument,
-    massIDDocument: {
-      ...massIDDocument,
-      externalEvents: massIDDocument.externalEvents?.filter(
-        (event) => event.name !== DROP_OFF.toString(),
-      ),
+interface WasteMassIsUniqueErrorTestCase extends RuleTestCase {
+  massIDAuditDocument: Document;
+  massIDDocument: Document | undefined;
+}
+
+export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
+  [
+    {
+      massIDAuditDocument,
+      massIDDocument: undefined,
+      resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: 'when the MassID document is missing',
     },
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_DROP_OFF_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `when the "${DROP_OFF}" event is missing`,
-  },
-  {
-    massIDAuditDocument,
-    massIDDocument: {
-      ...massIDDocument,
-      externalEvents: massIDDocument.externalEvents?.filter(
-        (event) => event.name !== PICK_UP.toString(),
-      ),
+    {
+      massIDAuditDocument,
+      massIDDocument: {
+        ...massIDDocument,
+        externalEvents: massIDDocument.externalEvents?.filter(
+          (event) => event.name !== DROP_OFF.toString(),
+        ),
+      },
+      resultComment: processorErrors.ERROR_MESSAGE.MISSING_DROP_OFF_EVENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `when the "${DROP_OFF}" event is missing`,
     },
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_PICK_UP_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `when the "${PICK_UP}" event is missing`,
-  },
-  {
-    massIDAuditDocument,
-    massIDDocument: {
-      ...massIDDocument,
-      externalEvents: massIDDocument.externalEvents?.filter(
-        (event) => event.label !== WASTE_GENERATOR.toString(),
-      ),
-    },
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_WASTE_GENERATOR_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `when the "${WASTE_GENERATOR}" event is missing`,
-  },
-  {
-    massIDAuditDocument,
-    massIDDocument: {
-      ...massIDDocument,
-      externalEvents: massIDDocument.externalEvents?.filter(
-        (event) => event.label !== RECYCLER.toString(),
-      ),
-    },
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `when the "${RECYCLER}" event is missing`,
-  },
-  {
-    massIDAuditDocument,
-    massIDDocument: {
-      ...massIDDocument,
-      externalEvents: [
-        ...(massIDDocument.externalEvents ?? []).filter(
+    {
+      massIDAuditDocument,
+      massIDDocument: {
+        ...massIDDocument,
+        externalEvents: massIDDocument.externalEvents?.filter(
           (event) => event.name !== PICK_UP.toString(),
         ),
-        stubBoldMassIDPickUpEvent({
-          metadataAttributes: [[VEHICLE_LICENSE_PLATE, undefined]],
-        }),
-      ],
+      },
+      resultComment: processorErrors.ERROR_MESSAGE.MISSING_PICK_UP_EVENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `when the "${PICK_UP}" event is missing`,
     },
-    resultComment: processorErrors.ERROR_MESSAGE.MISSING_VEHICLE_LICENSE_PLATE,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `when the "${VEHICLE_LICENSE_PLATE}" attribute is missing`,
-  },
-];
+    {
+      massIDAuditDocument,
+      massIDDocument: {
+        ...massIDDocument,
+        externalEvents: massIDDocument.externalEvents?.filter(
+          (event) => event.label !== WASTE_GENERATOR.toString(),
+        ),
+      },
+      resultComment:
+        processorErrors.ERROR_MESSAGE.MISSING_WASTE_GENERATOR_EVENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `when the "${WASTE_GENERATOR}" event is missing`,
+    },
+    {
+      massIDAuditDocument,
+      massIDDocument: {
+        ...massIDDocument,
+        externalEvents: massIDDocument.externalEvents?.filter(
+          (event) => event.label !== RECYCLER.toString(),
+        ),
+      },
+      resultComment: processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_EVENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `when the "${RECYCLER}" event is missing`,
+    },
+    {
+      massIDAuditDocument,
+      massIDDocument: {
+        ...massIDDocument,
+        externalEvents: [
+          ...(massIDDocument.externalEvents ?? []).filter(
+            (event) => event.name !== PICK_UP.toString(),
+          ),
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[VEHICLE_LICENSE_PLATE, undefined]],
+          }),
+        ],
+      },
+      resultComment:
+        processorErrors.ERROR_MESSAGE.MISSING_VEHICLE_LICENSE_PLATE,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `when the "${VEHICLE_LICENSE_PLATE}" attribute is missing`,
+    },
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
@@ -1,3 +1,5 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
@@ -17,75 +19,80 @@ const { WASTE_ORIGIN } = DocumentEventAttributeName;
 const { UNIDENTIFIED } = DocumentEventAttributeValue;
 const { WASTE_GENERATOR } = MethodologyDocumentEventLabel;
 
-export const wasteOriginIdentificationTestCases = [
-  {
-    events: {
-      [PICK_UP]: undefined,
+interface WasteOriginIdentificationTestCase extends RuleTestCase {
+  events: Record<string, ReturnType<typeof stubDocumentEvent> | undefined>;
+}
+
+export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCase[] =
+  [
+    {
+      events: {
+        [PICK_UP]: undefined,
+      },
+      resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `${PICK_UP} event is missing`,
     },
-    resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `${PICK_UP} event is missing`,
-  },
-  {
-    events: {
-      [`${ACTOR}-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
-      }),
+    {
+      events: {
+        [`${ACTOR}-${WASTE_GENERATOR}`]: undefined,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
+        }),
+      },
+      resultComment: RESULT_COMMENTS.passed.UNIDENTIFIED_WASTE_ORIGIN,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `${PICK_UP} event has the metadata ${WASTE_ORIGIN} with the value ${UNIDENTIFIED}`,
     },
-    resultComment: RESULT_COMMENTS.passed.UNIDENTIFIED_WASTE_ORIGIN,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `${PICK_UP} event has the metadata ${WASTE_ORIGIN} with the value ${UNIDENTIFIED}`,
-  },
-  {
-    events: {
-      [`${ACTOR}-${WASTE_GENERATOR}`]: stubDocumentEvent({
-        label: WASTE_GENERATOR,
-        name: ACTOR,
-      }),
-      [PICK_UP]: stubBoldMassIDPickUpEvent({
-        metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
-      }),
+    {
+      events: {
+        [`${ACTOR}-${WASTE_GENERATOR}`]: stubDocumentEvent({
+          label: WASTE_GENERATOR,
+          name: ACTOR,
+        }),
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [[WASTE_ORIGIN, UNIDENTIFIED]],
+        }),
+      },
+      resultComment: RESULT_COMMENTS.failed.WASTE_ORIGIN_CONFLICT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `${PICK_UP} event has the metadata ${WASTE_ORIGIN} with the value ${UNIDENTIFIED} and ${WASTE_GENERATOR} event is defined`,
     },
-    resultComment: RESULT_COMMENTS.failed.WASTE_ORIGIN_CONFLICT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `${PICK_UP} event has the metadata ${WASTE_ORIGIN} with the value ${UNIDENTIFIED} and ${WASTE_GENERATOR} event is defined`,
-  },
-  {
-    events: {
-      [`${ACTOR}-${WASTE_GENERATOR}`]: stubDocumentEvent({
-        label: WASTE_GENERATOR,
-        name: ACTOR,
-      }),
-      [PICK_UP]: stubBoldMassIDPickUpEvent(),
+    {
+      events: {
+        [`${ACTOR}-${WASTE_GENERATOR}`]: stubDocumentEvent({
+          label: WASTE_GENERATOR,
+          name: ACTOR,
+        }),
+        [PICK_UP]: stubBoldMassIDPickUpEvent(),
+      },
+      resultComment: RESULT_COMMENTS.passed.WASTE_ORIGIN_IDENTIFIED,
+      resultStatus: RuleOutputStatus.PASSED,
+      scenario: `${PICK_UP} event without ${WASTE_ORIGIN} metadata and ${WASTE_GENERATOR} event is defined`,
     },
-    resultComment: RESULT_COMMENTS.passed.WASTE_ORIGIN_IDENTIFIED,
-    resultStatus: RuleOutputStatus.PASSED,
-    scenario: `${PICK_UP} event without ${WASTE_ORIGIN} metadata and ${WASTE_GENERATOR} event is defined`,
-  },
-  {
-    events: {
-      [`${ACTOR}-${WASTE_GENERATOR}`]: undefined,
-      [PICK_UP]: stubBoldMassIDPickUpEvent(),
+    {
+      events: {
+        [`${ACTOR}-${WASTE_GENERATOR}`]: undefined,
+        [PICK_UP]: stubBoldMassIDPickUpEvent(),
+      },
+      resultComment: RESULT_COMMENTS.failed.MISSING_WASTE_GENERATOR_EVENT,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `${PICK_UP} event without ${WASTE_ORIGIN} metadata and no ${WASTE_GENERATOR} event`,
     },
-    resultComment: RESULT_COMMENTS.failed.MISSING_WASTE_GENERATOR_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `${PICK_UP} event without ${WASTE_ORIGIN} metadata and no ${WASTE_GENERATOR} event`,
-  },
-  {
-    events: {
-      [`${ACTOR}-${WASTE_GENERATOR}-1`]: stubDocumentEvent({
-        label: WASTE_GENERATOR,
-        name: ACTOR,
-      }),
-      [`${ACTOR}-${WASTE_GENERATOR}-2`]: stubDocumentEvent({
-        label: WASTE_GENERATOR,
-        name: ACTOR,
-      }),
-      [PICK_UP]: stubBoldMassIDPickUpEvent(),
+    {
+      events: {
+        [`${ACTOR}-${WASTE_GENERATOR}-1`]: stubDocumentEvent({
+          label: WASTE_GENERATOR,
+          name: ACTOR,
+        }),
+        [`${ACTOR}-${WASTE_GENERATOR}-2`]: stubDocumentEvent({
+          label: WASTE_GENERATOR,
+          name: ACTOR,
+        }),
+        [PICK_UP]: stubBoldMassIDPickUpEvent(),
+      },
+      resultComment: RESULT_COMMENTS.failed.MULTIPLE_WASTE_GENERATOR_EVENTS,
+      resultStatus: RuleOutputStatus.FAILED,
+      scenario: `MassID document with multiple ${WASTE_GENERATOR} events`,
     },
-    resultComment: RESULT_COMMENTS.failed.MULTIPLE_WASTE_GENERATOR_EVENTS,
-    resultStatus: RuleOutputStatus.FAILED,
-    scenario: `MassID document with multiple ${WASTE_GENERATOR} events`,
-  },
-];
+  ];

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -1,12 +1,16 @@
+import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
+
 import {
   BoldStubsBuilder,
   type MetadataAttributeParameter,
   stubBoldAccreditationResultEvent,
+  type StubBoldDocumentParameters,
   stubBoldMassIDWeighingEvent,
   stubBoldMonitoringSystemsAndEquipmentEvent,
   stubParticipant,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  type Document,
   DocumentCategory,
   type DocumentEvent,
   DocumentEventAttributeName,
@@ -246,7 +250,13 @@ const createTwoStepWeighingEvents = (
   ),
 });
 
-export const weighingTestCases = [
+interface WeighingTestCase extends RuleTestCase {
+  accreditationDocuments?: Map<string, StubBoldDocumentParameters> | undefined;
+  massIDDocumentEvents: Record<string, DocumentEvent | undefined>;
+  scaleTicketVerificationError?: string;
+}
+
+export const weighingTestCases: WeighingTestCase[] = [
   {
     massIDDocumentEvents: {
       [WEIGHING]: undefined,
@@ -888,7 +898,12 @@ const {
   .createParticipantAccreditationDocuments()
   .build();
 
-export const weighingErrorTestCases = [
+interface WeighingErrorTestCase extends RuleTestCase {
+  documents: Document[];
+  massIDAuditDocument: Document;
+}
+
+export const weighingErrorTestCases: WeighingErrorTestCase[] = [
   {
     documents: [...participantsAccreditationDocuments.values()],
     massIDAuditDocument,


### PR DESCRIPTION
## Summary

- Extend `RuleTestCase` base type in all 22 test-cases.ts files to enforce consistent `scenario`, `resultStatus`, and `resultComment` fields
- Replace `unknown` types with proper `Document`, `BoldExternalEventsObject`, `StubBoldDocumentParameters`, and other typed alternatives in error test case interfaces
- Simplify unnecessary type assertions in spec files where proper typing removes the need for casts

## Test plan

- [x] `pnpm ts:affected` passes
- [x] `pnpm lint:affected` passes
- [x] `pnpm test:affected` passes (except pre-existing failures: composting-cycle-timeframe 181-day boundary, waste-mass-is-unique e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized and tightened test-case shapes across many rule processors using explicit typed interfaces.
  * Converted numerous untyped test arrays to typed exports and added targeted success and error scenarios for rewards, MassID, and waste rules.
  * Added new fields to better model events/documents and preserved existing scenarios while simplifying some test parametrizations for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->