### PR TITLE
chore: standardize MassID/RecycledID nomenclature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm commit                  # Interactive conventional commit
 ```text
 libs/
 ├── methodologies/bold/rule-processors/
-│   ├── mass-id/              # Mass ID rule processors
+│   ├── mass-id/              # MassID rule processors
 │   ├── credit-order/         # Credit order processors
 │   └── mass-id-certificate/  # Certificate processors
 └── shared/

--- a/apps/methodologies/bold-carbon/rule-processors/mass-id/mass-id-qualifications/README.md
+++ b/apps/methodologies/bold-carbon/rule-processors/mass-id/mass-id-qualifications/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Mass ID Qualifications
+# MassID Qualifications
 
 Methodology: **BOLD Carbon**
 

--- a/apps/methodologies/bold-recycling/rule-processors/mass-id/mass-id-qualifications/README.md
+++ b/apps/methodologies/bold-recycling/rule-processors/mass-id/mass-id-qualifications/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Mass ID Qualifications
+# MassID Qualifications
 
 Methodology: **BOLD Recycling**
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.rule-definition.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.rule-definition.ts
@@ -4,6 +4,6 @@ export const ruleDefinition = {
   description:
     'Validates that the MassID document has the correct qualifications: category must be MassID, type must be Organic, measurement unit must be kg, value must be greater than zero, and subtype must be a valid organic waste subtype.',
   events: [],
-  name: 'Mass ID Qualifications',
+  name: 'MassID Qualifications',
   slug: 'mass-id-qualifications',
 } as const satisfies BaseRuleDefinition;

--- a/libs/shared/methodologies/bold/matchers/src/document.matchers.spec.ts
+++ b/libs/shared/methodologies/bold/matchers/src/document.matchers.spec.ts
@@ -54,7 +54,7 @@ describe('Document Matchers', () => {
   });
 
   describe('MASS_ID', () => {
-    it('should return true if the document category is Mass ID', () => {
+    it('should return true if the document category is MassID', () => {
       const documentRelation = stubDocumentRelation({
         category: DocumentCategory.MASS_ID,
       });
@@ -64,7 +64,7 @@ describe('Document Matchers', () => {
       expect(matchesResult).toBe(true);
     });
 
-    it('should return false if the document category is not Mass ID', () => {
+    it('should return false if the document category is not MassID', () => {
       const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
       });
@@ -111,7 +111,7 @@ describe('Document Matchers', () => {
   });
 
   describe('RECYCLED_ID', () => {
-    it('should return true if the document category is Methodology and type is Recycled ID', () => {
+    it('should return true if the document category is Methodology and type is RecycledID', () => {
       const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.RECYCLED_ID,
@@ -133,7 +133,7 @@ describe('Document Matchers', () => {
       expect(matchesResult).toBe(false);
     });
 
-    it('should return false if the document type is not Recycled ID', () => {
+    it('should return false if the document type is not RecycledID', () => {
       const documentRelation = stubDocumentRelation({
         category: DocumentCategory.METHODOLOGY,
         type: DocumentType.ORGANIC,

--- a/tools/rule-runner-cli/src/commands/dry-run.command.ts
+++ b/tools/rule-runner-cli/src/commands/dry-run.command.ts
@@ -54,7 +54,7 @@ export const dryRunCommand = new Command('dry-run')
   .addOption(
     new Option(
       '-d, --document-id <id>',
-      'Mass-ID document ID (Palantir document ID)',
+      'MassID document ID (Palantir document ID)',
     ),
   )
   .addOption(


### PR DESCRIPTION
## Summary
- Replace inconsistent "Mass ID", "Mass-ID", and "Recycled ID" with canonical PascalCase forms (MassID, RecycledID)
- Changes span documentation (CLAUDE.md, READMEs), rule definitions, test descriptions, and CLI help text
- 6 files updated, zero functional changes

## Test plan
- [x] `pnpm lint:affected` — 101 projects pass
- [x] `pnpm nx test shared-methodologies-bold-matchers` — 21 tests pass
- [x] Grep verified zero remaining occurrences of "Mass ID", "Mass-ID", "Recycled ID", "Gas ID"

🤖 Generated with [Claude Code](https://claude.com/claude-code)