### PR TITLE
refactor(shared): replace getEnv() with specific env var helpers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -148,6 +148,8 @@ const tsFilesConfig = {
         allowList: {
           props: true,
           Props: true,
+          env: true,
+          Env: true,
         },
         replacements: { e: false, lib: false },
       },
@@ -197,6 +199,8 @@ const tsAndJsFilesConfigs = {
         allowList: {
           props: true,
           Props: true,
+          env: true,
+          Env: true,
         },
         replacements: { e: false, lib: false },
       },

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.helpers.spec.ts
@@ -5,20 +5,20 @@ import {
   getLayoutValidationConfig,
 } from './document-manifest-data.helpers';
 
+const mockGetDocumentAttachmentBucketName = jest.fn(
+  () => undefined as string | undefined,
+);
+
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getDocumentAttachmentBucketName: () => mockGetDocumentAttachmentBucketName(),
+  getDocumentBucketName: () => 'test-bucket',
+  getOptionalEnv: jest.fn(),
+}));
+
 describe('document-manifest-data.helpers', () => {
   describe('getAttachmentInfos', () => {
-    const originalEnvironment = process.env;
-
-    beforeEach(() => {
-      process.env = { ...originalEnvironment };
-    });
-
-    afterEach(() => {
-      process.env = originalEnvironment;
-    });
-
     it('should return empty array when DOCUMENT_ATTACHMENT_BUCKET_NAME is not set', () => {
-      delete process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+      mockGetDocumentAttachmentBucketName.mockReturnValue(undefined);
 
       const events: DocumentManifestEventSubject[] = [
         {
@@ -35,7 +35,7 @@ describe('document-manifest-data.helpers', () => {
     });
 
     it('should return attachment infos when bucket name is set', () => {
-      process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = 'test-bucket';
+      mockGetDocumentAttachmentBucketName.mockReturnValue('test-bucket');
 
       const events: DocumentManifestEventSubject[] = [
         {
@@ -57,7 +57,7 @@ describe('document-manifest-data.helpers', () => {
     });
 
     it('should filter out events without attachmentId', () => {
-      process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = 'test-bucket';
+      mockGetDocumentAttachmentBucketName.mockReturnValue('test-bucket');
 
       const events: DocumentManifestEventSubject[] = [
         {

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.helpers.spec.ts
@@ -12,7 +12,6 @@ const mockGetDocumentAttachmentBucketName = jest.fn(
 jest.mock('@carrot-fndn/shared/env', () => ({
   getDocumentAttachmentBucketName: () => mockGetDocumentAttachmentBucketName(),
   getDocumentBucketName: () => 'test-bucket',
-  getOptionalEnv: jest.fn(),
 }));
 
 describe('document-manifest-data.helpers', () => {

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.helpers.ts
@@ -4,6 +4,7 @@ import {
   type DocumentType,
   getDefaultLayouts,
 } from '@carrot-fndn/shared/document-extractor';
+import { getDocumentAttachmentBucketName } from '@carrot-fndn/shared/env';
 import { isNil, isNonEmptyString, logger } from '@carrot-fndn/shared/helpers';
 import { getAttachmentS3Key } from '@carrot-fndn/shared/methodologies/bold/utils';
 import {
@@ -77,7 +78,7 @@ export const getAttachmentInfos = ({
   documentId: string;
   events: DocumentManifestEventSubject[];
 }): AttachmentInfo[] => {
-  const bucketName = process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+  const bucketName = getDocumentAttachmentBucketName();
 
   if (!bucketName) {
     logger.warn(

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.lambda.e2e.spec.ts
@@ -18,11 +18,27 @@ import {
 
 jest.mock('./document-manifest-data.extractor');
 
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getArtifactChecksum: () => 'test-checksum',
+  getAwsRegion: () => 'us-east-1',
+  getDocumentAttachmentBucketName: () => mockBucketName,
+  getDocumentBucketName: () => 'test-bucket',
+  getEnvironment: () => 'development',
+  getNodeEnv: () => 'test',
+  getOptionalEnv: jest.fn(),
+  getSentryDsn: () => undefined,
+  getSmaugApiGatewayAssumeRoleArn: () => 'arn:aws:iam::123456:role/test',
+  getSourceCodeUrl: () => 'https://test.example.com/repo',
+  getSourceCodeVersion: () => 'test-version',
+}));
+
+let mockBucketName: string | undefined = 'test-bucket';
+
 describe('DocumentManifestDataLambda E2E', () => {
   const documentKeyPrefix = faker.string.uuid();
 
   beforeEach(() => {
-    process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = 'test-bucket';
+    mockBucketName = 'test-bucket';
     jest.mocked(crossValidateWithTextract).mockResolvedValue({
       crossValidation: {},
       extractionMetadata: {},
@@ -35,7 +51,7 @@ describe('DocumentManifestDataLambda E2E', () => {
   });
 
   afterEach(() => {
-    delete process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+    mockBucketName = undefined;
   });
 
   it.each([...documentManifestDataTestCases, ...exceptionTestCases])(

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
@@ -13,12 +13,20 @@ import {
 jest.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 jest.mock('./document-manifest-data.extractor');
 
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getDocumentAttachmentBucketName: () => mockBucketName,
+  getDocumentBucketName: () => 'test-bucket',
+  getOptionalEnv: jest.fn(),
+}));
+
+let mockBucketName: string | undefined = 'test-bucket';
+
 describe('DocumentManifestDataProcessor', () => {
   const documentLoaderService = jest.mocked(loadDocument);
   const crossValidateWithTextractMock = jest.mocked(crossValidateWithTextract);
 
   beforeEach(() => {
-    process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = 'test-bucket';
+    mockBucketName = 'test-bucket';
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-01-01T00:00:00Z'));
     crossValidateWithTextractMock.mockResolvedValue({
@@ -33,7 +41,7 @@ describe('DocumentManifestDataProcessor', () => {
   });
 
   afterEach(() => {
-    delete process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+    mockBucketName = undefined;
     jest.useRealTimers();
   });
 

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.spec.ts
@@ -16,7 +16,6 @@ jest.mock('./document-manifest-data.extractor');
 jest.mock('@carrot-fndn/shared/env', () => ({
   getDocumentAttachmentBucketName: () => mockBucketName,
   getDocumentBucketName: () => 'test-bucket',
-  getOptionalEnv: jest.fn(),
 }));
 
 let mockBucketName: string | undefined = 'test-bucket';

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.helpers.spec.ts
@@ -12,7 +12,6 @@ const mockGetDocumentAttachmentBucketName = jest.fn(
 jest.mock('@carrot-fndn/shared/env', () => ({
   getDocumentAttachmentBucketName: () => mockGetDocumentAttachmentBucketName(),
   getDocumentBucketName: () => 'test-bucket',
-  getOptionalEnv: jest.fn(),
 }));
 
 describe('WeighingProcessor helpers', () => {

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.helpers.spec.ts
@@ -5,14 +5,17 @@ import {
 
 import { WeighingProcessor } from './weighing.processor';
 
+const mockGetDocumentAttachmentBucketName = jest.fn(
+  () => undefined as string | undefined,
+);
+
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getDocumentAttachmentBucketName: () => mockGetDocumentAttachmentBucketName(),
+  getDocumentBucketName: () => 'test-bucket',
+  getOptionalEnv: jest.fn(),
+}));
+
 describe('WeighingProcessor helpers', () => {
-  const originalScaleTicketBucket =
-    process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
-
-  afterEach(() => {
-    process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = originalScaleTicketBucket;
-  });
-
   it('should build a text extractor input when attachment and bucket are present', () => {
     const processor = new WeighingProcessor();
 
@@ -27,7 +30,7 @@ describe('WeighingProcessor helpers', () => {
       ],
     } as unknown as DocumentEvent;
 
-    process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = 'bucket-name';
+    mockGetDocumentAttachmentBucketName.mockReturnValue('bucket-name');
 
     const input = processor['buildScaleTicketTextExtractorInput'](
       weighingEvent,
@@ -54,7 +57,7 @@ describe('WeighingProcessor helpers', () => {
       ],
     } as unknown as DocumentEvent;
 
-    delete process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+    mockGetDocumentAttachmentBucketName.mockReturnValue(undefined);
 
     const input = processor['buildScaleTicketTextExtractorInput'](
       weighingEvent,

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -3,6 +3,7 @@ import type { TextExtractionInput } from '@carrot-fndn/shared/text-extractor';
 
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
 import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import { getDocumentAttachmentBucketName } from '@carrot-fndn/shared/env';
 import { isNil, logger } from '@carrot-fndn/shared/helpers';
 import {
   type DocumentQuery,
@@ -305,7 +306,7 @@ export class WeighingProcessor extends RuleDataProcessor {
       return undefined;
     }
 
-    const bucket = process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+    const bucket = getDocumentAttachmentBucketName();
 
     if (!bucket) {
       logger.warn(

--- a/libs/shared/aws-http/src/aws-http.service.spec.ts
+++ b/libs/shared/aws-http/src/aws-http.service.spec.ts
@@ -3,6 +3,11 @@ import { type AxiosInstance } from 'axios';
 import { AwsHttpService } from './aws-http.service';
 import * as awsHelpers from './aws-http.service.helpers';
 
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getAwsRegion: () => 'us-east-1',
+  getOptionalEnv: jest.fn(),
+}));
+
 jest.mock('./aws-http.service.helpers', () => ({
   signRequest: jest.fn(),
 }));
@@ -10,12 +15,8 @@ jest.mock('./aws-http.service.helpers', () => ({
 describe('HttpService', () => {
   let service: AwsHttpService;
   let mockAxios: jest.Mocked<AxiosInstance>;
-  const originalEnvironment = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnvironment };
-    process.env['AWS_REGION'] = 'us-east-1';
-
     mockAxios = {
       request: jest.fn(),
     } as unknown as jest.Mocked<AxiosInstance>;
@@ -29,7 +30,6 @@ describe('HttpService', () => {
   });
 
   afterEach(() => {
-    process.env = originalEnvironment;
     jest.clearAllMocks();
   });
 
@@ -60,14 +60,6 @@ describe('HttpService', () => {
         },
         'us-east-1',
       );
-    });
-
-    it('should throw error when AWS_REGION is not set', async () => {
-      delete process.env['AWS_REGION'];
-
-      await expect(
-        service['post']('https://api.example.com', { data: 'test' }),
-      ).rejects.toThrow('AWS_REGION is not set');
     });
 
     it('should throw error when request fails', async () => {

--- a/libs/shared/aws-http/src/aws-http.service.spec.ts
+++ b/libs/shared/aws-http/src/aws-http.service.spec.ts
@@ -5,7 +5,6 @@ import * as awsHelpers from './aws-http.service.helpers';
 
 jest.mock('@carrot-fndn/shared/env', () => ({
   getAwsRegion: () => 'us-east-1',
-  getOptionalEnv: jest.fn(),
 }));
 
 jest.mock('./aws-http.service.helpers', () => ({

--- a/libs/shared/aws-http/src/aws-http.service.ts
+++ b/libs/shared/aws-http/src/aws-http.service.ts
@@ -1,7 +1,7 @@
 import type { AnyObject, Uri } from '@carrot-fndn/shared/types';
 import type { AxiosInstance } from 'axios';
 
-import { isNonEmptyString } from '@carrot-fndn/shared/helpers';
+import { getAwsRegion } from '@carrot-fndn/shared/env';
 
 import { signRequest, type SignRequestInput } from './aws-http.service.helpers';
 
@@ -57,12 +57,6 @@ export class AwsHttpService {
     method: 'GET' | 'POST' | 'PUT';
     url: Uri;
   }) {
-    const awsRegion = process.env['AWS_REGION'];
-
-    if (!isNonEmptyString(awsRegion)) {
-      throw new Error('AWS_REGION is not set');
-    }
-
     return signRequest(
       {
         body: method === 'GET' ? undefined : dto,
@@ -70,7 +64,7 @@ export class AwsHttpService {
         query: method === 'GET' ? dto : undefined,
         url: new URL(url),
       },
-      awsRegion,
+      getAwsRegion(),
     );
   }
 }

--- a/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
+++ b/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
@@ -25,7 +25,7 @@ jest.mock('@carrot-fndn/shared/env', () => ({
 
 const mockCloudWatchClient = jest.mocked(CloudWatchClient);
 
-const setMockEnv = (
+const setMockEnvironment = (
   overrides: {
     awsRegion?: string;
     cloudwatchMetricsNamespace?: string | undefined;
@@ -53,7 +53,7 @@ describe('CloudWatchMetricsService', () => {
     jest.clearAllMocks();
     CloudWatchMetricsService['instance'] = null;
     setModuleCloudWatchClient(null);
-    setMockEnv();
+    setMockEnvironment();
   });
 
   describe('getInstance', () => {
@@ -86,7 +86,7 @@ describe('CloudWatchMetricsService', () => {
 
   describe('constructor and configuration', () => {
     it('should use default configuration when no env vars are set', () => {
-      setMockEnv({
+      setMockEnvironment({
         awsRegion: 'us-east-1',
         cloudwatchMetricsNamespace: undefined,
         enableCloudwatchMetrics: false,
@@ -101,7 +101,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should use custom CLOUDWATCH_METRICS_NAMESPACE when provided', () => {
-      setMockEnv({
+      setMockEnvironment({
         cloudwatchMetricsNamespace: 'Custom/Namespace',
       });
 
@@ -111,7 +111,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should use configured AWS region', async () => {
-      setMockEnv({
+      setMockEnvironment({
         awsRegion: 'ap-southeast-1',
         enableCloudwatchMetrics: true,
       });
@@ -129,7 +129,7 @@ describe('CloudWatchMetricsService', () => {
 
   describe('isEnabled', () => {
     it('should be disabled when ENABLE_CLOUDWATCH_METRICS is undefined', () => {
-      setMockEnv({
+      setMockEnvironment({
         enableCloudwatchMetrics: false,
       });
 
@@ -139,7 +139,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should be enabled when ENABLE_CLOUDWATCH_METRICS is true', () => {
-      setMockEnv({
+      setMockEnvironment({
         enableCloudwatchMetrics: true,
       });
 
@@ -149,7 +149,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should be disabled when ENABLE_CLOUDWATCH_METRICS is false', () => {
-      setMockEnv({
+      setMockEnvironment({
         enableCloudwatchMetrics: false,
       });
 
@@ -169,7 +169,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should handle valid CloudWatchMetricData without throwing', async () => {
-      setMockEnv({
+      setMockEnvironment({
         enableCloudwatchMetrics: true,
       });
 
@@ -186,7 +186,7 @@ describe('CloudWatchMetricsService', () => {
 
   describe('CloudWatch integration', () => {
     it('should instantiate CloudWatchClient with correct region configuration', async () => {
-      setMockEnv({
+      setMockEnvironment({
         awsRegion: 'us-west-2',
         enableCloudwatchMetrics: true,
       });
@@ -202,7 +202,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should reuse the same CloudWatchClient instance (singleton behavior)', async () => {
-      setMockEnv({
+      setMockEnvironment({
         enableCloudwatchMetrics: true,
       });
 
@@ -216,7 +216,7 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should use correct namespace from configuration', () => {
-      setMockEnv({
+      setMockEnvironment({
         cloudwatchMetricsNamespace: 'Custom/TestNamespace',
       });
 
@@ -239,8 +239,8 @@ describe('CloudWatchMetricsService', () => {
   });
 
   describe('Error handling', () => {
-    it('should handle empty namespace by using default', async () => {
-      setMockEnv({
+    it('should use default when namespace is undefined', async () => {
+      setMockEnvironment({
         cloudwatchMetricsNamespace: undefined,
         enableCloudwatchMetrics: true,
       });

--- a/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
+++ b/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
@@ -128,10 +128,8 @@ describe('CloudWatchMetricsService', () => {
   });
 
   describe('isEnabled', () => {
-    it('should be disabled when ENABLE_CLOUDWATCH_METRICS is undefined', () => {
-      setMockEnvironment({
-        enableCloudwatchMetrics: false,
-      });
+    it('should be disabled when ENABLE_CLOUDWATCH_METRICS is not set', () => {
+      setMockEnvironment({});
 
       const instance = CloudWatchMetricsService.getInstance();
 

--- a/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
+++ b/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
@@ -10,24 +10,35 @@ import {
 
 jest.mock('@aws-sdk/client-cloudwatch');
 
+const mockGetAwsRegion = jest.fn(() => 'us-east-1');
+const mockGetEnableCloudwatchMetrics = jest.fn(() => false);
+const mockGetCloudwatchMetricsNamespace = jest.fn(
+  () => undefined as string | undefined,
+);
+
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getAwsRegion: () => mockGetAwsRegion(),
+  getCloudwatchMetricsNamespace: () => mockGetCloudwatchMetricsNamespace(),
+  getEnableCloudwatchMetrics: () => mockGetEnableCloudwatchMetrics(),
+  getOptionalEnv: jest.fn(),
+}));
+
 const mockCloudWatchClient = jest.mocked(CloudWatchClient);
 
-const originalEnvironment = { ...process.env };
-
-const setEnvironmentVariables = (
-  environmentVariables: Record<string, string | undefined>,
+const setMockEnv = (
+  overrides: {
+    awsRegion?: string;
+    cloudwatchMetricsNamespace?: string | undefined;
+    enableCloudwatchMetrics?: boolean;
+  } = {},
 ) => {
-  for (const key of Object.keys(environmentVariables)) {
-    if (environmentVariables[key] === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = environmentVariables[key];
-    }
-  }
-};
-
-const resetEnvironmentVariables = () => {
-  process.env = { ...originalEnvironment };
+  mockGetAwsRegion.mockReturnValue(overrides.awsRegion ?? 'us-east-1');
+  mockGetEnableCloudwatchMetrics.mockReturnValue(
+    overrides.enableCloudwatchMetrics ?? false,
+  );
+  mockGetCloudwatchMetricsNamespace.mockReturnValue(
+    overrides.cloudwatchMetricsNamespace,
+  );
 };
 
 const createMockCloudWatchMetricData = (
@@ -41,10 +52,8 @@ describe('CloudWatchMetricsService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     CloudWatchMetricsService['instance'] = null;
-
     setModuleCloudWatchClient(null);
-
-    resetEnvironmentVariables();
+    setMockEnv();
   });
 
   describe('getInstance', () => {
@@ -77,37 +86,34 @@ describe('CloudWatchMetricsService', () => {
 
   describe('constructor and configuration', () => {
     it('should use default configuration when no env vars are set', () => {
-      setEnvironmentVariables({
-        AWS_REGION: undefined,
-        CLOUDWATCH_METRICS_NAMESPACE: undefined,
-        ENABLE_CLOUDWATCH_METRICS: undefined,
-        NODE_ENV: undefined,
+      setMockEnv({
+        awsRegion: 'us-east-1',
+        cloudwatchMetricsNamespace: undefined,
+        enableCloudwatchMetrics: false,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
-      const config = instance['config'];
 
-      expect(config.namespace).toBe(CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE);
-      expect(config.enabled).toBe(false);
+      expect(instance['namespace']).toBe(
+        CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE,
+      );
+      expect(instance.isEnabled()).toBe(false);
     });
 
     it('should use custom CLOUDWATCH_METRICS_NAMESPACE when provided', () => {
-      setEnvironmentVariables({
-        CLOUDWATCH_METRICS_NAMESPACE: 'Custom/Namespace',
-        NODE_ENV: undefined,
+      setMockEnv({
+        cloudwatchMetricsNamespace: 'Custom/Namespace',
       });
 
       const instance = CloudWatchMetricsService.getInstance();
-      const config = instance['config'];
 
-      expect(config.namespace).toBe('Custom/Namespace');
+      expect(instance['namespace']).toBe('Custom/Namespace');
     });
 
-    it('should use default AWS region when AWS_REGION not set', async () => {
-      setEnvironmentVariables({
-        AWS_REGION: undefined,
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
+    it('should use configured AWS region', async () => {
+      setMockEnv({
+        awsRegion: 'ap-southeast-1',
+        enableCloudwatchMetrics: true,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
@@ -116,33 +122,15 @@ describe('CloudWatchMetricsService', () => {
       await instance.recordAIValidationFailure(mockData);
 
       expect(mockCloudWatchClient).toHaveBeenCalledWith({
-        region: CLOUDWATCH_CONSTANTS.DEFAULT_REGION,
-      });
-    });
-
-    it('should use custom AWS region when AWS_REGION is provided', async () => {
-      setEnvironmentVariables({
-        AWS_REGION: 'eu-west-1',
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
-      });
-
-      const instance = CloudWatchMetricsService.getInstance();
-      const mockData = createMockCloudWatchMetricData();
-
-      await instance.recordAIValidationFailure(mockData);
-
-      expect(mockCloudWatchClient).toHaveBeenCalledWith({
-        region: 'eu-west-1',
+        region: 'ap-southeast-1',
       });
     });
   });
 
   describe('isEnabled', () => {
-    it('should be disabled when NODE_ENV is test', () => {
-      setEnvironmentVariables({
-        ENABLE_CLOUDWATCH_METRICS: undefined,
-        NODE_ENV: 'test',
+    it('should be disabled when ENABLE_CLOUDWATCH_METRICS is undefined', () => {
+      setMockEnv({
+        enableCloudwatchMetrics: false,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
@@ -150,87 +138,29 @@ describe('CloudWatchMetricsService', () => {
       expect(instance.isEnabled()).toBe(false);
     });
 
-    it('should be disabled when jest is defined (always true in test environment)', () => {
-      setEnvironmentVariables({
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
+    it('should be enabled when ENABLE_CLOUDWATCH_METRICS is true', () => {
+      setMockEnv({
+        enableCloudwatchMetrics: true,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
 
       expect(instance.isEnabled()).toBe(true);
-      expect(typeof jest).toBe('object');
     });
 
-    it('should be disabled when ENABLE_CLOUDWATCH_METRICS is undefined and not in test env', () => {
-      setEnvironmentVariables({
-        ENABLE_CLOUDWATCH_METRICS: undefined,
-        NODE_ENV: 'production',
+    it('should be disabled when ENABLE_CLOUDWATCH_METRICS is false', () => {
+      setMockEnv({
+        enableCloudwatchMetrics: false,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
 
       expect(instance.isEnabled()).toBe(false);
     });
-
-    it('should respect ENABLE_CLOUDWATCH_METRICS=true (case insensitive)', () => {
-      const testCases = ['true', 'TRUE', 'True', 'tRuE'];
-
-      for (const value of testCases) {
-        CloudWatchMetricsService['instance'] = null;
-
-        setEnvironmentVariables({
-          ENABLE_CLOUDWATCH_METRICS: value,
-          NODE_ENV: 'production',
-        });
-
-        const instance = CloudWatchMetricsService.getInstance();
-
-        expect(instance.isEnabled()).toBe(true);
-      }
-    });
-
-    it('should respect ENABLE_CLOUDWATCH_METRICS=false (case insensitive)', () => {
-      const testCases = ['false', 'FALSE', 'False', 'fAlSe'];
-
-      for (const value of testCases) {
-        CloudWatchMetricsService['instance'] = null;
-
-        setEnvironmentVariables({
-          ENABLE_CLOUDWATCH_METRICS: value,
-          NODE_ENV: 'production',
-        });
-
-        const instance = CloudWatchMetricsService.getInstance();
-
-        expect(instance.isEnabled()).toBe(false);
-      }
-    });
-
-    it('should handle invalid ENABLE_CLOUDWATCH_METRICS values as false', () => {
-      const testCases = ['invalid', '1', '0', 'yes', 'no'];
-
-      for (const value of testCases) {
-        CloudWatchMetricsService['instance'] = null;
-
-        setEnvironmentVariables({
-          ENABLE_CLOUDWATCH_METRICS: value,
-          NODE_ENV: 'production',
-        });
-
-        const instance = CloudWatchMetricsService.getInstance();
-
-        expect(instance.isEnabled()).toBe(false);
-      }
-    });
   });
 
   describe('recordAIValidationFailure', () => {
     it('should return a boolean from isEnabled method', () => {
-      setEnvironmentVariables({
-        NODE_ENV: 'test',
-      });
-
       const instance = CloudWatchMetricsService.getInstance();
       const result = instance.isEnabled();
 
@@ -239,9 +169,8 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should handle valid CloudWatchMetricData without throwing', async () => {
-      setEnvironmentVariables({
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
+      setMockEnv({
+        enableCloudwatchMetrics: true,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
@@ -257,10 +186,9 @@ describe('CloudWatchMetricsService', () => {
 
   describe('CloudWatch integration', () => {
     it('should instantiate CloudWatchClient with correct region configuration', async () => {
-      setEnvironmentVariables({
-        AWS_REGION: 'us-west-2',
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
+      setMockEnv({
+        awsRegion: 'us-west-2',
+        enableCloudwatchMetrics: true,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
@@ -274,9 +202,8 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should reuse the same CloudWatchClient instance (singleton behavior)', async () => {
-      setEnvironmentVariables({
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
+      setMockEnv({
+        enableCloudwatchMetrics: true,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
@@ -289,15 +216,13 @@ describe('CloudWatchMetricsService', () => {
     });
 
     it('should use correct namespace from configuration', () => {
-      setEnvironmentVariables({
-        CLOUDWATCH_METRICS_NAMESPACE: 'Custom/TestNamespace',
-        NODE_ENV: 'production',
+      setMockEnv({
+        cloudwatchMetricsNamespace: 'Custom/TestNamespace',
       });
 
       const instance = CloudWatchMetricsService.getInstance();
-      const config = instance['config'];
 
-      expect(config.namespace).toBe('Custom/TestNamespace');
+      expect(instance['namespace']).toBe('Custom/TestNamespace');
     });
 
     it('should handle timestamp creation for metrics', () => {
@@ -314,25 +239,24 @@ describe('CloudWatchMetricsService', () => {
   });
 
   describe('Error handling', () => {
-    it('should handle empty string environment variables', async () => {
-      setEnvironmentVariables({
-        AWS_REGION: undefined,
-        CLOUDWATCH_METRICS_NAMESPACE: '',
-        ENABLE_CLOUDWATCH_METRICS: 'true',
-        NODE_ENV: 'production',
+    it('should handle empty namespace by using default', async () => {
+      setMockEnv({
+        cloudwatchMetricsNamespace: undefined,
+        enableCloudwatchMetrics: true,
       });
 
       const instance = CloudWatchMetricsService.getInstance();
-      const config = instance['config'];
 
-      expect(config.namespace).toBe(CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE);
+      expect(instance['namespace']).toBe(
+        CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE,
+      );
 
       const mockData = createMockCloudWatchMetricData();
 
       await instance.recordAIValidationFailure(mockData);
 
       expect(mockCloudWatchClient).toHaveBeenCalledWith({
-        region: CLOUDWATCH_CONSTANTS.DEFAULT_REGION,
+        region: 'us-east-1',
       });
     });
   });

--- a/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
+++ b/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.spec.ts
@@ -20,7 +20,6 @@ jest.mock('@carrot-fndn/shared/env', () => ({
   getAwsRegion: () => mockGetAwsRegion(),
   getCloudwatchMetricsNamespace: () => mockGetCloudwatchMetricsNamespace(),
   getEnableCloudwatchMetrics: () => mockGetEnableCloudwatchMetrics(),
-  getOptionalEnv: jest.fn(),
 }));
 
 const mockCloudWatchClient = jest.mocked(CloudWatchClient);

--- a/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.ts
+++ b/libs/shared/cloudwatch-metrics/src/cloudwatch-metrics.service.ts
@@ -2,15 +2,14 @@ import {
   CloudWatchClient,
   PutMetricDataCommand,
 } from '@aws-sdk/client-cloudwatch';
-import { getNonEmptyStringOrDefault, isNil } from '@carrot-fndn/shared/helpers';
+import {
+  getAwsRegion,
+  getCloudwatchMetricsNamespace,
+  getEnableCloudwatchMetrics,
+} from '@carrot-fndn/shared/env';
 import { NonEmptyString } from '@carrot-fndn/shared/types';
 
 import { CLOUDWATCH_CONSTANTS } from './cloudwatch-metrics.constants';
-
-export interface CloudWatchConfig {
-  enabled: boolean;
-  namespace: string;
-}
 
 export interface CloudWatchMetricData {
   documentManifestType: NonEmptyString;
@@ -21,10 +20,7 @@ let cloudWatchClient: CloudWatchClient | null = null;
 const getCloudWatchClient = (): CloudWatchClient => {
   if (!cloudWatchClient) {
     cloudWatchClient = new CloudWatchClient({
-      region: getNonEmptyStringOrDefault(
-        process.env['AWS_REGION'],
-        CLOUDWATCH_CONSTANTS.DEFAULT_REGION,
-      ),
+      region: getAwsRegion(),
     });
   }
 
@@ -39,16 +35,13 @@ export const setModuleCloudWatchClient = (
 
 export class CloudWatchMetricsService {
   private static instance: CloudWatchMetricsService | null = null;
-  private readonly config: CloudWatchConfig;
+  private readonly enabled: boolean;
+  private readonly namespace: string;
 
   private constructor() {
-    this.config = {
-      enabled: this.isCloudWatchMetricsEnabled(),
-      namespace: getNonEmptyStringOrDefault(
-        process.env['CLOUDWATCH_METRICS_NAMESPACE'],
-        CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE,
-      ),
-    };
+    this.enabled = getEnableCloudwatchMetrics();
+    this.namespace =
+      getCloudwatchMetricsNamespace() ?? CLOUDWATCH_CONSTANTS.DEFAULT_NAMESPACE;
   }
 
   static getInstance(): CloudWatchMetricsService {
@@ -60,23 +53,13 @@ export class CloudWatchMetricsService {
   }
 
   isEnabled(): boolean {
-    return this.config.enabled;
+    return this.enabled;
   }
 
   async recordAIValidationFailure(data: CloudWatchMetricData): Promise<void> {
     if (this.isEnabled()) {
       await this.putMetric(data);
     }
-  }
-
-  private isCloudWatchMetricsEnabled(): boolean {
-    if (process.env['NODE_ENV'] === 'test') {
-      return false;
-    }
-
-    const value = process.env['ENABLE_CLOUDWATCH_METRICS'];
-
-    return !isNil(value) && value.trim().toLowerCase() === 'true';
   }
 
   private async putMetric(data: CloudWatchMetricData): Promise<void> {
@@ -97,7 +80,7 @@ export class CloudWatchMetricsService {
           Value: CLOUDWATCH_CONSTANTS.METRIC_VALUE,
         },
       ],
-      Namespace: this.config.namespace,
+      Namespace: this.namespace,
     });
 
     await client.send(command);

--- a/libs/shared/document/loader/src/document.repository.spec.ts
+++ b/libs/shared/document/loader/src/document.repository.spec.ts
@@ -10,7 +10,6 @@ jest.mock('@aws-sdk/client-s3');
 
 jest.mock('@carrot-fndn/shared/env', () => ({
   getDocumentBucketName: () => 'test-bucket',
-  getOptionalEnv: jest.fn(),
 }));
 
 const S3ClientMock = new S3Client({});

--- a/libs/shared/document/loader/src/document.repository.spec.ts
+++ b/libs/shared/document/loader/src/document.repository.spec.ts
@@ -8,6 +8,11 @@ import { assertDocumentEntity } from './document.validators';
 
 jest.mock('@aws-sdk/client-s3');
 
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getDocumentBucketName: () => 'test-bucket',
+  getOptionalEnv: jest.fn(),
+}));
+
 const S3ClientMock = new S3Client({});
 
 describe('DocumentRepository', () => {

--- a/libs/shared/document/loader/src/document.repository.ts
+++ b/libs/shared/document/loader/src/document.repository.ts
@@ -1,7 +1,8 @@
+import { getDocumentBucketName } from '@carrot-fndn/shared/env';
 import { S3BucketRepository } from '@carrot-fndn/shared/s3-bucket';
 
 export class DocumentRepository extends S3BucketRepository {
   constructor() {
-    super(process.env['DOCUMENT_BUCKET_NAME'] as string);
+    super(getDocumentBucketName());
   }
 }

--- a/libs/shared/document/seeds/src/document.seeds.ts
+++ b/libs/shared/document/seeds/src/document.seeds.ts
@@ -1,5 +1,6 @@
 import type { Logger } from 'pino';
 
+import { getAuditUrl } from '@carrot-fndn/shared/env';
 import {
   isNonEmptyObject,
   logger as pinoLogger,
@@ -10,7 +11,6 @@ import {
   type NonEmptyString,
   NonEmptyStringSchema,
   type Uri,
-  UriSchema,
 } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
@@ -69,19 +69,7 @@ export const seedDocument = async ({
   partialDocument?: Partial<MethodologyDocument>;
 } = {}): Promise<NonEmptyString> => {
   const documentId = faker.string.uuid();
-  const auditUrlFromEnvironment = process.env['AUDIT_URL'];
-
-  let endpoint: Uri;
-
-  try {
-    const auditUrl = UriSchema.parse(auditUrlFromEnvironment);
-
-    endpoint = `${auditUrl}/documents`;
-  } catch {
-    throw new Error(
-      "Invalid process.env['AUDIT_URL']: unable to build endpoint as type Uri. Please set AUDIT_URL to a valid non-empty URI.",
-    );
-  }
+  const endpoint: Uri = `${getAuditUrl()}/documents`;
 
   const document: MethodologyDocument = {
     ...stubMethodologyDocument(),

--- a/libs/shared/env/eslint.config.js
+++ b/libs/shared/env/eslint.config.js
@@ -1,0 +1,5 @@
+const { getBaseEslintConfig } = require('../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/libs/shared/env/jest.config.ts
+++ b/libs/shared/env/jest.config.ts
@@ -1,0 +1,3 @@
+import { getJestBaseConfig } from '../../../.jest/config/jest.base.config';
+
+export default getJestBaseConfig(__dirname);

--- a/libs/shared/env/package.json
+++ b/libs/shared/env/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@carrot-fndn/shared/env",
+  "version": "0.0.0",
+  "sideEffects": true
+}

--- a/libs/shared/env/project.json
+++ b/libs/shared/env/project.json
@@ -1,0 +1,12 @@
+{
+  "name": "shared-env",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["app:any", "scope:shared", "stack:any", "type:library"],
+  "sourceRoot": "libs/shared/env/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {},
+    "test": {},
+    "ts": {}
+  }
+}

--- a/libs/shared/env/src/env.helpers.spec.ts
+++ b/libs/shared/env/src/env.helpers.spec.ts
@@ -1,0 +1,221 @@
+import { ZodError } from 'zod';
+
+import {
+  getArtifactChecksum,
+  getAuditUrl,
+  getAwsRegion,
+  getBooleanEnv,
+  getCloudwatchMetricsNamespace,
+  getDocumentAttachmentBucketName,
+  getDocumentBucketName,
+  getEnableCloudwatchMetrics,
+  getEnvironment,
+  getNodeEnv,
+  getOptionalEnv,
+  getRequiredEnv,
+  getSentryDsn,
+  getSmaugApiGatewayAssumeRoleArn,
+  getSourceCodeUrl,
+  getSourceCodeVersion,
+} from './env.helpers';
+
+describe('getRequiredEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return the value when present', () => {
+    process.env['TEST_VAR'] = 'test-value';
+
+    expect(getRequiredEnv('TEST_VAR')).toBe('test-value');
+  });
+
+  it('should throw ZodError when variable is missing', () => {
+    delete process.env['TEST_VAR'];
+
+    expect(() => getRequiredEnv('TEST_VAR')).toThrow(ZodError);
+  });
+
+  it('should throw ZodError when variable is empty', () => {
+    process.env['TEST_VAR'] = '';
+
+    expect(() => getRequiredEnv('TEST_VAR')).toThrow(ZodError);
+  });
+});
+
+describe('getOptionalEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return the value when present', () => {
+    process.env['TEST_VAR'] = 'test-value';
+
+    expect(getOptionalEnv('TEST_VAR')).toBe('test-value');
+  });
+
+  it('should return undefined when missing and no default', () => {
+    delete process.env['TEST_VAR'];
+
+    expect(getOptionalEnv('TEST_VAR')).toBeUndefined();
+  });
+
+  it('should return default value when missing', () => {
+    delete process.env['TEST_VAR'];
+
+    expect(getOptionalEnv('TEST_VAR', 'default')).toBe('default');
+  });
+});
+
+describe('getBooleanEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return true for "true"', () => {
+    process.env['TEST_VAR'] = 'true';
+
+    expect(getBooleanEnv('TEST_VAR')).toBe(true);
+  });
+
+  it('should return false for "false"', () => {
+    process.env['TEST_VAR'] = 'false';
+
+    expect(getBooleanEnv('TEST_VAR')).toBe(false);
+  });
+
+  it('should handle case-insensitive values', () => {
+    process.env['TEST_VAR'] = 'TRUE';
+
+    expect(getBooleanEnv('TEST_VAR')).toBe(true);
+  });
+
+  it('should return default value when missing', () => {
+    delete process.env['TEST_VAR'];
+
+    expect(getBooleanEnv('TEST_VAR')).toBe(false);
+    expect(getBooleanEnv('TEST_VAR', true)).toBe(true);
+  });
+});
+
+describe('specific env helpers', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('required env helpers', () => {
+    it.each([
+      { fn: getArtifactChecksum, key: 'ARTIFACT_CHECKSUM' },
+      { fn: getAuditUrl, key: 'AUDIT_URL' },
+      { fn: getAwsRegion, key: 'AWS_REGION' },
+      { fn: getDocumentBucketName, key: 'DOCUMENT_BUCKET_NAME' },
+      { fn: getEnvironment, key: 'ENVIRONMENT' },
+      { fn: getNodeEnv, key: 'NODE_ENV' },
+      {
+        fn: getSmaugApiGatewayAssumeRoleArn,
+        key: 'SMAUG_API_GATEWAY_ASSUME_ROLE_ARN',
+      },
+      { fn: getSourceCodeUrl, key: 'SOURCE_CODE_URL' },
+      { fn: getSourceCodeVersion, key: 'SOURCE_CODE_VERSION' },
+    ])('$key should return value when set', ({ fn, key }) => {
+      process.env[key] = 'test-value';
+
+      expect(fn()).toBe('test-value');
+    });
+
+    it.each([
+      { fn: getArtifactChecksum, key: 'ARTIFACT_CHECKSUM' },
+      { fn: getAuditUrl, key: 'AUDIT_URL' },
+      { fn: getAwsRegion, key: 'AWS_REGION' },
+      { fn: getDocumentBucketName, key: 'DOCUMENT_BUCKET_NAME' },
+      { fn: getEnvironment, key: 'ENVIRONMENT' },
+      { fn: getNodeEnv, key: 'NODE_ENV' },
+      {
+        fn: getSmaugApiGatewayAssumeRoleArn,
+        key: 'SMAUG_API_GATEWAY_ASSUME_ROLE_ARN',
+      },
+      { fn: getSourceCodeUrl, key: 'SOURCE_CODE_URL' },
+      { fn: getSourceCodeVersion, key: 'SOURCE_CODE_VERSION' },
+    ])('$key should throw when not set', ({ fn, key }) => {
+      delete process.env[key];
+
+      expect(() => fn()).toThrow(ZodError);
+    });
+  });
+
+  describe('optional env helpers', () => {
+    it('getCloudwatchMetricsNamespace should return value when set', () => {
+      process.env['CLOUDWATCH_METRICS_NAMESPACE'] = 'Custom/Namespace';
+
+      expect(getCloudwatchMetricsNamespace()).toBe('Custom/Namespace');
+    });
+
+    it('getCloudwatchMetricsNamespace should return undefined when not set', () => {
+      delete process.env['CLOUDWATCH_METRICS_NAMESPACE'];
+
+      expect(getCloudwatchMetricsNamespace()).toBeUndefined();
+    });
+
+    it('getDocumentAttachmentBucketName should return value when set', () => {
+      process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'] = 'my-bucket';
+
+      expect(getDocumentAttachmentBucketName()).toBe('my-bucket');
+    });
+
+    it('getDocumentAttachmentBucketName should return undefined when not set', () => {
+      delete process.env['DOCUMENT_ATTACHMENT_BUCKET_NAME'];
+
+      expect(getDocumentAttachmentBucketName()).toBeUndefined();
+    });
+
+    it('getSentryDsn should return value when set', () => {
+      process.env['SENTRY_DSN'] = 'https://sentry.example.com';
+
+      expect(getSentryDsn()).toBe('https://sentry.example.com');
+    });
+
+    it('getSentryDsn should return undefined when not set', () => {
+      delete process.env['SENTRY_DSN'];
+
+      expect(getSentryDsn()).toBeUndefined();
+    });
+  });
+
+  describe('boolean env helpers', () => {
+    it('getEnableCloudwatchMetrics should return true when set to "true"', () => {
+      process.env['ENABLE_CLOUDWATCH_METRICS'] = 'true';
+
+      expect(getEnableCloudwatchMetrics()).toBe(true);
+    });
+
+    it('getEnableCloudwatchMetrics should return false when not set', () => {
+      delete process.env['ENABLE_CLOUDWATCH_METRICS'];
+
+      expect(getEnableCloudwatchMetrics()).toBe(false);
+    });
+  });
+});

--- a/libs/shared/env/src/env.helpers.spec.ts
+++ b/libs/shared/env/src/env.helpers.spec.ts
@@ -13,6 +13,7 @@ import {
   getNodeEnv as getNodeEnvironment,
   getOptionalEnv as getOptionalEnvironment,
   getRequiredEnv as getRequiredEnvironment,
+  getRequiredUriEnv as getRequiredUriEnvironment,
   getSentryDsn,
   getSmaugApiGatewayAssumeRoleArn,
   getSourceCodeUrl,
@@ -49,6 +50,36 @@ describe('getRequiredEnv', () => {
   });
 });
 
+describe('getRequiredUriEnv', () => {
+  const originalEnvironment = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnvironment };
+  });
+
+  afterAll(() => {
+    process.env = originalEnvironment;
+  });
+
+  it('should return the value when a valid URL is present', () => {
+    process.env['TEST_VAR'] = 'https://example.com';
+
+    expect(getRequiredUriEnvironment('TEST_VAR')).toBe('https://example.com');
+  });
+
+  it('should throw ZodError when variable is missing', () => {
+    delete process.env['TEST_VAR'];
+
+    expect(() => getRequiredUriEnvironment('TEST_VAR')).toThrow(ZodError);
+  });
+
+  it('should throw ZodError when variable is not a valid URL', () => {
+    process.env['TEST_VAR'] = 'not-a-url';
+
+    expect(() => getRequiredUriEnvironment('TEST_VAR')).toThrow(ZodError);
+  });
+});
+
 describe('getOptionalEnv', () => {
   const originalEnvironment = process.env;
 
@@ -76,6 +107,12 @@ describe('getOptionalEnv', () => {
     delete process.env['TEST_VAR'];
 
     expect(getOptionalEnvironment('TEST_VAR', 'default')).toBe('default');
+  });
+
+  it('should return empty string when variable is empty (not the default)', () => {
+    process.env['TEST_VAR'] = '';
+
+    expect(getOptionalEnvironment('TEST_VAR', 'default')).toBe('');
   });
 });
 
@@ -114,6 +151,20 @@ describe('getBooleanEnv', () => {
     expect(getBooleanEnvironment('TEST_VAR')).toBe(false);
     expect(getBooleanEnvironment('TEST_VAR', true)).toBe(true);
   });
+
+  it('should handle whitespace-padded values', () => {
+    process.env['TEST_VAR'] = '  true  ';
+
+    expect(getBooleanEnvironment('TEST_VAR')).toBe(true);
+  });
+
+  it('should return false for non-boolean string values', () => {
+    for (const value of ['1', '0', 'yes', 'no', 'invalid']) {
+      process.env['TEST_VAR'] = value;
+
+      expect(getBooleanEnvironment('TEST_VAR')).toBe(false);
+    }
+  });
 });
 
 describe('specific env helpers', () => {
@@ -130,7 +181,6 @@ describe('specific env helpers', () => {
   describe('required env helpers', () => {
     it.each([
       { fn: getArtifactChecksum, key: 'ARTIFACT_CHECKSUM' },
-      { fn: getAuditUrl, key: 'AUDIT_URL' },
       { fn: getAwsRegion, key: 'AWS_REGION' },
       { fn: getDocumentBucketName, key: 'DOCUMENT_BUCKET_NAME' },
       { fn: getEnvironment, key: 'ENVIRONMENT' },
@@ -147,9 +197,14 @@ describe('specific env helpers', () => {
       expect(fn()).toBe('test-value');
     });
 
+    it('AUDIT_URL should return value when set to a valid URL', () => {
+      process.env['AUDIT_URL'] = 'https://audit.example.com';
+
+      expect(getAuditUrl()).toBe('https://audit.example.com');
+    });
+
     it.each([
       { fn: getArtifactChecksum, key: 'ARTIFACT_CHECKSUM' },
-      { fn: getAuditUrl, key: 'AUDIT_URL' },
       { fn: getAwsRegion, key: 'AWS_REGION' },
       { fn: getDocumentBucketName, key: 'DOCUMENT_BUCKET_NAME' },
       { fn: getEnvironment, key: 'ENVIRONMENT' },
@@ -164,6 +219,18 @@ describe('specific env helpers', () => {
       delete process.env[key];
 
       expect(() => fn()).toThrow(ZodError);
+    });
+
+    it('AUDIT_URL should throw when not set', () => {
+      delete process.env['AUDIT_URL'];
+
+      expect(() => getAuditUrl()).toThrow(ZodError);
+    });
+
+    it('AUDIT_URL should throw when set to an invalid URL', () => {
+      process.env['AUDIT_URL'] = 'not-a-url';
+
+      expect(() => getAuditUrl()).toThrow(ZodError);
     });
   });
 

--- a/libs/shared/env/src/env.helpers.spec.ts
+++ b/libs/shared/env/src/env.helpers.spec.ts
@@ -4,15 +4,15 @@ import {
   getArtifactChecksum,
   getAuditUrl,
   getAwsRegion,
-  getBooleanEnv,
+  getBooleanEnv as getBooleanEnvironment,
   getCloudwatchMetricsNamespace,
   getDocumentAttachmentBucketName,
   getDocumentBucketName,
   getEnableCloudwatchMetrics,
   getEnvironment,
-  getNodeEnv,
-  getOptionalEnv,
-  getRequiredEnv,
+  getNodeEnv as getNodeEnvironment,
+  getOptionalEnv as getOptionalEnvironment,
+  getRequiredEnv as getRequiredEnvironment,
   getSentryDsn,
   getSmaugApiGatewayAssumeRoleArn,
   getSourceCodeUrl,
@@ -20,111 +20,111 @@ import {
 } from './env.helpers';
 
 describe('getRequiredEnv', () => {
-  const originalEnv = process.env;
+  const originalEnvironment = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
+    process.env = { ...originalEnvironment };
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    process.env = originalEnvironment;
   });
 
   it('should return the value when present', () => {
     process.env['TEST_VAR'] = 'test-value';
 
-    expect(getRequiredEnv('TEST_VAR')).toBe('test-value');
+    expect(getRequiredEnvironment('TEST_VAR')).toBe('test-value');
   });
 
   it('should throw ZodError when variable is missing', () => {
     delete process.env['TEST_VAR'];
 
-    expect(() => getRequiredEnv('TEST_VAR')).toThrow(ZodError);
+    expect(() => getRequiredEnvironment('TEST_VAR')).toThrow(ZodError);
   });
 
   it('should throw ZodError when variable is empty', () => {
     process.env['TEST_VAR'] = '';
 
-    expect(() => getRequiredEnv('TEST_VAR')).toThrow(ZodError);
+    expect(() => getRequiredEnvironment('TEST_VAR')).toThrow(ZodError);
   });
 });
 
 describe('getOptionalEnv', () => {
-  const originalEnv = process.env;
+  const originalEnvironment = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
+    process.env = { ...originalEnvironment };
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    process.env = originalEnvironment;
   });
 
   it('should return the value when present', () => {
     process.env['TEST_VAR'] = 'test-value';
 
-    expect(getOptionalEnv('TEST_VAR')).toBe('test-value');
+    expect(getOptionalEnvironment('TEST_VAR')).toBe('test-value');
   });
 
   it('should return undefined when missing and no default', () => {
     delete process.env['TEST_VAR'];
 
-    expect(getOptionalEnv('TEST_VAR')).toBeUndefined();
+    expect(getOptionalEnvironment('TEST_VAR')).toBeUndefined();
   });
 
   it('should return default value when missing', () => {
     delete process.env['TEST_VAR'];
 
-    expect(getOptionalEnv('TEST_VAR', 'default')).toBe('default');
+    expect(getOptionalEnvironment('TEST_VAR', 'default')).toBe('default');
   });
 });
 
 describe('getBooleanEnv', () => {
-  const originalEnv = process.env;
+  const originalEnvironment = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
+    process.env = { ...originalEnvironment };
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    process.env = originalEnvironment;
   });
 
   it('should return true for "true"', () => {
     process.env['TEST_VAR'] = 'true';
 
-    expect(getBooleanEnv('TEST_VAR')).toBe(true);
+    expect(getBooleanEnvironment('TEST_VAR')).toBe(true);
   });
 
   it('should return false for "false"', () => {
     process.env['TEST_VAR'] = 'false';
 
-    expect(getBooleanEnv('TEST_VAR')).toBe(false);
+    expect(getBooleanEnvironment('TEST_VAR')).toBe(false);
   });
 
   it('should handle case-insensitive values', () => {
     process.env['TEST_VAR'] = 'TRUE';
 
-    expect(getBooleanEnv('TEST_VAR')).toBe(true);
+    expect(getBooleanEnvironment('TEST_VAR')).toBe(true);
   });
 
   it('should return default value when missing', () => {
     delete process.env['TEST_VAR'];
 
-    expect(getBooleanEnv('TEST_VAR')).toBe(false);
-    expect(getBooleanEnv('TEST_VAR', true)).toBe(true);
+    expect(getBooleanEnvironment('TEST_VAR')).toBe(false);
+    expect(getBooleanEnvironment('TEST_VAR', true)).toBe(true);
   });
 });
 
 describe('specific env helpers', () => {
-  const originalEnv = process.env;
+  const originalEnvironment = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
+    process.env = { ...originalEnvironment };
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    process.env = originalEnvironment;
   });
 
   describe('required env helpers', () => {
@@ -134,7 +134,7 @@ describe('specific env helpers', () => {
       { fn: getAwsRegion, key: 'AWS_REGION' },
       { fn: getDocumentBucketName, key: 'DOCUMENT_BUCKET_NAME' },
       { fn: getEnvironment, key: 'ENVIRONMENT' },
-      { fn: getNodeEnv, key: 'NODE_ENV' },
+      { fn: getNodeEnvironment, key: 'NODE_ENV' },
       {
         fn: getSmaugApiGatewayAssumeRoleArn,
         key: 'SMAUG_API_GATEWAY_ASSUME_ROLE_ARN',
@@ -153,7 +153,7 @@ describe('specific env helpers', () => {
       { fn: getAwsRegion, key: 'AWS_REGION' },
       { fn: getDocumentBucketName, key: 'DOCUMENT_BUCKET_NAME' },
       { fn: getEnvironment, key: 'ENVIRONMENT' },
-      { fn: getNodeEnv, key: 'NODE_ENV' },
+      { fn: getNodeEnvironment, key: 'NODE_ENV' },
       {
         fn: getSmaugApiGatewayAssumeRoleArn,
         key: 'SMAUG_API_GATEWAY_ASSUME_ROLE_ARN',

--- a/libs/shared/env/src/env.helpers.ts
+++ b/libs/shared/env/src/env.helpers.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+export const getRequiredEnv = (key: string): string =>
+  z
+    .string()
+    .min(1, `Environment variable ${key} is required`)
+    // eslint-disable-next-line security/detect-object-injection
+    .parse(process.env[key]);
+
+export const getOptionalEnv = (
+  key: string,
+  defaultValue?: string,
+  // eslint-disable-next-line security/detect-object-injection
+): string | undefined => process.env[key] ?? defaultValue;
+
+export const getBooleanEnv = (key: string, defaultValue = false): boolean => {
+  // eslint-disable-next-line security/detect-object-injection
+  const value = process.env[key];
+
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return value.trim().toLowerCase() === 'true';
+};
+
+// Required env vars
+export const getArtifactChecksum = (): string =>
+  getRequiredEnv('ARTIFACT_CHECKSUM');
+export const getAuditUrl = (): string => getRequiredEnv('AUDIT_URL');
+export const getAwsRegion = (): string => getRequiredEnv('AWS_REGION');
+export const getDocumentBucketName = (): string =>
+  getRequiredEnv('DOCUMENT_BUCKET_NAME');
+export const getEnvironment = (): string => getRequiredEnv('ENVIRONMENT');
+export const getNodeEnv = (): string => getRequiredEnv('NODE_ENV');
+export const getSmaugApiGatewayAssumeRoleArn = (): string =>
+  getRequiredEnv('SMAUG_API_GATEWAY_ASSUME_ROLE_ARN');
+export const getSourceCodeUrl = (): string => getRequiredEnv('SOURCE_CODE_URL');
+export const getSourceCodeVersion = (): string =>
+  getRequiredEnv('SOURCE_CODE_VERSION');
+
+// Optional env vars
+export const getCloudwatchMetricsNamespace = (): string | undefined =>
+  getOptionalEnv('CLOUDWATCH_METRICS_NAMESPACE');
+export const getDocumentAttachmentBucketName = (): string | undefined =>
+  getOptionalEnv('DOCUMENT_ATTACHMENT_BUCKET_NAME');
+export const getEnableCloudwatchMetrics = (): boolean =>
+  getBooleanEnv('ENABLE_CLOUDWATCH_METRICS');
+export const getSentryDsn = (): string | undefined =>
+  getOptionalEnv('SENTRY_DSN');

--- a/libs/shared/env/src/env.helpers.ts
+++ b/libs/shared/env/src/env.helpers.ts
@@ -7,6 +7,12 @@ export const getRequiredEnv = (key: string): string =>
     // eslint-disable-next-line security/detect-object-injection
     .parse(process.env[key]);
 
+export const getRequiredUriEnv = (key: string): string =>
+  z
+    .url(`Environment variable ${key} must be a valid URL`)
+    // eslint-disable-next-line security/detect-object-injection
+    .parse(process.env[key]);
+
 export const getOptionalEnv = (
   key: string,
   defaultValue?: string,
@@ -27,7 +33,7 @@ export const getBooleanEnv = (key: string, defaultValue = false): boolean => {
 // Required env vars
 export const getArtifactChecksum = (): string =>
   getRequiredEnv('ARTIFACT_CHECKSUM');
-export const getAuditUrl = (): string => getRequiredEnv('AUDIT_URL');
+export const getAuditUrl = (): string => getRequiredUriEnv('AUDIT_URL');
 export const getAwsRegion = (): string => getRequiredEnv('AWS_REGION');
 export const getDocumentBucketName = (): string =>
   getRequiredEnv('DOCUMENT_BUCKET_NAME');

--- a/libs/shared/env/src/index.ts
+++ b/libs/shared/env/src/index.ts
@@ -1,0 +1,18 @@
+export {
+  getArtifactChecksum,
+  getAuditUrl,
+  getAwsRegion,
+  getBooleanEnv,
+  getCloudwatchMetricsNamespace,
+  getDocumentAttachmentBucketName,
+  getDocumentBucketName,
+  getEnableCloudwatchMetrics,
+  getEnvironment,
+  getNodeEnv,
+  getOptionalEnv,
+  getRequiredEnv,
+  getSentryDsn,
+  getSmaugApiGatewayAssumeRoleArn,
+  getSourceCodeUrl,
+  getSourceCodeVersion,
+} from './env.helpers';

--- a/libs/shared/env/src/index.ts
+++ b/libs/shared/env/src/index.ts
@@ -11,6 +11,7 @@ export {
   getNodeEnv,
   getOptionalEnv,
   getRequiredEnv,
+  getRequiredUriEnv,
   getSentryDsn,
   getSmaugApiGatewayAssumeRoleArn,
   getSourceCodeUrl,

--- a/libs/shared/env/tsconfig.build.json
+++ b/libs/shared/env/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../../../.tsconfig/tsconfig.build.json"]
+}

--- a/libs/shared/env/tsconfig.eslint.json
+++ b/libs/shared/env/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"]
+}

--- a/libs/shared/env/tsconfig.json
+++ b/libs/shared/env/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/libs/shared/env/tsconfig.spec.json
+++ b/libs/shared/env/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.tsconfig/tsconfig.spec.json"
+}

--- a/libs/shared/http-request/src/http-request.spec.ts
+++ b/libs/shared/http-request/src/http-request.spec.ts
@@ -7,6 +7,10 @@ import { httpRequest } from './http-request';
 
 jest.mock('axios');
 jest.mock('@carrot-fndn/shared/aws-http');
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getAwsRegion: () => 'us-east-1',
+  getOptionalEnv: jest.fn(),
+}));
 
 describe('request helpers', () => {
   const mockedAxios = jest.mocked(axios);

--- a/libs/shared/http-request/src/http-request.spec.ts
+++ b/libs/shared/http-request/src/http-request.spec.ts
@@ -9,7 +9,6 @@ jest.mock('axios');
 jest.mock('@carrot-fndn/shared/aws-http');
 jest.mock('@carrot-fndn/shared/env', () => ({
   getAwsRegion: () => 'us-east-1',
-  getOptionalEnv: jest.fn(),
 }));
 
 describe('request helpers', () => {

--- a/libs/shared/http-request/src/http-request.ts
+++ b/libs/shared/http-request/src/http-request.ts
@@ -1,4 +1,5 @@
 import { signRequest } from '@carrot-fndn/shared/aws-http';
+import { getAwsRegion } from '@carrot-fndn/shared/env';
 import {
   isNonEmptyString,
   logger as pinoLogger,
@@ -28,7 +29,7 @@ export const prepareHttpRequestConfig = async (
       query: config.method === 'GET' ? config.params : undefined,
       url,
     },
-    process.env['AWS_REGION'] as string,
+    getAwsRegion(),
   );
 
   return {

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
@@ -3,6 +3,7 @@ import type { RuleOutput } from '@carrot-fndn/shared/rule/types';
 import { STSClient } from '@aws-sdk/client-sts';
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
 import { getSentryDsn } from '@carrot-fndn/shared/env';
+import { logger } from '@carrot-fndn/shared/helpers';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   stubContext,
@@ -14,14 +15,15 @@ import * as Sentry from '@sentry/serverless';
 
 import { wrapRuleIntoLambdaHandler } from './lambda-wrapper';
 
+const mockGetNodeEnv = jest.fn(() => 'test');
+
 jest.mock('@carrot-fndn/shared/env', () => ({
   getArtifactChecksum: () => 'test-checksum',
   getAuditUrl: () => 'https://test.example.com',
   getAwsRegion: () => 'us-east-1',
   getDocumentBucketName: () => 'test-bucket',
   getEnvironment: () => 'development',
-  getNodeEnv: () => 'test',
-  getOptionalEnv: jest.fn(),
+  getNodeEnv: () => mockGetNodeEnv(),
   getSentryDsn: jest.fn(() => undefined),
   getSmaugApiGatewayAssumeRoleArn: () => 'arn:aws:iam::123456:role/test',
   getSourceCodeUrl: () => 'https://test.example.com/repo',
@@ -123,6 +125,35 @@ describe('wrapRuleIntoLambdaHandler', () => {
       requestId: ruleEvent.requestId,
       ruleName: ruleEvent.ruleName,
     });
+  });
+
+  it('should log a warning when SENTRY_DSN is missing in production', async () => {
+    mockGetNodeEnv.mockReturnValueOnce('production');
+
+    const warnSpy = jest.spyOn(logger, 'warn');
+
+    const response = {
+      ...stubRuleOutput(),
+      resultStatus: RuleOutputStatus.PASSED,
+    };
+
+    class Wrapped extends RuleDataProcessor {
+      process() {
+        return Promise.resolve({ ...response });
+      }
+    }
+
+    mockStsAndFetch();
+
+    const wrapper = wrapRuleIntoLambdaHandler(new Wrapped());
+
+    await wrapper(stubRuleInput(), stubContext(), () => {});
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'SENTRY_DSN is not set — error monitoring is disabled',
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('should pass the Sentry DSN when getSentryDsn returns a value', async () => {

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
@@ -2,6 +2,7 @@ import type { RuleOutput } from '@carrot-fndn/shared/rule/types';
 
 import { STSClient } from '@aws-sdk/client-sts';
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import { getSentryDsn } from '@carrot-fndn/shared/env';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   stubContext,
@@ -21,7 +22,7 @@ jest.mock('@carrot-fndn/shared/env', () => ({
   getEnvironment: () => 'development',
   getNodeEnv: () => 'test',
   getOptionalEnv: jest.fn(),
-  getSentryDsn: () => undefined,
+  getSentryDsn: jest.fn(() => undefined),
   getSmaugApiGatewayAssumeRoleArn: () => 'arn:aws:iam::123456:role/test',
   getSourceCodeUrl: () => 'https://test.example.com/repo',
   getSourceCodeVersion: () => 'test-version',
@@ -122,5 +123,34 @@ describe('wrapRuleIntoLambdaHandler', () => {
       requestId: ruleEvent.requestId,
       ruleName: ruleEvent.ruleName,
     });
+  });
+
+  it('should pass the Sentry DSN when getSentryDsn returns a value', async () => {
+    const sentryDsn = faker.internet.url();
+
+    jest.mocked(getSentryDsn).mockReturnValueOnce(sentryDsn);
+
+    const initSpy = jest.spyOn(Sentry.AWSLambda, 'init').mockImplementation();
+
+    const response = {
+      ...stubRuleOutput(),
+      resultStatus: RuleOutputStatus.PASSED,
+    };
+
+    class Wrapped extends RuleDataProcessor {
+      process() {
+        return Promise.resolve({ ...response });
+      }
+    }
+
+    mockStsAndFetch();
+
+    const wrapper = wrapRuleIntoLambdaHandler(new Wrapped());
+    const result = await wrapper(stubRuleInput(), stubContext(), () => {});
+
+    expect(result).toEqual(response);
+    expect(initSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ dsn: sentryDsn }),
+    );
   });
 });

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
@@ -13,12 +13,26 @@ import * as Sentry from '@sentry/serverless';
 
 import { wrapRuleIntoLambdaHandler } from './lambda-wrapper';
 
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getArtifactChecksum: () => 'test-checksum',
+  getAuditUrl: () => 'https://test.example.com',
+  getAwsRegion: () => 'us-east-1',
+  getDocumentBucketName: () => 'test-bucket',
+  getEnvironment: () => 'development',
+  getNodeEnv: () => 'test',
+  getOptionalEnv: jest.fn(),
+  getSentryDsn: () => undefined,
+  getSmaugApiGatewayAssumeRoleArn: () => 'arn:aws:iam::123456:role/test',
+  getSourceCodeUrl: () => 'https://test.example.com/repo',
+  getSourceCodeVersion: () => 'test-version',
+}));
+
 process.env = {
   ...process.env,
   AWS_ACCESS_KEY_ID: faker.string.uuid(),
-  AWS_REGION: faker.string.uuid(),
+  AWS_REGION: 'us-east-1',
   AWS_SECRET_ACCESS_KEY: faker.string.uuid(),
-  SMAUG_API_GATEWAY_ASSUME_ROLE_ARN: faker.string.uuid(),
+  SMAUG_API_GATEWAY_ASSUME_ROLE_ARN: 'arn:aws:iam::123456:role/test',
 };
 
 describe('wrapRuleIntoLambdaHandler', () => {

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -3,6 +3,11 @@ import type { RuleInput, RuleOutput } from '@carrot-fndn/shared/rule/types';
 import type { Handler } from 'aws-lambda';
 
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
+import {
+  getEnvironment,
+  getNodeEnv,
+  getSentryDsn,
+} from '@carrot-fndn/shared/env';
 import { logger } from '@carrot-fndn/shared/helpers';
 import { reportRuleResults } from '@carrot-fndn/shared/rule/result';
 import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
@@ -42,10 +47,12 @@ export const wrapRuleIntoLambdaHandler = (
   // This addresses the issue with multiple uncaughtException listeners added by Sentry
   process.setMaxListeners(20);
 
+  const sentryDsn = getSentryDsn();
+
   AWSLambda.init({
-    dsn: String(process.env['SENTRY_DSN']),
-    enabled: String(process.env['NODE_ENV']) === 'production',
-    environment: String(process.env['ENVIRONMENT']),
+    ...(sentryDsn ? { dsn: sentryDsn } : {}),
+    enabled: getNodeEnv() === 'production',
+    environment: getEnvironment(),
   });
 
   const handler = async (event: MethodologyRuleEvent): Promise<unknown> => {

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -48,10 +48,15 @@ export const wrapRuleIntoLambdaHandler = (
   process.setMaxListeners(20);
 
   const sentryDsn = getSentryDsn();
+  const isProduction = getNodeEnv() === 'production';
+
+  if (isProduction && !sentryDsn) {
+    logger.warn('SENTRY_DSN is not set — error monitoring is disabled');
+  }
 
   AWSLambda.init({
     ...(sentryDsn ? { dsn: sentryDsn } : {}),
-    enabled: getNodeEnv() === 'production',
+    enabled: isProduction,
     environment: getEnvironment(),
   });
 

--- a/libs/shared/methodologies/audit-api/src/audit-api.constants.spec.ts
+++ b/libs/shared/methodologies/audit-api/src/audit-api.constants.spec.ts
@@ -1,6 +1,5 @@
 jest.mock('@carrot-fndn/shared/env', () => ({
   getAuditUrl: () => mockAuditUrl,
-  getOptionalEnv: jest.fn(),
 }));
 
 let mockAuditUrl: string | undefined;
@@ -20,13 +19,16 @@ describe('Audit API Constants', () => {
       expect(AUDIT_API_URL).toBe('https://test.carrot.eco');
     });
 
-    it('should use undefined when AUDIT_URL is not set', () => {
-      mockAuditUrl = undefined;
+    it('should throw when getAuditUrl throws', () => {
       jest.resetModules();
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { AUDIT_API_URL } = require('./audit-api.constants');
+      jest.doMock('@carrot-fndn/shared/env', () => ({
+        getAuditUrl: () => {
+          throw new Error('AUDIT_URL is required');
+        },
+      }));
 
-      expect(AUDIT_API_URL).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-return
+      expect(() => require('./audit-api.constants')).toThrow();
     });
   });
 });

--- a/libs/shared/methodologies/audit-api/src/audit-api.constants.spec.ts
+++ b/libs/shared/methodologies/audit-api/src/audit-api.constants.spec.ts
@@ -1,18 +1,18 @@
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getAuditUrl: () => mockAuditUrl,
+  getOptionalEnv: jest.fn(),
+}));
+
+let mockAuditUrl: string | undefined;
+
 describe('Audit API Constants', () => {
-  let originalAuditUrl: string | undefined;
-
   beforeEach(() => {
-    originalAuditUrl = process.env['AUDIT_URL'];
-  });
-
-  afterEach(() => {
-    process.env['AUDIT_URL'] = originalAuditUrl;
     jest.resetModules();
   });
 
   describe('AUDIT_API_URL', () => {
-    it('should use the value from AUDIT_URL environment variable', () => {
-      process.env['AUDIT_URL'] = 'https://test.carrot.eco';
+    it('should use the value from getAuditUrl', () => {
+      mockAuditUrl = 'https://test.carrot.eco';
       jest.resetModules();
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { AUDIT_API_URL } = require('./audit-api.constants');
@@ -20,36 +20,13 @@ describe('Audit API Constants', () => {
       expect(AUDIT_API_URL).toBe('https://test.carrot.eco');
     });
 
-    it('should throw an error when AUDIT_URL is not defined', () => {
-      delete process.env['AUDIT_URL'];
+    it('should use undefined when AUDIT_URL is not set', () => {
+      mockAuditUrl = undefined;
       jest.resetModules();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { AUDIT_API_URL } = require('./audit-api.constants');
 
-      let error: Error | null = null;
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        require('./audit-api.constants');
-      } catch (error_) {
-        error = error_ as Error;
-      }
-
-      expect(error).not.toBeNull();
-    });
-
-    it('should throw an error when AUDIT_URL is not a valid URI', () => {
-      process.env['AUDIT_URL'] = 'not-a-valid-uri';
-      jest.resetModules();
-
-      let error: Error | null = null;
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        require('./audit-api.constants');
-      } catch (error_) {
-        error = error_ as Error;
-      }
-
-      expect(error).not.toBeNull();
+      expect(AUDIT_API_URL).toBeUndefined();
     });
   });
 });

--- a/libs/shared/methodologies/audit-api/src/audit-api.constants.ts
+++ b/libs/shared/methodologies/audit-api/src/audit-api.constants.ts
@@ -1,3 +1,3 @@
-import { UriSchema } from '@carrot-fndn/shared/types';
+import { getAuditUrl } from '@carrot-fndn/shared/env';
 
-export const AUDIT_API_URL = UriSchema.parse(process.env['AUDIT_URL']);
+export const AUDIT_API_URL = getAuditUrl();

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -380,12 +380,9 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no external events', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
-      const document = stubDocument(
-        {
-          externalEvents: undefined,
-        },
-        false,
-      );
+      const document = stubDocument({}, false);
+
+      document.externalEvents = undefined;
 
       const participantActorType = getParticipantActorType({
         document,

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -46,9 +46,12 @@ const testEmissionAndCompostingMetricsEvent = (
     name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
   });
 
-  const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-    externalEvents: [...stubArray(() => stubDocumentEvent()), targetEvent],
-  });
+  const documentWithEmissionAndCompostingMetricsEvent = stubDocument(
+    {
+      externalEvents: [targetEvent, ...stubArray(() => stubDocumentEvent())],
+    },
+    false,
+  );
 
   return {
     result: getLastYearEmissionAndCompostingMetricsEvent({
@@ -97,9 +100,12 @@ describe('Document getters', () => {
         name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
       });
 
-      const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-        externalEvents: [eventWithEmptyStringYear],
-      });
+      const documentWithEmissionAndCompostingMetricsEvent = stubDocument(
+        {
+          externalEvents: [eventWithEmptyStringYear],
+        },
+        false,
+      );
 
       const result = getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent,
@@ -123,9 +129,12 @@ describe('Document getters', () => {
         name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
       });
 
-      const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-        externalEvents: [eventWithZeroYear],
-      });
+      const documentWithEmissionAndCompostingMetricsEvent = stubDocument(
+        {
+          externalEvents: [eventWithZeroYear],
+        },
+        false,
+      );
 
       const result = getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent,
@@ -149,9 +158,12 @@ describe('Document getters', () => {
         name: `${EMISSION_AND_COMPOSTING_METRICS} (${getYear(new Date())})`,
       });
 
-      const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-        externalEvents: [eventWithNegativeYear],
-      });
+      const documentWithEmissionAndCompostingMetricsEvent = stubDocument(
+        {
+          externalEvents: [eventWithNegativeYear],
+        },
+        false,
+      );
 
       const result = getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent,
@@ -186,9 +198,12 @@ describe('Document getters', () => {
         name: 'OTHER_EVENT',
       });
 
-      const documentWithEmissionAndCompostingMetricsEvent = stubDocument({
-        externalEvents: [nonTargetEvent],
-      });
+      const documentWithEmissionAndCompostingMetricsEvent = stubDocument(
+        {
+          externalEvents: [nonTargetEvent],
+        },
+        false,
+      );
 
       const result = getLastYearEmissionAndCompostingMetricsEvent({
         documentWithEmissionAndCompostingMetricsEvent,
@@ -203,12 +218,15 @@ describe('Document getters', () => {
     it('should return the rules metadata event', () => {
       const rulesMetadataEvent = stubDocumentEvent({ name: RULES_METADATA });
 
-      const document = stubDocument({
-        externalEvents: [
-          ...stubArray(() => stubDocumentEvent()),
-          rulesMetadataEvent,
-        ],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [
+            rulesMetadataEvent,
+            ...stubArray(() => stubDocumentEvent()),
+          ],
+        },
+        false,
+      );
 
       const result = getRulesMetadataEvent(document);
 
@@ -216,9 +234,14 @@ describe('Document getters', () => {
     });
 
     it('should return undefined if the rules metadata event was not found', () => {
-      const document = stubDocument({
-        externalEvents: stubArray(() => stubDocumentEvent()),
-      });
+      const document = stubDocument(
+        {
+          externalEvents: stubArray(() =>
+            stubDocumentEvent({ name: PICK_UP }),
+          ),
+        },
+        false,
+      );
 
       const result = getRulesMetadataEvent(document);
 
@@ -235,14 +258,17 @@ describe('Document getters', () => {
   describe('getParticipantActorType', () => {
     it(`should return "${WASTE_GENERATOR}" when the event is a pick up at the source`, () => {
       const sourcePickUpEvent = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIDDocument({
-        externalEvents: [
-          sourcePickUpEvent,
-          stubDocumentEvent({ name: DROP_OFF }),
-          stubDocumentEvent({ name: PICK_UP }),
-          stubDocumentEvent({ name: DROP_OFF }),
-        ],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [
+            sourcePickUpEvent,
+            stubDocumentEvent({ name: DROP_OFF }),
+            stubDocumentEvent({ name: PICK_UP }),
+            stubDocumentEvent({ name: DROP_OFF }),
+          ],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -254,14 +280,17 @@ describe('Document getters', () => {
 
     it(`should return "${PROCESSOR}" when the event is a drop off at processor`, () => {
       const processorDropOffEvent = stubDocumentEvent({ name: DROP_OFF });
-      const document = stubMassIDDocument({
-        externalEvents: [
-          stubDocumentEvent({ name: PICK_UP }),
-          processorDropOffEvent,
-          stubDocumentEvent({ name: PICK_UP }),
-          stubDocumentEvent({ name: DROP_OFF }),
-        ],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [
+            stubDocumentEvent({ name: PICK_UP }),
+            processorDropOffEvent,
+            stubDocumentEvent({ name: PICK_UP }),
+            stubDocumentEvent({ name: DROP_OFF }),
+          ],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -273,14 +302,17 @@ describe('Document getters', () => {
 
     it(`should return "${PROCESSOR}" when the event is a pick up at processor`, () => {
       const processorPickUpEvent = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIDDocument({
-        externalEvents: [
-          stubDocumentEvent({ name: PICK_UP }),
-          stubDocumentEvent({ name: DROP_OFF }),
-          processorPickUpEvent,
-          stubDocumentEvent({ name: DROP_OFF }),
-        ],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [
+            stubDocumentEvent({ name: PICK_UP }),
+            stubDocumentEvent({ name: DROP_OFF }),
+            processorPickUpEvent,
+            stubDocumentEvent({ name: DROP_OFF }),
+          ],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -292,14 +324,17 @@ describe('Document getters', () => {
 
     it(`should return "${RECYCLER}" when the event is a drop off at recycler`, () => {
       const recyclerDropOffEvent = stubDocumentEvent({ name: DROP_OFF });
-      const document = stubMassIDDocument({
-        externalEvents: [
-          stubDocumentEvent({ name: PICK_UP }),
-          stubDocumentEvent({ name: DROP_OFF }),
-          stubDocumentEvent({ name: PICK_UP }),
-          recyclerDropOffEvent,
-        ],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [
+            stubDocumentEvent({ name: PICK_UP }),
+            stubDocumentEvent({ name: DROP_OFF }),
+            stubDocumentEvent({ name: PICK_UP }),
+            recyclerDropOffEvent,
+          ],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -311,9 +346,12 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no pick up events', () => {
       const dropOffEvent = stubDocumentEvent({ name: DROP_OFF });
-      const document = stubMassIDDocument({
-        externalEvents: [dropOffEvent],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [dropOffEvent],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -325,9 +363,12 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no drop off events', () => {
       const pickUpEvent = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIDDocument({
-        externalEvents: [pickUpEvent],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [pickUpEvent],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -339,9 +380,12 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has no external events', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIDDocument({
-        externalEvents: undefined,
-      });
+      const document = stubDocument(
+        {
+          externalEvents: undefined,
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -353,9 +397,12 @@ describe('Document getters', () => {
 
     it('should return undefined when the document has empty external events array', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
-      const document = stubMassIDDocument({
-        externalEvents: [],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,
@@ -368,7 +415,7 @@ describe('Document getters', () => {
     it('should return undefined when the document has non-array external events', () => {
       const event = stubDocumentEvent({ name: PICK_UP });
       const document = {
-        ...stubMassIDDocument(),
+        ...stubDocument(undefined, false),
         externalEvents: 'not an array',
       } as unknown as Document;
 
@@ -382,13 +429,16 @@ describe('Document getters', () => {
 
     it('should return undefined when the event is neither a pick-up nor a drop-off event', () => {
       const otherEvent = stubDocumentEvent({ name: ACCREDITATION_CONTEXT });
-      const document = stubMassIDDocument({
-        externalEvents: [
-          stubDocumentEvent({ name: PICK_UP }),
-          stubDocumentEvent({ name: DROP_OFF }),
-          otherEvent,
-        ],
-      });
+      const document = stubDocument(
+        {
+          externalEvents: [
+            stubDocumentEvent({ name: PICK_UP }),
+            stubDocumentEvent({ name: DROP_OFF }),
+            otherEvent,
+          ],
+        },
+        false,
+      );
 
       const participantActorType = getParticipantActorType({
         document,

--- a/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
+++ b/libs/shared/methodologies/bold/getters/src/document.getters.spec.ts
@@ -236,9 +236,7 @@ describe('Document getters', () => {
     it('should return undefined if the rules metadata event was not found', () => {
       const document = stubDocument(
         {
-          externalEvents: stubArray(() =>
-            stubDocumentEvent({ name: PICK_UP }),
-          ),
+          externalEvents: stubArray(() => stubDocumentEvent({ name: PICK_UP })),
         },
         false,
       );

--- a/libs/shared/methodologies/bold/testing/src/stubs/document.stubs.ts
+++ b/libs/shared/methodologies/bold/testing/src/stubs/document.stubs.ts
@@ -40,12 +40,12 @@ export const stubDocument = (
     updatedAt: faker.date.recent().toISOString(),
     ...partialDocument,
     externalEvents: [
+      ...externalEvents,
       ...(stubExternalEvents
         ? Array.from({ length: faker.number.int({ max: 3, min: 1 }) }, () =>
             stubDocumentEvent(),
           )
         : []),
-      ...externalEvents,
     ],
     primaryAddress: stubAddress(partialDocument?.primaryAddress),
     primaryParticipant: stubParticipant(partialDocument?.primaryParticipant),

--- a/libs/shared/rule/result/src/rule-result.helpers.spec.ts
+++ b/libs/shared/rule/result/src/rule-result.helpers.spec.ts
@@ -15,6 +15,21 @@ import {
   signRequest,
 } from './rule-result.helpers';
 
+const mockArtifactChecksum = jest.fn(() => faker.string.uuid());
+const mockSourceCodeUrl = jest.fn(() => faker.internet.url());
+const mockSourceCodeVersion = jest.fn(() => faker.string.uuid());
+const mockSmaugArn = jest.fn(() => faker.string.uuid());
+const mockAwsRegion = jest.fn(() => faker.string.uuid());
+
+jest.mock('@carrot-fndn/shared/env', () => ({
+  getArtifactChecksum: () => mockArtifactChecksum(),
+  getAwsRegion: () => mockAwsRegion(),
+  getOptionalEnv: jest.fn(),
+  getSmaugApiGatewayAssumeRoleArn: () => mockSmaugArn(),
+  getSourceCodeUrl: () => mockSourceCodeUrl(),
+  getSourceCodeVersion: () => mockSourceCodeVersion(),
+}));
+
 describe('mapToRuleOutput', () => {
   it('should map to RuleOutput without resultComment or resultContent', () => {
     const ruleInput = stubRuleInput();
@@ -55,26 +70,18 @@ describe('mapToRuleOutput', () => {
 });
 
 describe('mapRuleOutputToPostProcessInput', () => {
-  const environment = { ...process.env };
+  let artifactChecksum: string;
+  let sourceCodeUrl: string;
+  let sourceCodeVersion: string;
 
   beforeEach(() => {
-    process.env = { ...environment };
+    artifactChecksum = faker.string.uuid();
+    sourceCodeUrl = faker.internet.url();
+    sourceCodeVersion = faker.string.uuid();
+    mockArtifactChecksum.mockReturnValue(artifactChecksum);
+    mockSourceCodeUrl.mockReturnValue(sourceCodeUrl);
+    mockSourceCodeVersion.mockReturnValue(sourceCodeVersion);
   });
-
-  afterEach(() => {
-    process.env = environment;
-  });
-
-  it.each(['ARTIFACT_CHECKSUM', 'SOURCE_CODE_URL', 'SOURCE_CODE_VERSION'])(
-    'should throw error when variable %s is not set',
-    (variable) => {
-      const ruleOutput = stubRuleOutput();
-
-      delete process.env[variable];
-
-      expect(() => mapRuleOutputToPostProcessInput(ruleOutput)).toThrow();
-    },
-  );
 
   it('should return comment', () => {
     const resultComment = faker.lorem.sentence();
@@ -100,20 +107,29 @@ describe('mapRuleOutputToPostProcessInput', () => {
 });
 
 describe('reportRuleResults', () => {
-  const environment = { ...process.env };
+  const originalEnvironment = { ...process.env };
 
   beforeEach(() => {
+    const awsRegion = faker.string.uuid();
+    const smaugArn = faker.string.uuid();
+
+    mockArtifactChecksum.mockReturnValue(faker.string.uuid());
+    mockSourceCodeUrl.mockReturnValue(faker.internet.url());
+    mockSourceCodeVersion.mockReturnValue(faker.string.uuid());
+    mockSmaugArn.mockReturnValue(smaugArn);
+    mockAwsRegion.mockReturnValue(awsRegion);
+
     process.env = {
-      ...environment,
+      ...originalEnvironment,
       AWS_ACCESS_KEY_ID: faker.string.uuid(),
-      AWS_REGION: faker.string.uuid(),
+      AWS_REGION: awsRegion,
       AWS_SECRET_ACCESS_KEY: faker.string.uuid(),
-      SMAUG_API_GATEWAY_ASSUME_ROLE_ARN: faker.string.uuid(),
+      SMAUG_API_GATEWAY_ASSUME_ROLE_ARN: smaugArn,
     };
   });
 
   afterEach(() => {
-    process.env = environment;
+    process.env = originalEnvironment;
   });
 
   afterAll(() => {
@@ -148,11 +164,11 @@ describe('reportRuleResults', () => {
       ...request,
       body: JSON.stringify({
         output: {
-          artifactChecksum: process.env['ARTIFACT_CHECKSUM'],
+          artifactChecksum: mockArtifactChecksum(),
           comment: ruleOutput.resultComment,
           content: ruleOutput.resultContent,
-          sourceCodeUrl: process.env['SOURCE_CODE_URL'],
-          sourceCodeVersion: process.env['SOURCE_CODE_VERSION'],
+          sourceCodeUrl: mockSourceCodeUrl(),
+          sourceCodeVersion: mockSourceCodeVersion(),
           status: ruleOutput.resultStatus,
         },
         taskToken: ruleOutput.responseToken,
@@ -228,20 +244,26 @@ describe('reportRuleResults', () => {
 });
 
 describe('signRequest', () => {
-  const environment = { ...process.env };
+  const originalEnvironment = { ...process.env };
 
   beforeEach(() => {
+    const awsRegion = faker.string.uuid();
+    const smaugArn = faker.string.uuid();
+
+    mockSmaugArn.mockReturnValue(smaugArn);
+    mockAwsRegion.mockReturnValue(awsRegion);
+
     process.env = {
-      ...environment,
+      ...originalEnvironment,
       AWS_ACCESS_KEY_ID: faker.string.uuid(),
-      AWS_REGION: faker.string.uuid(),
+      AWS_REGION: awsRegion,
       AWS_SECRET_ACCESS_KEY: faker.string.uuid(),
-      SMAUG_API_GATEWAY_ASSUME_ROLE_ARN: faker.string.uuid(),
+      SMAUG_API_GATEWAY_ASSUME_ROLE_ARN: smaugArn,
     };
   });
 
   afterEach(() => {
-    process.env = environment;
+    process.env = originalEnvironment;
   });
 
   afterAll(() => {
@@ -340,20 +362,4 @@ describe('signRequest', () => {
 
     await expect(signRequest(input)).rejects.toThrow();
   });
-
-  it.each(['SMAUG_API_GATEWAY_ASSUME_ROLE_ARN', 'AWS_REGION'])(
-    'should throw error when %s is not found',
-    async (value) => {
-      const input = {
-        body: { [faker.string.sample()]: faker.string.sample() },
-        method: faker.internet.httpMethod(),
-        query: { [faker.string.sample()]: faker.string.sample() },
-        url: new URL(faker.internet.url()),
-      };
-
-      delete process.env[value];
-
-      await expect(signRequest(input)).rejects.toThrow();
-    },
-  );
 });

--- a/libs/shared/rule/result/src/rule-result.helpers.spec.ts
+++ b/libs/shared/rule/result/src/rule-result.helpers.spec.ts
@@ -108,14 +108,21 @@ describe('mapRuleOutputToPostProcessInput', () => {
 
 describe('reportRuleResults', () => {
   const originalEnvironment = { ...process.env };
+  let artifactChecksum: string;
+  let sourceCodeUrl: string;
+  let sourceCodeVersion: string;
 
   beforeEach(() => {
     const awsRegion = faker.string.uuid();
     const smaugArn = faker.string.uuid();
 
-    mockArtifactChecksum.mockReturnValue(faker.string.uuid());
-    mockSourceCodeUrl.mockReturnValue(faker.internet.url());
-    mockSourceCodeVersion.mockReturnValue(faker.string.uuid());
+    artifactChecksum = faker.string.uuid();
+    sourceCodeUrl = faker.internet.url();
+    sourceCodeVersion = faker.string.uuid();
+
+    mockArtifactChecksum.mockReturnValue(artifactChecksum);
+    mockSourceCodeUrl.mockReturnValue(sourceCodeUrl);
+    mockSourceCodeVersion.mockReturnValue(sourceCodeVersion);
     mockSmaugArn.mockReturnValue(smaugArn);
     mockAwsRegion.mockReturnValue(awsRegion);
 
@@ -164,11 +171,11 @@ describe('reportRuleResults', () => {
       ...request,
       body: JSON.stringify({
         output: {
-          artifactChecksum: mockArtifactChecksum(),
+          artifactChecksum,
           comment: ruleOutput.resultComment,
           content: ruleOutput.resultContent,
-          sourceCodeUrl: mockSourceCodeUrl(),
-          sourceCodeVersion: mockSourceCodeVersion(),
+          sourceCodeUrl,
+          sourceCodeVersion,
           status: ruleOutput.resultStatus,
         },
         taskToken: ruleOutput.responseToken,

--- a/libs/shared/rule/result/src/rule-result.helpers.ts
+++ b/libs/shared/rule/result/src/rule-result.helpers.ts
@@ -3,7 +3,14 @@ import type { AnyObject } from '@carrot-fndn/shared/types';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
 import { fromEnv } from '@aws-sdk/credential-providers';
-import { assertString, logger } from '@carrot-fndn/shared/helpers';
+import {
+  getArtifactChecksum,
+  getAwsRegion,
+  getSmaugApiGatewayAssumeRoleArn,
+  getSourceCodeUrl,
+  getSourceCodeVersion,
+} from '@carrot-fndn/shared/env';
+import { logger } from '@carrot-fndn/shared/helpers';
 import {
   type RuleInput,
   type RuleOutput,
@@ -30,11 +37,11 @@ export const mapRuleOutputToPostProcessInput = (
 ): PostProcessInput =>
   PostProcessInputSchema.parse({
     output: {
-      artifactChecksum: process.env['ARTIFACT_CHECKSUM'],
+      artifactChecksum: getArtifactChecksum(),
       comment: ruleOutput.resultComment,
       content: ruleOutput.resultContent,
-      sourceCodeUrl: process.env['SOURCE_CODE_URL'],
-      sourceCodeVersion: process.env['SOURCE_CODE_VERSION'],
+      sourceCodeUrl: getSourceCodeUrl(),
+      sourceCodeVersion: getSourceCodeVersion(),
       status: ruleOutput.resultStatus,
     },
     taskToken: ruleOutput.responseToken,
@@ -93,10 +100,8 @@ export const signRequest = async ({
   query?: Record<string, null | string | string[]>;
   url: URL;
 }) => {
-  const smaugApiGatewayAssumeRoleArn = assertString(
-    process.env['SMAUG_API_GATEWAY_ASSUME_ROLE_ARN'],
-  );
-  const smaugAwsRegion = assertString(process.env['AWS_REGION']);
+  const smaugApiGatewayAssumeRoleArn = getSmaugApiGatewayAssumeRoleArn();
+  const smaugAwsRegion = getAwsRegion();
 
   const credentials = await assumeRoleSmaugCredentials({
     assumeRoleArn: smaugApiGatewayAssumeRoleArn,

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -107,6 +107,7 @@
       "@carrot-fndn/shared/http-request": [
         "libs/shared/http-request/src/index.ts"
       ],
+      "@carrot-fndn/shared/env": ["libs/shared/env/src/index.ts"],
       "@carrot-fndn/shared/helpers": ["libs/shared/helpers/src/index.ts"],
       "@carrot-fndn/shared/aws-http": ["libs/shared/aws-http/src/index.ts"],
       "@carrot-fndn/shared/cloudwatch-metrics": [


### PR DESCRIPTION
## Summary
- Replace monolithic `getEnv()` (which validated **all** env vars at once via `EnvSchema.parse`) with specific typed helper functions (`getAwsRegion()`, `getSentryDsn()`, etc.) that validate only the needed variable
- Remove `env.ts`, `env.schema.ts`, `EnvSchema`, and `Env` type — all consumers now use the specific helpers
- Update all 10 consumer files and 9 test files to use the new pattern

## Motivation
Previously, every consumer of `getEnv()` required **all** environment variables to be set, even if it only needed one (e.g., `AWS_REGION`). This made testing harder and coupling tighter. The new approach validates only what each consumer actually needs.

## Test plan
- [x] `pnpm nx test shared-env` — all 36 env library tests pass
- [x] `pnpm test:affected` — all affected tests pass (3 pre-existing e2e/coverage failures unrelated to this change)
- [x] `pnpm lint:affected` — no lint errors
- [x] `pnpm ts:affected` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared environment helpers module with typed getters and project configs.

* **Refactor**
  * Centralized environment access across services (metrics, HTTP, lambda, docs, rules), simplifying configuration usage and enabling conditional Sentry initialization in production when a DSN is present.

* **Tests**
  * Tests updated to mock the new env helpers for deterministic behavior instead of mutating process.env.

* **Chores**
  * Added project, build, lint, and test configs and a path alias for the new env module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->