### PR TITLE
fix(script): remove devDependencies leak from production bundle

### DIFF
--- a/libs/shared/document/loader/src/index.ts
+++ b/libs/shared/document/loader/src/index.ts
@@ -2,4 +2,3 @@ export * from './cached-document-loader.service';
 export * from './document-loader.provider';
 export * from './document-loader.service';
 export * from './document-loader.types';
-export * from './document.stubs';

--- a/libs/shared/methodologies/bold/io-helpers/src/document-query.service.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document-query.service.spec.ts
@@ -1,8 +1,8 @@
 import {
   type DocumentEntity,
   provideDocumentLoaderService,
-  stubDocumentEntity,
 } from '@carrot-fndn/shared/document/loader';
+import { stubDocumentEntity } from '@carrot-fndn/shared/document/loader/stubs';
 import {
   stubDocument,
   stubDocumentEvent,

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
@@ -1,8 +1,8 @@
 import {
   type DocumentEntity,
   type DocumentLoaderService,
-  stubDocumentEntity,
 } from '@carrot-fndn/shared/document/loader';
+import { stubDocumentEntity } from '@carrot-fndn/shared/document/loader/stubs';
 import { stubDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
 import { faker } from '@faker-js/faker';

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -28,6 +28,23 @@ then
   exit 1
 fi
 
+# Validate bundle does not contain devDependencies
+LEAKED=$(node -p "
+  const buildPkg = require('./$BUILD_PATH/package.json');
+  const rootPkg = require('./package.json');
+  const prodDeps = Object.keys(buildPkg.dependencies || {});
+  Object.keys(rootPkg.devDependencies || {})
+    .filter(d => !prodDeps.includes(d))
+    .filter(d => require('fs').readFileSync('$BUILD_PATH/main.js','utf8').includes(d))
+    .join('\n')
+" 2>/dev/null)
+if [ -n "$LEAKED" ]; then
+  echo "Error: devDependencies leaked into bundle:"
+  echo "$LEAKED"
+  exit 1
+fi
+
+
 # Create the zip folder if it doesn't exist
 if ! mkdir -p "$ZIP_DIR"
 then

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -101,6 +101,9 @@
       "@carrot-fndn/shared/document/loader": [
         "libs/shared/document/loader/src/index.ts"
       ],
+       "@carrot-fndn/shared/document/loader/stubs": [
+        "libs/shared/document/loader/src/document.stubs.ts"
+      ],
       "@carrot-fndn/shared/document/seeds": [
         "libs/shared/document/seeds/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- Remove `@faker-js/faker` from Lambda production bundle by removing stubs re-export from the `document-loader` barrel file
- Add CI validation in `package-lambda.sh` to detect devDependencies inlined in bundles
- Create dedicated path alias `@carrot-fndn/shared/document/loader/stubs` for test imports

## Details

The `document-loader` barrel (`index.ts`) was re-exporting `document.stubs.ts`, which imports `@faker-js/faker`. Since webpack bundles all barrel exports, faker was inlined into every Lambda bundle, causing `Runtime.ImportModuleError` in production.

### Changes
- **`libs/shared/document/loader/src/index.ts`** — removed `export * from './document.stubs'`
- **`scripts/package-lambda.sh`** — added validation step that checks the built bundle for devDependencies
- **`tsconfig.paths.json`** — added `@carrot-fndn/shared/document/loader/stubs` path alias
- **2 spec files** — updated imports to use the new stubs path

---

- [x] I declare that I have self-reviewed this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added validation to prevent development dependencies from leaking into production bundles, ensuring cleaner and more secure deployments.
  * Optimized module exports and import paths for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->