### PR TITLE
refactor: replace RuleOutputStatus dot-notation with string literals

### DIFF
--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.processor.ts
@@ -23,7 +23,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { type NonZeroPositive } from '@carrot-fndn/shared/types';
 import BigNumber from 'bignumber.js';
@@ -160,11 +159,11 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
 
       const resultContent = calculateRewardsDistribution(ruleSubject);
 
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.PASSED, {
+      return mapToRuleOutput(ruleInput, 'PASSED', {
         resultContent,
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.errorProcessor.getResultCommentFromError(error),
       });
     }

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -550,7 +550,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     expectedActorsResult: expectedResults.singleCertificateStandard,
     expectedCertificateTotalValue: documents.massID1Value,
     massIDCertificateDocuments: documents.standard.massIDCertificateDocuments,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'single certificate with equal distribution',
     unitPrice: UNIT_PRICE_VALUE,
   },
@@ -560,7 +560,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     expectedCertificateTotalValue: documents.massID1Value,
     massIDCertificateDocuments:
       documents.multiHauler.massIDCertificateDocuments,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'single certificate with multiple HAULER participants',
     unitPrice: UNIT_PRICE_VALUE,
   },
@@ -570,7 +570,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     expectedCertificateTotalValue: documents.multipleCertificates.totalValue,
     massIDCertificateDocuments:
       documents.multipleCertificates.massIDCertificateDocuments,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'multiple certificates with the same participants',
     unitPrice: UNIT_PRICE_VALUE,
   },
@@ -619,7 +619,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
     creditOrderDocument: errorTestData.errorStubs.creditOrderDocument,
     massIDCertificateDocuments: [],
     resultComment: ERROR_MESSAGES.CERTIFICATE_DOCUMENT_NOT_FOUND(RECYCLED_ID),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `the ${RECYCLED_ID} documents is not found`,
   },
   {
@@ -628,7 +628,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
       ...errorTestData.errorStubs.massIDCertificateDocuments,
     ],
     resultComment: ERROR_MESSAGES.CREDIT_ORDER_DOCUMENT_NOT_FOUND,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `the ${CREDIT_ORDER} document is not found`,
   },
   {
@@ -637,7 +637,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
       ...errorTestData.errorStubs.massIDCertificateDocuments,
     ],
     resultComment: ERROR_MESSAGES.INVALID_CREDIT_UNIT_PRICE,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `the "${CREDIT_UNIT_PRICE}" attribute in the ${CREDIT_ORDER} document is invalid`,
   },
   {
@@ -649,7 +649,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
       ERROR_MESSAGES.REWARDS_DISTRIBUTION_RULE_RESULT_CONTENT_NOT_FOUND(
         errorTestData.errorStubs.massIDCertificateDocuments[0]!.id,
       ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `a certificate document has no "${RULE_RESULT_DETAILS}" attribute`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -26,7 +26,6 @@ import {
   RewardsDistributionActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyActorType } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
@@ -551,7 +550,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     expectedActorsResult: expectedResults.singleCertificateStandard,
     expectedCertificateTotalValue: documents.massID1Value,
     massIDCertificateDocuments: documents.standard.massIDCertificateDocuments,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'single certificate with equal distribution',
     unitPrice: UNIT_PRICE_VALUE,
   },
@@ -561,7 +560,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     expectedCertificateTotalValue: documents.massID1Value,
     massIDCertificateDocuments:
       documents.multiHauler.massIDCertificateDocuments,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'single certificate with multiple HAULER participants',
     unitPrice: UNIT_PRICE_VALUE,
   },
@@ -571,7 +570,7 @@ export const rewardsDistributionProcessorTestCases: TestCase[] = [
     expectedCertificateTotalValue: documents.multipleCertificates.totalValue,
     massIDCertificateDocuments:
       documents.multipleCertificates.massIDCertificateDocuments,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'multiple certificates with the same participants',
     unitPrice: UNIT_PRICE_VALUE,
   },
@@ -620,7 +619,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
     creditOrderDocument: errorTestData.errorStubs.creditOrderDocument,
     massIDCertificateDocuments: [],
     resultComment: ERROR_MESSAGES.CERTIFICATE_DOCUMENT_NOT_FOUND(RECYCLED_ID),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `the ${RECYCLED_ID} documents is not found`,
   },
   {
@@ -629,7 +628,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
       ...errorTestData.errorStubs.massIDCertificateDocuments,
     ],
     resultComment: ERROR_MESSAGES.CREDIT_ORDER_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `the ${CREDIT_ORDER} document is not found`,
   },
   {
@@ -638,7 +637,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
       ...errorTestData.errorStubs.massIDCertificateDocuments,
     ],
     resultComment: ERROR_MESSAGES.INVALID_CREDIT_UNIT_PRICE,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `the "${CREDIT_UNIT_PRICE}" attribute in the ${CREDIT_ORDER} document is invalid`,
   },
   {
@@ -650,7 +649,7 @@ export const rewardsDistributionProcessorErrors: ErrorTestCase[] = [
       ERROR_MESSAGES.REWARDS_DISTRIBUTION_RULE_RESULT_CONTENT_NOT_FOUND(
         errorTestData.errorStubs.massIDCertificateDocuments[0]!.id,
       ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `a certificate document has no "${RULE_RESULT_DETAILS}" attribute`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.ts
@@ -26,7 +26,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import BigNumber from 'bignumber.js';
 
@@ -132,14 +131,14 @@ export class RewardsDistributionProcessor extends RuleDataProcessor {
         wasteGeneratorVerificationDocument,
       });
 
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.PASSED, {
+      return mapToRuleOutput(ruleInput, 'PASSED', {
         resultContent: {
           massIDDocumentId: massIDDocument.id,
           massIDRewards: mapMassIDRewards(actorRewards),
         },
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.errorProcessor.getResultCommentFromError(error),
       });
     }

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -18,7 +18,6 @@ import {
   RewardsDistributionActorType,
   RewardsDistributionWasteType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { REWARDS_DISTRIBUTION_BY_WASTE_TYPE } from './rewards-distribution.constants';
 import { ERROR_MESSAGES } from './rewards-distribution.errors';
@@ -172,7 +171,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
         massIDPartialDocument: {
           subtype: wasteType,
         },
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
         scenario: `the massRewards is calculated successfully for ${wasteType} waste type and ${expectedRewards} rewards`,
       }),
     ),
@@ -188,7 +187,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       massIDPartialDocument: {
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is not present`,
     },
     {
@@ -202,7 +201,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       massIDPartialDocument: {
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `the rewards discount is applied if the origin is not identified and the ${HAULER} actor is present`,
     },
     {
@@ -211,7 +210,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       massIDPartialDocument: {
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `all rewards are applied for the ${REWARDS_DISTRIBUTION_BY_WASTE_TYPE['Food, Food Waste and Beverages']}`,
     },
     {
@@ -220,7 +219,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       massIDPartialDocument: {
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `Large Business discount is applied when Waste Generator Verification Document is missing (defaults to Large Business)`,
     },
     {
@@ -229,7 +228,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       massIDPartialDocument: {
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `Large Business discount is applied when Waste Generator Verification Document indicates Large Business`,
       wasteGeneratorVerificationDocument:
         createWasteGeneratorVerificationDocument(LARGE_BUSINESS),
@@ -243,7 +242,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       massIDPartialDocument: {
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `no discount is applied when Waste Generator Verification Document indicates Small Business`,
       wasteGeneratorVerificationDocument:
         createWasteGeneratorVerificationDocument(SMALL_BUSINESS),
@@ -268,14 +267,14 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
       documents: [],
       massIDAuditDocument,
       resultComment: ERROR_MESSAGES.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `${MASS_ID} document is not found`,
     },
     {
       documents: [massIDDocument],
       massIDAuditDocument,
       resultComment: ERROR_MESSAGES.METHODOLOGY_DOCUMENT_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `${METHODOLOGY} document is not found`,
     },
     {
@@ -292,7 +291,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
       resultComment: ERROR_MESSAGES.MISSING_REQUIRED_ACTORS(massIDDocument.id, [
         RewardsDistributionActorType.INTEGRATOR,
       ]),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `the ${MASS_ID} document does not have the required actors`,
     },
     {
@@ -305,7 +304,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
       ],
       massIDAuditDocument,
       resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `the ${METHODOLOGY} document does not have the required actors`,
     },
     {
@@ -320,7 +319,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
       resultComment: ERROR_MESSAGES.EXTERNAL_EVENTS_NOT_FOUND(
         massIDDocument.id,
       ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `the ${MASS_ID} document does not have external events`,
     },
     {
@@ -333,7 +332,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
       ],
       massIDAuditDocument,
       resultComment: ERROR_MESSAGES.UNEXPECTED_DOCUMENT_SUBTYPE('unknown'),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `the ${MASS_ID} document has an unexpected subtype`,
     },
     {
@@ -350,7 +349,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
       ],
       massIDAuditDocument,
       resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `the ${METHODOLOGY} document does not have the required address in actors`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.spec.ts
@@ -8,10 +8,7 @@ import {
   type DocumentEvent,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import {
-  type RuleOutput,
-  RuleOutputStatus,
-} from '@carrot-fndn/shared/rule/types';
+import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 import { differenceInDays, parseISO } from 'date-fns';
 
@@ -41,7 +38,7 @@ describe('CompostingCycleTimeframeProcessor', () => {
         );
 
         resultComment =
-          testCase.resultStatus === RuleOutputStatus.PASSED
+          testCase.resultStatus === 'PASSED'
             ? RESULT_COMMENTS.passed.TIMEFRAME_WITHIN_RANGE(difference)
             : RESULT_COMMENTS.failed.TIMEFRAME_OUT_OF_RANGE(difference);
       } else {

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.ts
@@ -30,14 +30,14 @@ export class CompostingCycleTimeframeProcessor extends ParentDocumentRuleProcess
     if (isNil(dropOffDate)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (isNil(recycledDate)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_RECYCLED_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.ts
@@ -8,7 +8,6 @@ import {
   type DocumentEvent,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { differenceInDays, parseISO } from 'date-fns';
 
 import { RESULT_COMMENTS } from './composting-cycle-timeframe.constants';
@@ -31,14 +30,14 @@ export class CompostingCycleTimeframeProcessor extends ParentDocumentRuleProcess
     if (isNil(dropOffDate)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (isNil(recycledDate)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_RECYCLED_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -48,13 +47,11 @@ export class CompostingCycleTimeframeProcessor extends ParentDocumentRuleProcess
     );
 
     const resultStatus =
-      difference >= 60 && difference <= 180
-        ? RuleOutputStatus.PASSED
-        : RuleOutputStatus.FAILED;
+      difference >= 60 && difference <= 180 ? 'PASSED' : 'FAILED';
 
     return {
       resultComment:
-        resultStatus === RuleOutputStatus.PASSED
+        resultStatus === 'PASSED'
           ? RESULT_COMMENTS.passed.TIMEFRAME_WITHIN_RANGE(difference)
           : RESULT_COMMENTS.failed.TIMEFRAME_OUT_OF_RANGE(difference),
       resultStatus,

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
@@ -1,7 +1,6 @@
 import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 interface CompostingCycleTimeframeTestCase extends Omit<
   RuleTestCase,
@@ -31,13 +30,13 @@ export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase
       recycledEventDate: RECYCLED_DATE_EARLIER,
       resultComment:
         'The composting cycle duration of 2 days is below the minimum accepted range of 60 days.',
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'Time interval is less than 60 days (2 days)',
     },
     {
       dropOffEventDate: undefined,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${DROP_OFF}" event date is missing`,
     },
     {
@@ -46,37 +45,37 @@ export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase
       recycledEventDate: RECYCLED_DATE_EARLIER,
       resultComment:
         'The composting cycle duration of 94 days is within the accepted range of 60 to 180 days.',
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'Time interval is within range (94 days)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_60_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'Edge case: Exactly 60 days (minimum allowed)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_180_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'Edge case: Exactly 180 days (maximum allowed)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_59_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'Edge case: 59 days (just below minimum)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_181_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'Edge case: 182 days (just above maximum)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_94_DAYS,
       recycledEventDate: undefined,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${RECYCLED}" event date is missing`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
@@ -30,13 +30,13 @@ export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase
       recycledEventDate: RECYCLED_DATE_EARLIER,
       resultComment:
         'The composting cycle duration of 2 days is below the minimum accepted range of 60 days.',
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'Time interval is less than 60 days (2 days)',
     },
     {
       dropOffEventDate: undefined,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${DROP_OFF}" event date is missing`,
     },
     {
@@ -45,37 +45,37 @@ export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase
       recycledEventDate: RECYCLED_DATE_EARLIER,
       resultComment:
         'The composting cycle duration of 94 days is within the accepted range of 60 to 180 days.',
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'Time interval is within range (94 days)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_60_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'Edge case: Exactly 60 days (minimum allowed)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_180_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'Edge case: Exactly 180 days (maximum allowed)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_59_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'Edge case: 59 days (just below minimum)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_181_DAYS,
       recycledEventDate: RECYCLED_DATE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'Edge case: 182 days (just above maximum)',
     },
     {
       dropOffEventDate: DROP_OFF_DATE_94_DAYS,
       recycledEventDate: undefined,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${RECYCLED}" event date is missing`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.ts
@@ -108,14 +108,14 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
     if (!isNonEmptyArray(ruleSubject.documentManifestEvents)) {
       return {
         resultComment: RESULT_COMMENTS.MISSING_EVENT(this.documentManifestType),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (isNil(ruleSubject.recyclerEvent)) {
       return {
         resultComment: RESULT_COMMENTS.MISSING_RECYCLER_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -135,7 +135,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
     if (allFailMessages.length > 0) {
       return {
         resultComment: allFailMessages.join(' '),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -167,7 +167,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
           failReasons: crossValidationResult.failReasons,
           ...(reviewReasons.length > 0 && { reviewReasons }),
         },
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -184,7 +184,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
           extractionMetadata,
           reviewReasons: crossValidationResult.reviewReasons,
         },
-        resultStatus: 'REVIEW_REQUIRED' as const,
+        resultStatus: 'REVIEW_REQUIRED',
       };
     }
 
@@ -194,7 +194,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
         crossValidation: crossValidationResult.crossValidation,
         extractionMetadata,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.processor.ts
@@ -24,7 +24,6 @@ import {
   DocumentEventName,
   ReportType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   type MethodologyDocumentEventAttachment,
   type MethodologyDocumentEventAttribute,
@@ -109,14 +108,14 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
     if (!isNonEmptyArray(ruleSubject.documentManifestEvents)) {
       return {
         resultComment: RESULT_COMMENTS.MISSING_EVENT(this.documentManifestType),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (isNil(ruleSubject.recyclerEvent)) {
       return {
         resultComment: RESULT_COMMENTS.MISSING_RECYCLER_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -136,7 +135,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
     if (allFailMessages.length > 0) {
       return {
         resultComment: allFailMessages.join(' '),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -168,7 +167,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
           failReasons: crossValidationResult.failReasons,
           ...(reviewReasons.length > 0 && { reviewReasons }),
         },
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -185,7 +184,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
           extractionMetadata,
           reviewReasons: crossValidationResult.reviewReasons,
         },
-        resultStatus: RuleOutputStatus.REVIEW_REQUIRED,
+        resultStatus: 'REVIEW_REQUIRED' as const,
       };
     }
 
@@ -195,7 +194,7 @@ export class DocumentManifestDataProcessor extends ParentDocumentRuleProcessor<R
         crossValidation: crossValidationResult.crossValidation,
         extractionMetadata,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
@@ -73,7 +73,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.MISSING_EVENT(documentManifestType),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document does not have a ${documentManifestType} event`,
   },
   ...[ISSUE_DATE, DOCUMENT_NUMBER, DOCUMENT_TYPE].map((attribute) => ({
@@ -89,7 +89,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: attributeErrorMessages[attribute]!,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a ${documentManifestType} event without a ${attribute}`,
   })),
   {
@@ -108,7 +108,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: `${RESULT_COMMENTS.MISSING_DOCUMENT_TYPE} ${RESULT_COMMENTS.MISSING_DOCUMENT_NUMBER}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a ${documentManifestType} event without a ${DOCUMENT_NUMBER} and ${DOCUMENT_TYPE}`,
   },
   {
@@ -129,7 +129,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     manifestExample: true,
     resultComment:
       RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL(documentManifestType),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a ${documentManifestType} event with a wrong attachment label`,
   },
   {
@@ -150,7 +150,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: RESULT_COMMENTS.INVALID_ISSUE_DATE_FORMAT(CUBIC_METER),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a ${documentManifestType} event ${ISSUE_DATE} with a wrong format`,
   },
   {
@@ -169,7 +169,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       }),
     },
     resultComment: RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE('EMITIARE'),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a ${documentManifestType} event ${DOCUMENT_TYPE} with a wrong format`,
   },
   {
@@ -192,7 +192,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED(
         documentManifestType,
       ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has an ${EXEMPTION_JUSTIFICATION} and an attachment`,
   },
   {
@@ -208,7 +208,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: RESULT_COMMENTS.MISSING_ATTRIBUTES(documentManifestType),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has no attachment and no ${EXEMPTION_JUSTIFICATION}`,
   },
   {
@@ -218,7 +218,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.MISSING_RECYCLER_EVENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has no ${RECYCLER} event`,
   },
   {
@@ -241,7 +241,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     manifestExample: true,
     resultComment:
       RESULT_COMMENTS.PROVIDE_EXEMPTION_JUSTIFICATION(documentManifestType),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The MassID document has a ${EXEMPTION_JUSTIFICATION} without attachment`,
   },
   {
@@ -277,7 +277,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       issueDate: '2025-03-20',
       value: 100,
     }),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The MassID document has a valid ${documentManifestType} event and attachment`,
   },
   {
@@ -341,7 +341,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       issueDate: '2025-03-18',
       value: 200,
     })}`,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The MassID document has two valid ${documentManifestType} events and attachments`,
   },
   {
@@ -362,7 +362,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     resultComment:
       RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED(TRANSPORT_MANIFEST),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has both a valid ${TRANSPORT_MANIFEST} attachment and ${EXEMPTION_JUSTIFICATION}`,
   },
 ];
@@ -395,7 +395,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: 'Document number mismatch',
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'Cross-validation finds mismatches in the document',
   },
   {
@@ -427,7 +427,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: 'Review required: Low confidence extraction',
-    resultStatus: 'REVIEW_REQUIRED' as const,
+    resultStatus: 'REVIEW_REQUIRED',
     scenario: 'Cross-validation requires review',
   },
   {
@@ -459,7 +459,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: 'The attachment pass message from extraction',
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'Cross-validation provides pass messages',
   },
   {
@@ -493,7 +493,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
     },
     resultComment:
       'Document number mismatch Review required: Low confidence extraction',
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario:
       'Cross-validation finds mismatches and also requires review for other fields',
   },
@@ -504,7 +504,7 @@ export const exceptionTestCases: DocumentManifestDataTestCase[] = [
     documentManifestType: RECYCLING_MANIFEST as DocumentManifestType,
     events: {},
     resultComment: RESULT_COMMENTS.ADDRESS_MISMATCH,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a ${RECYCLING_MANIFEST} event with a different address than the ${RECYCLER} event`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
@@ -11,7 +11,6 @@ import {
   DocumentEventAttributeName,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyDocumentEventAttributeFormat,
   MethodologyDocumentEventLabel,
@@ -74,7 +73,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.MISSING_EVENT(documentManifestType),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document does not have a ${documentManifestType} event`,
   },
   ...[ISSUE_DATE, DOCUMENT_NUMBER, DOCUMENT_TYPE].map((attribute) => ({
@@ -90,7 +89,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: attributeErrorMessages[attribute]!,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a ${documentManifestType} event without a ${attribute}`,
   })),
   {
@@ -109,7 +108,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: `${RESULT_COMMENTS.MISSING_DOCUMENT_TYPE} ${RESULT_COMMENTS.MISSING_DOCUMENT_NUMBER}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a ${documentManifestType} event without a ${DOCUMENT_NUMBER} and ${DOCUMENT_TYPE}`,
   },
   {
@@ -130,7 +129,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     manifestExample: true,
     resultComment:
       RESULT_COMMENTS.INCORRECT_ATTACHMENT_LABEL(documentManifestType),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a ${documentManifestType} event with a wrong attachment label`,
   },
   {
@@ -151,7 +150,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: RESULT_COMMENTS.INVALID_ISSUE_DATE_FORMAT(CUBIC_METER),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a ${documentManifestType} event ${ISSUE_DATE} with a wrong format`,
   },
   {
@@ -170,7 +169,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       }),
     },
     resultComment: RESULT_COMMENTS.INVALID_BR_DOCUMENT_TYPE('EMITIARE'),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a ${documentManifestType} event ${DOCUMENT_TYPE} with a wrong format`,
   },
   {
@@ -193,7 +192,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED(
         documentManifestType,
       ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has an ${EXEMPTION_JUSTIFICATION} and an attachment`,
   },
   {
@@ -209,7 +208,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: RESULT_COMMENTS.MISSING_ATTRIBUTES(documentManifestType),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has no attachment and no ${EXEMPTION_JUSTIFICATION}`,
   },
   {
@@ -219,7 +218,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.MISSING_RECYCLER_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has no ${RECYCLER} event`,
   },
   {
@@ -242,7 +241,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     manifestExample: true,
     resultComment:
       RESULT_COMMENTS.PROVIDE_EXEMPTION_JUSTIFICATION(documentManifestType),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The MassID document has a ${EXEMPTION_JUSTIFICATION} without attachment`,
   },
   {
@@ -278,7 +277,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       issueDate: '2025-03-20',
       value: 100,
     }),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The MassID document has a valid ${documentManifestType} event and attachment`,
   },
   {
@@ -342,7 +341,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
       issueDate: '2025-03-18',
       value: 200,
     })}`,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The MassID document has two valid ${documentManifestType} events and attachments`,
   },
   {
@@ -363,7 +362,7 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     },
     resultComment:
       RESULT_COMMENTS.ATTACHMENT_AND_JUSTIFICATION_PROVIDED(TRANSPORT_MANIFEST),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has both a valid ${TRANSPORT_MANIFEST} attachment and ${EXEMPTION_JUSTIFICATION}`,
   },
 ];
@@ -396,7 +395,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: 'Document number mismatch',
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'Cross-validation finds mismatches in the document',
   },
   {
@@ -428,7 +427,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: 'Review required: Low confidence extraction',
-    resultStatus: RuleOutputStatus.REVIEW_REQUIRED,
+    resultStatus: 'REVIEW_REQUIRED' as const,
     scenario: 'Cross-validation requires review',
   },
   {
@@ -460,7 +459,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
       ...defaultEvents,
     },
     resultComment: 'The attachment pass message from extraction',
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'Cross-validation provides pass messages',
   },
   {
@@ -494,7 +493,7 @@ export const crossValidationTestCases: DocumentManifestDataTestCase[] = [
     },
     resultComment:
       'Document number mismatch Review required: Low confidence extraction',
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario:
       'Cross-validation finds mismatches and also requires review for other fields',
   },
@@ -505,7 +504,7 @@ export const exceptionTestCases: DocumentManifestDataTestCase[] = [
     documentManifestType: RECYCLING_MANIFEST as DocumentManifestType,
     events: {},
     resultComment: RESULT_COMMENTS.ADDRESS_MISMATCH,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a ${RECYCLING_MANIFEST} event with a different address than the ${RECYCLER} event`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
@@ -49,14 +49,14 @@ export class DriverIdentificationProcessor extends ParentDocumentRuleProcessor<R
     if (vehicleType === SLUDGE_PIPES) {
       return {
         resultComment: RESULT_COMMENTS.passed.SLUDGE_PIPES,
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
     if (hasDriverId && hasJustification) {
       return {
         resultComment: RESULT_COMMENTS.failed.DRIVER_AND_JUSTIFICATION_PROVIDED,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -64,7 +64,7 @@ export class DriverIdentificationProcessor extends ParentDocumentRuleProcessor<R
       return {
         resultComment:
           RESULT_COMMENTS.failed.MISSING_JUSTIFICATION(vehicleTypeString),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -73,13 +73,13 @@ export class DriverIdentificationProcessor extends ParentDocumentRuleProcessor<R
         resultComment: RESULT_COMMENTS.passed.JUSTIFICATION_PROVIDED(
           String(driverIdentifierExemptionJustification),
         ),
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.DRIVER_IDENTIFIER,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.processor.ts
@@ -15,7 +15,6 @@ import {
   DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './driver-identification.constants';
 
@@ -50,14 +49,14 @@ export class DriverIdentificationProcessor extends ParentDocumentRuleProcessor<R
     if (vehicleType === SLUDGE_PIPES) {
       return {
         resultComment: RESULT_COMMENTS.passed.SLUDGE_PIPES,
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
     if (hasDriverId && hasJustification) {
       return {
         resultComment: RESULT_COMMENTS.failed.DRIVER_AND_JUSTIFICATION_PROVIDED,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -65,7 +64,7 @@ export class DriverIdentificationProcessor extends ParentDocumentRuleProcessor<R
       return {
         resultComment:
           RESULT_COMMENTS.failed.MISSING_JUSTIFICATION(vehicleTypeString),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -74,13 +73,13 @@ export class DriverIdentificationProcessor extends ParentDocumentRuleProcessor<R
         resultComment: RESULT_COMMENTS.passed.JUSTIFICATION_PROVIDED(
           String(driverIdentifierExemptionJustification),
         ),
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.DRIVER_IDENTIFIER,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
@@ -5,7 +5,6 @@ import {
   DocumentEventAttributeName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { faker } from '@faker-js/faker';
 
 import { RESULT_COMMENTS } from './driver-identification.constants';
@@ -35,7 +34,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.passed.DRIVER_IDENTIFIER,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${DRIVER_IDENTIFIER}" is provided`,
   },
   {
@@ -48,7 +47,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
     }),
     resultComment:
       RESULT_COMMENTS.passed.JUSTIFICATION_PROVIDED(someJustification),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${DRIVER_IDENTIFIER}" is not provided, but the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" is provided`,
   },
   {
@@ -61,7 +60,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.failed.MISSING_JUSTIFICATION(BOAT),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${DRIVER_IDENTIFIER}" is not provided and the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" is not provided`,
   },
   {
@@ -74,7 +73,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.passed.SLUDGE_PIPES,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The vehicle type is "${SLUDGE_PIPES}"`,
   },
   {
@@ -86,7 +85,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.failed.DRIVER_AND_JUSTIFICATION_PROVIDED,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `Both "${DRIVER_IDENTIFIER}" and "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" are provided`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/driver-identification.test-cases.ts
@@ -34,7 +34,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.passed.DRIVER_IDENTIFIER,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${DRIVER_IDENTIFIER}" is provided`,
   },
   {
@@ -47,7 +47,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
     }),
     resultComment:
       RESULT_COMMENTS.passed.JUSTIFICATION_PROVIDED(someJustification),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${DRIVER_IDENTIFIER}" is not provided, but the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" is provided`,
   },
   {
@@ -60,7 +60,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.failed.MISSING_JUSTIFICATION(BOAT),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${DRIVER_IDENTIFIER}" is not provided and the "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" is not provided`,
   },
   {
@@ -73,7 +73,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.passed.SLUDGE_PIPES,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The vehicle type is "${SLUDGE_PIPES}"`,
   },
   {
@@ -85,7 +85,7 @@ export const driverIdentificationTestCases: DriverIdentificationTestCase[] = [
       ],
     }),
     resultComment: RESULT_COMMENTS.failed.DRIVER_AND_JUSTIFICATION_PROVIDED,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `Both "${DRIVER_IDENTIFIER}" and "${DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION}" are provided`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.processor.ts
@@ -43,7 +43,7 @@ export class DropOffAtRecyclerProcessor extends ParentDocumentRuleProcessor<Rule
     if (isNil(lastDropOffEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -51,20 +51,20 @@ export class DropOffAtRecyclerProcessor extends ParentDocumentRuleProcessor<Rule
       return {
         resultComment:
           RESULT_COMMENTS.failed.MISSING_RECEIVING_OPERATOR_IDENTIFIER,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (lastDropOffEvent.address.id !== recyclerEvent?.address.id) {
       return {
         resultComment: RESULT_COMMENTS.failed.ADDRESS_MISMATCH,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.VALID_DROP_OFF,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.processor.ts
@@ -14,7 +14,6 @@ import {
   DocumentEventAttributeName,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   type MethodologyDocumentEventAttributeValue,
   MethodologyDocumentEventLabel,
@@ -44,7 +43,7 @@ export class DropOffAtRecyclerProcessor extends ParentDocumentRuleProcessor<Rule
     if (isNil(lastDropOffEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -52,20 +51,20 @@ export class DropOffAtRecyclerProcessor extends ParentDocumentRuleProcessor<Rule
       return {
         resultComment:
           RESULT_COMMENTS.failed.MISSING_RECEIVING_OPERATOR_IDENTIFIER,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (lastDropOffEvent.address.id !== recyclerEvent?.address.id) {
       return {
         resultComment: RESULT_COMMENTS.failed.ADDRESS_MISMATCH,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.VALID_DROP_OFF,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
@@ -28,7 +28,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
     events: { [DROP_OFF]: undefined },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has no "${DROP_OFF}" event`,
   },
   {
@@ -39,7 +39,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
     },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.MISSING_RECEIVING_OPERATOR_IDENTIFIER,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a "${DROP_OFF}" event but no "${RECEIVING_OPERATOR_IDENTIFIER}" attribute`,
   },
   {
@@ -47,7 +47,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
       [DROP_OFF]: stubBoldMassIDDropOffEvent(),
     },
     resultComment: RESULT_COMMENTS.failed.ADDRESS_MISMATCH,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has a "${DROP_OFF}" event, but the "${RECYCLER}" event address does not match the "${DROP_OFF}" event address`,
   },
   {
@@ -66,7 +66,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
     manifestExample: true,
     manifestFields: { addressFields: ['latitude', 'longitude'] },
     resultComment: RESULT_COMMENTS.passed.VALID_DROP_OFF,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The MassID document has a "${DROP_OFF}" event and a "${RECYCLER}" event, and the "${DROP_OFF}" event address matches the "${RECYCLER}" event address`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/drop-off-at-recycler.test-cases.ts
@@ -9,7 +9,6 @@ import {
   DocumentEventAttributeName,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './drop-off-at-recycler.constants';
@@ -29,7 +28,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
     events: { [DROP_OFF]: undefined },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has no "${DROP_OFF}" event`,
   },
   {
@@ -40,7 +39,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
     },
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.MISSING_RECEIVING_OPERATOR_IDENTIFIER,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a "${DROP_OFF}" event but no "${RECEIVING_OPERATOR_IDENTIFIER}" attribute`,
   },
   {
@@ -48,7 +47,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
       [DROP_OFF]: stubBoldMassIDDropOffEvent(),
     },
     resultComment: RESULT_COMMENTS.failed.ADDRESS_MISMATCH,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has a "${DROP_OFF}" event, but the "${RECYCLER}" event address does not match the "${DROP_OFF}" event address`,
   },
   {
@@ -67,7 +66,7 @@ export const dropOffAtRecyclerTestCases: DropOffAtRecyclerTestCase[] = [
     manifestExample: true,
     manifestFields: { addressFields: ['latitude', 'longitude'] },
     resultComment: RESULT_COMMENTS.passed.VALID_DROP_OFF,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The MassID document has a "${DROP_OFF}" event and a "${RECYCLER}" event, and the "${DROP_OFF}" event address matches the "${RECYCLER}" event address`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
@@ -35,7 +35,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 
 import {
@@ -100,7 +99,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
         resultComment: getOrUndefined(resultComment),
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.processorErrors.getResultCommentFromError(error),
       });
     }
@@ -129,7 +128,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
     const allResults = [...actorResults.values()].flat();
 
     const passed = allResults.every(
-      (result) => result.resultStatus === RuleOutputStatus.PASSED,
+      (result) => result.resultStatus === 'PASSED',
     );
 
     const resultComment = allResults
@@ -138,7 +137,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
 
     return {
       resultComment,
-      resultStatus: passed ? RuleOutputStatus.PASSED : RuleOutputStatus.FAILED,
+      resultStatus: passed ? 'PASSED' : 'FAILED',
     };
   }
 
@@ -257,7 +256,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
           {
             resultComment:
               RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(actorType),
-            resultStatus: RuleOutputStatus.PASSED,
+            resultStatus: 'PASSED' as const,
           },
         ];
       }
@@ -268,7 +267,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
         {
           resultComment:
             RESULT_COMMENTS.failed.MISSING_ACCREDITATION_ADDRESS(actorType),
-          resultStatus: RuleOutputStatus.FAILED,
+          resultStatus: 'FAILED' as const,
         },
       ];
     }
@@ -285,7 +284,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
             actorType,
             addressDistance,
           ),
-          resultStatus: RuleOutputStatus.FAILED,
+          resultStatus: 'FAILED' as const,
         },
       ];
     }
@@ -307,7 +306,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
               actorType,
               addressDistance,
             ),
-            resultStatus: RuleOutputStatus.PASSED,
+            resultStatus: 'PASSED' as const,
           },
         ];
       }
@@ -326,7 +325,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
               actorType,
               gpsDistance,
             ),
-            resultStatus: RuleOutputStatus.FAILED,
+            resultStatus: 'FAILED' as const,
           },
         ];
       }
@@ -338,7 +337,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
             addressDistance,
             gpsDistance,
           ),
-          resultStatus: RuleOutputStatus.PASSED,
+          resultStatus: 'PASSED' as const,
         },
       ];
     }
@@ -349,7 +348,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
           actorType,
           addressDistance,
         ),
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       },
     ];
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
@@ -256,7 +256,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
           {
             resultComment:
               RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(actorType),
-            resultStatus: 'PASSED' as const,
+            resultStatus: 'PASSED',
           },
         ];
       }
@@ -267,7 +267,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
         {
           resultComment:
             RESULT_COMMENTS.failed.MISSING_ACCREDITATION_ADDRESS(actorType),
-          resultStatus: 'FAILED' as const,
+          resultStatus: 'FAILED',
         },
       ];
     }
@@ -284,7 +284,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
             actorType,
             addressDistance,
           ),
-          resultStatus: 'FAILED' as const,
+          resultStatus: 'FAILED',
         },
       ];
     }
@@ -306,7 +306,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
               actorType,
               addressDistance,
             ),
-            resultStatus: 'PASSED' as const,
+            resultStatus: 'PASSED',
           },
         ];
       }
@@ -325,7 +325,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
               actorType,
               gpsDistance,
             ),
-            resultStatus: 'FAILED' as const,
+            resultStatus: 'FAILED',
           },
         ];
       }
@@ -337,7 +337,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
             addressDistance,
             gpsDistance,
           ),
-          resultStatus: 'PASSED' as const,
+          resultStatus: 'PASSED',
         },
       ];
     }
@@ -348,7 +348,7 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
           actorType,
           addressDistance,
         ),
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       },
     ];
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -21,7 +21,6 @@ import {
   DocumentEventName,
   MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyApprovedExceptionType,
   type MethodologyParticipant,
@@ -380,7 +379,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
       ]),
       actorParticipants,
       resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.failed.MISSING_ACCREDITATION_ADDRESS(RECYCLER)}`,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The accredited address is not set',
     },
     {
@@ -409,7 +408,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITH_GPS(WASTE_GENERATOR, manifestNearbyWasteGeneratorAddressDistance, manifestNearbyWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS(RECYCLER, manifestNearbyRecyclerAddressDistance, manifestNearbyRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `The GPS is set and both GPS coordinates and event address are valid and within the ${MAX_ALLOWED_DISTANCE} m radius`,
     },
     {
@@ -438,7 +437,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(WASTE_GENERATOR, manifestInvalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, manifestInvalidRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The address is valid but the GPS geolocation is invalid',
     },
     {
@@ -459,7 +458,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: RESULT_COMMENTS.failed.INVALID_ACTOR_TYPE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The processor cannot extract the actor type',
     },
     {
@@ -484,7 +483,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The GPS is not set, but the accredited address is set and is valid',
     },
@@ -508,7 +507,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The GPS is not set, but the accredited address is set and not valid',
     },
@@ -548,7 +547,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The Waste Generator verification document is missing (should pass, not fail)',
     },
@@ -590,7 +589,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped for Recycler on DROP_OFF)',
     },
@@ -632,7 +631,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped)',
     },
@@ -676,7 +675,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The Recycler has only latitude GPS exception (should NOT skip GPS validation)',
     },
@@ -721,7 +720,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The Recycler has expired GPS exceptions (should NOT skip GPS validation)',
     },
@@ -754,7 +753,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
       ],
       massIDAuditDocument,
       resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID document does not exist',
     },
     {
@@ -768,7 +767,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
         errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_REQUIRED_EVENTS(
           massIDDocument.id,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The MassID document does not contain a DROP_OFF or PICK_UP event',
     },
@@ -778,7 +777,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
       resultComment:
         errorMessage.ERROR_MESSAGE
           .PARTICIPANT_ACCREDITATION_DOCUMENTS_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The accreditation documents were not found',
     },
     {
@@ -786,7 +785,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
       massIDAuditDocument: undefined,
       resultComment:
         errorMessage.ERROR_MESSAGE.MASS_ID_AUDIT_DOCUMENT_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID Audit document does not exist',
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -379,7 +379,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
       ]),
       actorParticipants,
       resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.failed.MISSING_ACCREDITATION_ADDRESS(RECYCLER)}`,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The accredited address is not set',
     },
     {
@@ -408,7 +408,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITH_GPS(WASTE_GENERATOR, manifestNearbyWasteGeneratorAddressDistance, manifestNearbyWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS(RECYCLER, manifestNearbyRecyclerAddressDistance, manifestNearbyRecyclerAddressDistance)}`,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: `The GPS is set and both GPS coordinates and event address are valid and within the ${MAX_ALLOWED_DISTANCE} m radius`,
     },
     {
@@ -437,7 +437,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(WASTE_GENERATOR, manifestInvalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, manifestInvalidRecyclerAddressDistance)}`,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The address is valid but the GPS geolocation is invalid',
     },
     {
@@ -458,7 +458,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: RESULT_COMMENTS.failed.INVALID_ACTOR_TYPE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The processor cannot extract the actor type',
     },
     {
@@ -483,7 +483,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The GPS is not set, but the accredited address is set and is valid',
     },
@@ -507,7 +507,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(WASTE_GENERATOR, invalidWasteGeneratorAddressDistance)} ${RESULT_COMMENTS.failed.INVALID_ADDRESS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The GPS is not set, but the accredited address is set and not valid',
     },
@@ -547,7 +547,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.OPTIONAL_VALIDATION_SKIPPED(WASTE_GENERATOR)} ${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(RECYCLER, 0)}`,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The Waste Generator verification document is missing (should pass, not fail)',
     },
@@ -589,7 +589,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped for Recycler on DROP_OFF)',
     },
@@ -631,7 +631,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.passed.PASSED_WITH_GPS_EXCEPTION(RECYCLER, nearbyRecyclerAddressDistance)}`,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The Recycler has GPS exceptions for DROP_OFF event (GPS validation should be skipped)',
     },
@@ -675,7 +675,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The Recycler has only latitude GPS exception (should NOT skip GPS validation)',
     },
@@ -720,7 +720,7 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
         },
       },
       resultComment: `${RESULT_COMMENTS.passed.PASSED_WITHOUT_GPS(WASTE_GENERATOR, 0)} ${RESULT_COMMENTS.failed.INVALID_GPS_DISTANCE(RECYCLER, invalidRecyclerAddressDistance)}`,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The Recycler has expired GPS exceptions (should NOT skip GPS validation)',
     },
@@ -753,7 +753,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
       ],
       massIDAuditDocument,
       resultComment: errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID document does not exist',
     },
     {
@@ -767,7 +767,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
         errorMessage.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_REQUIRED_EVENTS(
           massIDDocument.id,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The MassID document does not contain a DROP_OFF or PICK_UP event',
     },
@@ -777,7 +777,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
       resultComment:
         errorMessage.ERROR_MESSAGE
           .PARTICIPANT_ACCREDITATION_DOCUMENTS_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The accreditation documents were not found',
     },
     {
@@ -785,7 +785,7 @@ export const geolocationAndAddressPrecisionErrorTestCases: GeolocationAndAddress
       massIDAuditDocument: undefined,
       resultComment:
         errorMessage.ERROR_MESSAGE.MASS_ID_AUDIT_DOCUMENT_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID Audit document does not exist',
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.processor.ts
@@ -42,14 +42,14 @@ export class HaulerIdentificationProcessor extends ParentDocumentRuleProcessor<S
     if (isNil(pickUpEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.PICK_UP_EVENT_MISSING,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (!isNil(haulerEvent)) {
       return {
         resultComment: RESULT_COMMENTS.passed.HAULER_EVENT_FOUND,
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
@@ -66,7 +66,7 @@ export class HaulerIdentificationProcessor extends ParentDocumentRuleProcessor<S
         resultComment: RESULT_COMMENTS.passed.HAULER_NOT_REQUIRED(
           vehicleType as string,
         ),
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
@@ -74,7 +74,7 @@ export class HaulerIdentificationProcessor extends ParentDocumentRuleProcessor<S
       resultComment: RESULT_COMMENTS.failed.HAULER_EVENT_MISSING(
         vehicleType as string,
       ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.processor.ts
@@ -16,7 +16,6 @@ import {
   DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './hauler-identification.constants';
@@ -43,14 +42,14 @@ export class HaulerIdentificationProcessor extends ParentDocumentRuleProcessor<S
     if (isNil(pickUpEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.PICK_UP_EVENT_MISSING,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (!isNil(haulerEvent)) {
       return {
         resultComment: RESULT_COMMENTS.passed.HAULER_EVENT_FOUND,
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
@@ -67,7 +66,7 @@ export class HaulerIdentificationProcessor extends ParentDocumentRuleProcessor<S
         resultComment: RESULT_COMMENTS.passed.HAULER_NOT_REQUIRED(
           vehicleType as string,
         ),
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
@@ -75,7 +74,7 @@ export class HaulerIdentificationProcessor extends ParentDocumentRuleProcessor<S
       resultComment: RESULT_COMMENTS.failed.HAULER_EVENT_MISSING(
         vehicleType as string,
       ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
@@ -42,7 +42,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
     ]),
     manifestExample: true,
     resultComment: RESULT_COMMENTS.passed.HAULER_EVENT_FOUND,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${VEHICLE_TYPE}" attribute is set with a vehicle type that is not ${OPTIONAL_HAULER_VEHICLE_TYPES.join(
       ', ',
     )} and the "${HAULER}" actor event exists`,
@@ -59,7 +59,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
     ]),
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.HAULER_EVENT_MISSING(TRUCK),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_TYPE}" attribute is set with a vehicle type that is not ${OPTIONAL_HAULER_VEHICLE_TYPES.join(
       ', ',
     )} and the "${HAULER}" actor event does not exist`,
@@ -78,7 +78,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
     resultComment: RESULT_COMMENTS.passed.HAULER_NOT_REQUIRED(
       DocumentEventVehicleType.CART,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${VEHICLE_TYPE}" attribute is set with a vehicle type that is ${OPTIONAL_HAULER_VEHICLE_TYPES.join(
       ', ',
     )} and the "${HAULER}" actor event does not exist`,
@@ -95,7 +95,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
       [PICK_UP, undefined],
     ]),
     resultComment: RESULT_COMMENTS.failed.PICK_UP_EVENT_MISSING,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${PICK_UP}" event is missing`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/src/hauler-identification.test-cases.ts
@@ -9,7 +9,6 @@ import {
   DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './hauler-identification.constants';
@@ -43,7 +42,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
     ]),
     manifestExample: true,
     resultComment: RESULT_COMMENTS.passed.HAULER_EVENT_FOUND,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is set with a vehicle type that is not ${OPTIONAL_HAULER_VEHICLE_TYPES.join(
       ', ',
     )} and the "${HAULER}" actor event exists`,
@@ -60,7 +59,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
     ]),
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.HAULER_EVENT_MISSING(TRUCK),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is set with a vehicle type that is not ${OPTIONAL_HAULER_VEHICLE_TYPES.join(
       ', ',
     )} and the "${HAULER}" actor event does not exist`,
@@ -79,7 +78,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
     resultComment: RESULT_COMMENTS.passed.HAULER_NOT_REQUIRED(
       DocumentEventVehicleType.CART,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is set with a vehicle type that is ${OPTIONAL_HAULER_VEHICLE_TYPES.join(
       ', ',
     )} and the "${HAULER}" actor event does not exist`,
@@ -96,7 +95,7 @@ export const haulerIdentificationTestCases: HaulerIdentificationTestCase[] = [
       [PICK_UP, undefined],
     ]),
     resultComment: RESULT_COMMENTS.failed.PICK_UP_EVENT_MISSING,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${PICK_UP}" event is missing`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.spec.ts
@@ -4,7 +4,7 @@ import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers'
 import { MassIDOrganicSubtype } from '@carrot-fndn/shared/methodologies/bold/types';
 import {
   type RuleOutput,
-  RuleOutputStatus,
+  type RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { stubEnumValue, stubRuleInput } from '@carrot-fndn/shared/testing';
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.ts
@@ -9,7 +9,6 @@ import {
   MassIDOrganicSubtype,
   MeasurementUnit,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './mass-id-qualifications.constants';
 import { MassIDQualificationsProcessorErrors } from './mass-id-qualifications.errors';
@@ -76,7 +75,7 @@ export class MassIDQualificationsProcessor extends ParentDocumentRuleProcessor<D
       resultComment: isValid
         ? RESULT_COMMENTS.passed.VALID_QUALIFICATIONS
         : errorMessages.join(' '),
-      resultStatus: isValid ? RuleOutputStatus.PASSED : RuleOutputStatus.FAILED,
+      resultStatus: isValid ? 'PASSED' : 'FAILED',
     };
   }
 
@@ -99,7 +98,7 @@ export class MassIDQualificationsProcessor extends ParentDocumentRuleProcessor<D
       return {
         resultComment:
           this.processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -107,7 +106,7 @@ export class MassIDQualificationsProcessor extends ParentDocumentRuleProcessor<D
       return {
         resultComment:
           this.processorErrors.ERROR_MESSAGE.DOCUMENT_SUBTYPE_NOT_FOUND,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.processor.ts
@@ -98,7 +98,7 @@ export class MassIDQualificationsProcessor extends ParentDocumentRuleProcessor<D
       return {
         resultComment:
           this.processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -106,7 +106,7 @@ export class MassIDQualificationsProcessor extends ParentDocumentRuleProcessor<D
       return {
         resultComment:
           this.processorErrors.ERROR_MESSAGE.DOCUMENT_SUBTYPE_NOT_FOUND,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
@@ -22,7 +22,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     manifestFields: { includeCurrentValue: true },
     massIDDocument: massIDStubs.massIDDocument,
     resultComment: RESULT_COMMENTS.passed.VALID_QUALIFICATIONS,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'All the criteria are met',
   },
   {
@@ -33,7 +33,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       category: 'INVALID_CATEGORY',
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_CATEGORY('INVALID_CATEGORY'),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The category does not match',
   },
   {
@@ -44,7 +44,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       type: 'INVALID_TYPE',
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_TYPE('INVALID_TYPE'),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The type is not ORGANIC',
   },
   {
@@ -56,7 +56,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     },
     resultComment:
       RESULT_COMMENTS.failed.INVALID_MEASUREMENT_UNIT('INVALID_UNIT'),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The measurement unit is not "kg"',
   },
   {
@@ -67,7 +67,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       currentValue: 0,
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_VALUE(0),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The current value is not greater than 0',
   },
   {
@@ -78,7 +78,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       subtype: 'Invalid Subtype',
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_SUBTYPE('Invalid Subtype'),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The subtype is defined but not in the allowed list',
   },
   {
@@ -86,7 +86,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     manifestFields: { includeCurrentValue: true },
     massIDDocument: { ...massIDStubs.massIDDocument, type: undefined },
     resultComment: processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The document type was not found',
   },
   {
@@ -94,7 +94,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     manifestFields: { includeCurrentValue: true },
     massIDDocument: { ...massIDStubs.massIDDocument, subtype: undefined },
     resultComment: processorErrors.ERROR_MESSAGE.DOCUMENT_SUBTYPE_NOT_FOUND,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The document subtype was not found',
   },
   {
@@ -107,7 +107,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       RESULT_COMMENTS.failed.INVALID_TYPE('INVALID_TYPE'),
       RESULT_COMMENTS.failed.INVALID_SUBTYPE('INVALID_SUBTYPE'),
     ].join(' '),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'Multiple errors were found',
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/src/mass-id-qualifications.test-cases.ts
@@ -2,7 +2,6 @@ import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './mass-id-qualifications.constants';
 import { MassIDQualificationsProcessorErrors } from './mass-id-qualifications.errors';
@@ -23,7 +22,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     manifestFields: { includeCurrentValue: true },
     massIDDocument: massIDStubs.massIDDocument,
     resultComment: RESULT_COMMENTS.passed.VALID_QUALIFICATIONS,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'All the criteria are met',
   },
   {
@@ -34,7 +33,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       category: 'INVALID_CATEGORY',
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_CATEGORY('INVALID_CATEGORY'),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The category does not match',
   },
   {
@@ -45,7 +44,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       type: 'INVALID_TYPE',
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_TYPE('INVALID_TYPE'),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The type is not ORGANIC',
   },
   {
@@ -57,7 +56,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     },
     resultComment:
       RESULT_COMMENTS.failed.INVALID_MEASUREMENT_UNIT('INVALID_UNIT'),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The measurement unit is not "kg"',
   },
   {
@@ -68,7 +67,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       currentValue: 0,
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_VALUE(0),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The current value is not greater than 0',
   },
   {
@@ -79,7 +78,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       subtype: 'Invalid Subtype',
     },
     resultComment: RESULT_COMMENTS.failed.INVALID_SUBTYPE('Invalid Subtype'),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The subtype is defined but not in the allowed list',
   },
   {
@@ -87,7 +86,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     manifestFields: { includeCurrentValue: true },
     massIDDocument: { ...massIDStubs.massIDDocument, type: undefined },
     resultComment: processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The document type was not found',
   },
   {
@@ -95,7 +94,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
     manifestFields: { includeCurrentValue: true },
     massIDDocument: { ...massIDStubs.massIDDocument, subtype: undefined },
     resultComment: processorErrors.ERROR_MESSAGE.DOCUMENT_SUBTYPE_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The document subtype was not found',
   },
   {
@@ -108,7 +107,7 @@ export const massIDQualificationsTestCases: MassIDQualificationsTestCase[] = [
       RESULT_COMMENTS.failed.INVALID_TYPE('INVALID_TYPE'),
       RESULT_COMMENTS.failed.INVALID_SUBTYPE('INVALID_SUBTYPE'),
     ].join(' '),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'Multiple errors were found',
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -95,7 +95,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
     if (!isNonEmptyString(sortingData.sortingDescription)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_SORTING_DESCRIPTION,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -111,7 +111,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
           sortingData.deductedWeight,
           Number(expectedDeducted.toFixed(3)),
         ),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -124,7 +124,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
           sortingData.grossWeight,
           sortingData.valueBeforeSorting,
         ),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -137,7 +137,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
           sortingData.documentCurrentValue,
           sortingData.valueAfterSorting,
         ),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -146,7 +146,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
         resultComment: RESULT_COMMENTS.failed.SORTING_VALUE_EXCEEDS_TOLERANCE(
           sortingData.sortingValueCalculationDifference,
         ),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -154,7 +154,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
       resultComment: RESULT_COMMENTS.passed.SORTING_VALUE_WITHIN_TOLERANCE(
         sortingData.sortingValueCalculationDifference,
       ),
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.processor.ts
@@ -26,7 +26,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { type MethodologyDocumentEventAttributeValue } from '@carrot-fndn/shared/types';
 
@@ -86,7 +85,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
         resultComment: getOrUndefined(resultComment),
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.processorErrors.getResultCommentFromError(error),
       });
     }
@@ -96,7 +95,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
     if (!isNonEmptyString(sortingData.sortingDescription)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_SORTING_DESCRIPTION,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -112,7 +111,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
           sortingData.deductedWeight,
           Number(expectedDeducted.toFixed(3)),
         ),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -125,7 +124,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
           sortingData.grossWeight,
           sortingData.valueBeforeSorting,
         ),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -138,7 +137,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
           sortingData.documentCurrentValue,
           sortingData.valueAfterSorting,
         ),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -147,7 +146,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
         resultComment: RESULT_COMMENTS.failed.SORTING_VALUE_EXCEEDS_TOLERANCE(
           sortingData.sortingValueCalculationDifference,
         ),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -155,7 +154,7 @@ export class MassIDSortingProcessor extends RuleDataProcessor {
       resultComment: RESULT_COMMENTS.passed.SORTING_VALUE_WITHIN_TOLERANCE(
         sortingData.sortingValueCalculationDifference,
       ),
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -20,7 +20,6 @@ import {
   DocumentEventName,
   MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyDocumentEventAttributeFormat,
   MethodologyDocumentEventLabel,
@@ -136,7 +135,7 @@ const createErrorTestCase = (
   documents,
   massIDAuditDocument,
   resultComment,
-  resultStatus: RuleOutputStatus.FAILED,
+  resultStatus: 'FAILED' as const,
   scenario,
 });
 
@@ -248,7 +247,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       currentValue: calculatedSortingValue,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_SORTING_DESCRIPTION,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The sorting description is missing',
   },
   {
@@ -269,7 +268,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       currentValue: MANIFEST_SORTING_VALUE,
     },
     resultComment: RESULT_COMMENTS.passed.SORTING_VALUE_WITHIN_TOLERANCE(0),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario:
       'The sorting value calculation difference is less or equal to 0.1',
   },
@@ -291,7 +290,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       calculatedSortingValue + 1,
       calculatedSortingValue,
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario:
       'The document current value does not match the sorting event value',
   },
@@ -309,7 +308,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     resultComment: RESULT_COMMENTS.failed.SORTING_VALUE_EXCEEDS_TOLERANCE(
       Math.abs(calculatedSortingValue - wrongSortingValue),
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The sorting value calculation difference is greater than 0.1',
   },
   {
@@ -330,7 +329,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       mismatchedDeductedWeight,
       Number((grossWeight * sortingFactor).toFixed(3)),
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario:
       'The deducted weight does not match the expected value based on sorting factor',
   },
@@ -351,7 +350,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       grossWeight + 0.2,
       valueBeforeSorting,
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The gross weight does not match the previous event value',
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -135,7 +135,7 @@ const createErrorTestCase = (
   documents,
   massIDAuditDocument,
   resultComment,
-  resultStatus: 'FAILED' as const,
+  resultStatus: 'FAILED',
   scenario,
 });
 
@@ -247,7 +247,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       currentValue: calculatedSortingValue,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_SORTING_DESCRIPTION,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The sorting description is missing',
   },
   {
@@ -268,7 +268,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       currentValue: MANIFEST_SORTING_VALUE,
     },
     resultComment: RESULT_COMMENTS.passed.SORTING_VALUE_WITHIN_TOLERANCE(0),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario:
       'The sorting value calculation difference is less or equal to 0.1',
   },
@@ -290,7 +290,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       calculatedSortingValue + 1,
       calculatedSortingValue,
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario:
       'The document current value does not match the sorting event value',
   },
@@ -308,7 +308,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     resultComment: RESULT_COMMENTS.failed.SORTING_VALUE_EXCEEDS_TOLERANCE(
       Math.abs(calculatedSortingValue - wrongSortingValue),
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The sorting value calculation difference is greater than 0.1',
   },
   {
@@ -329,7 +329,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       mismatchedDeductedWeight,
       Number((grossWeight * sortingFactor).toFixed(3)),
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario:
       'The deducted weight does not match the expected value based on sorting factor',
   },
@@ -350,7 +350,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       grossWeight + 0.2,
       valueBeforeSorting,
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The gross weight does not match the previous event value',
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.helpers.ts
@@ -6,7 +6,6 @@ import type {
 import { getOrDefault } from '@carrot-fndn/shared/helpers';
 import { eventHasMetadataAttribute } from '@carrot-fndn/shared/methodologies/bold/predicates';
 import { DocumentEventAttributeName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentStatus } from '@carrot-fndn/shared/types';
 
 const { CANCELLED } = MethodologyDocumentStatus;
@@ -28,7 +27,7 @@ const isMassIDAuditPassed = (document: Document): boolean =>
     eventHasMetadataAttribute({
       event,
       metadataName: DocumentEventAttributeName.EVALUATION_RESULT,
-      metadataValues: RuleOutputStatus.PASSED,
+      metadataValues: 'PASSED',
     }),
   );
 

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
@@ -21,7 +21,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { type NonEmptyString } from '@carrot-fndn/shared/types';
 
@@ -72,7 +71,7 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
         resultComment: getOrUndefined(resultComment),
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.errorProcessor.getResultCommentFromError(error),
       });
     }
@@ -127,7 +126,7 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
 
     return {
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.processor.ts
@@ -126,7 +126,7 @@ export class NoConflictingCertificateOrCreditProcessor extends RuleDataProcessor
 
     return {
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
@@ -14,7 +14,6 @@ import {
   DocumentType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentStatus } from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 
@@ -109,7 +108,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       documents: [simpleMassIDStubs.massIDDocument],
       massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'No credit is linked to the MassID document',
     },
     {
@@ -123,7 +122,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
           BoldMethodologyName.RECYCLING,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The MassID has an approved audit document for the same methodology name',
     },
@@ -135,7 +134,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
           ...duplicatedMassIDAuditDocument,
           externalEvents: [
             ...(duplicatedMassIDAuditDocument.externalEvents?.filter(
-              (event) => !event.name.includes(RuleOutputStatus.PASSED),
+              (event) => !event.name.includes('PASSED'),
             ) ?? []),
           ],
         },
@@ -145,7 +144,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
           BoldMethodologyName.RECYCLING,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The MassID has an in-progress audit document for the same methodology name',
     },
@@ -157,7 +156,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       ],
       massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The MassID has an approved audit document for a different methodology',
     },
@@ -172,7 +171,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CERTIFICATE_DOCUMENT(
           DocumentType.RECYCLED_ID,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The MassID has a valid certificate document of the specified type',
     },
@@ -187,7 +186,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       resultComment:
         processorError.ERROR_MESSAGE
           .MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID has a valid credit document',
     },
     {
@@ -201,7 +200,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       ],
       massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'The MassID has a cancelled certificate document',
     },
     {
@@ -219,7 +218,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       ],
       massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'The MassID has a cancelled credit document',
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/no-conflicting-certificate-or-credit.test-cases.ts
@@ -108,7 +108,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       documents: [simpleMassIDStubs.massIDDocument],
       massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'No credit is linked to the MassID document',
     },
     {
@@ -122,7 +122,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
           BoldMethodologyName.RECYCLING,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The MassID has an approved audit document for the same methodology name',
     },
@@ -144,7 +144,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_AUDIT_FOR_SAME_METHODOLOGY_NAME(
           BoldMethodologyName.RECYCLING,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The MassID has an in-progress audit document for the same methodology name',
     },
@@ -156,7 +156,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       ],
       massIDAuditDocument: simpleMassIDStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The MassID has an approved audit document for a different methodology',
     },
@@ -171,7 +171,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_HAS_A_VALID_CERTIFICATE_DOCUMENT(
           DocumentType.RECYCLED_ID,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The MassID has a valid certificate document of the specified type',
     },
@@ -186,7 +186,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       resultComment:
         processorError.ERROR_MESSAGE
           .MASS_ID_DOCUMENT_HAS_A_VALID_CREDIT_DOCUMENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID has a valid credit document',
     },
     {
@@ -200,7 +200,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       ],
       massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'The MassID has a cancelled certificate document',
     },
     {
@@ -218,7 +218,7 @@ export const noConflictingCertificateOrCreditTestCases: NoConflictingCertificate
       ],
       massIDAuditDocument: massIDWithAuditStubs.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.NO_CONFLICTING_CERTIFICATE,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'The MassID has a cancelled credit document',
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
@@ -29,7 +29,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
@@ -66,7 +65,7 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
         resultComment: getOrUndefined(resultComment),
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.errorProcessor.getResultCommentFromError(error),
       });
     }
@@ -111,7 +110,7 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
 
     return {
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.processor.ts
@@ -110,7 +110,7 @@ export class ParticipantAccreditationsAndVerificationsRequirementsProcessor exte
 
     return {
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
@@ -17,7 +17,6 @@ import {
   MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { mapDocumentRelation } from '@carrot-fndn/shared/methodologies/bold/utils';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { addDays, subDays } from 'date-fns';
 
 import { RESULT_COMMENTS } from './participant-accreditations-and-verifications-requirements.constants';
@@ -312,7 +311,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         "The participants' accreditation documents exist and the accreditation is active",
     },
@@ -322,7 +321,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment:
         processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: "The participants' accreditation documents were not found",
     },
     {
@@ -333,7 +332,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         "The participants' accreditation documents exist and the accreditation is active",
     },
@@ -343,7 +342,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment:
         processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: "The participants' accreditation documents were not found",
     },
     {
@@ -359,7 +358,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
           [INTEGRATOR],
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: "Some participants' accreditation documents were not found",
     },
     {
@@ -369,7 +368,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment: processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID document does not exist',
     },
     {
@@ -386,7 +385,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
           massIDAuditWithAccreditationsAndVerifications.massIDDocument.id,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID document does not contain events',
     },
     {
@@ -399,7 +398,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
           [INTEGRATOR],
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         "The participants' accreditation documents exist and the accreditation is not active",
     },
@@ -410,7 +409,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       ],
       massIDAuditDocument: massIDWithWasteGeneratorNoResult.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The WASTE_GENERATOR has an accreditation document without a result event (should pass - Waste Generator is ignored)',
     },
@@ -422,7 +421,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithWasteGeneratorValidResult.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The WASTE_GENERATOR has a valid accreditation result event (should pass - Waste Generator is ignored)',
     },
@@ -434,7 +433,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithWasteGeneratorInvalidResult.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The WASTE_GENERATOR has an invalid accreditation result event (expired) (should pass - Waste Generator is ignored)',
     },
@@ -449,7 +448,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         wasteGeneratorSecondAccreditation,
       ),
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The WASTE_GENERATOR has multiple valid accreditations (should pass - Waste Generator is ignored)',
     },
@@ -461,7 +460,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithParticipantMultipleRoles.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The participant has one valid accreditation as PROCESSOR and one as RECYCLER (should pass)',
     },
@@ -473,7 +472,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithWasteGeneratorButNoAccreditation.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The WASTE_GENERATOR event exists but no accreditation document provided (should pass - Waste Generator is ignored)',
     },
@@ -492,7 +491,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
           processorOriginalAccreditation.primaryParticipant.id,
           PROCESSOR,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The MassID document has a PROCESSOR with multiple valid accreditations (should fail)',
     },

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/src/participant-accreditations-and-verifications-requirements.test-cases.ts
@@ -311,7 +311,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         "The participants' accreditation documents exist and the accreditation is active",
     },
@@ -321,7 +321,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment:
         processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: "The participants' accreditation documents were not found",
     },
     {
@@ -332,7 +332,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         "The participants' accreditation documents exist and the accreditation is active",
     },
@@ -342,7 +342,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment:
         processorError.ERROR_MESSAGE.ACCREDITATION_DOCUMENTS_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: "The participants' accreditation documents were not found",
     },
     {
@@ -358,7 +358,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
           [INTEGRATOR],
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: "Some participants' accreditation documents were not found",
     },
     {
@@ -368,7 +368,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDAuditWithAccreditationsAndVerifications.massIDAuditDocument,
       resultComment: processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID document does not exist',
     },
     {
@@ -385,7 +385,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         processorError.ERROR_MESSAGE.MASS_ID_DOCUMENT_DOES_NOT_CONTAIN_EVENTS(
           massIDAuditWithAccreditationsAndVerifications.massIDDocument.id,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID document does not contain events',
     },
     {
@@ -398,7 +398,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         processorError.ERROR_MESSAGE.MISSING_PARTICIPANTS_ACCREDITATION_DOCUMENTS(
           [INTEGRATOR],
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         "The participants' accreditation documents exist and the accreditation is not active",
     },
@@ -409,7 +409,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       ],
       massIDAuditDocument: massIDWithWasteGeneratorNoResult.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The WASTE_GENERATOR has an accreditation document without a result event (should pass - Waste Generator is ignored)',
     },
@@ -421,7 +421,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithWasteGeneratorValidResult.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The WASTE_GENERATOR has a valid accreditation result event (should pass - Waste Generator is ignored)',
     },
@@ -433,7 +433,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithWasteGeneratorInvalidResult.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The WASTE_GENERATOR has an invalid accreditation result event (expired) (should pass - Waste Generator is ignored)',
     },
@@ -448,7 +448,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
         wasteGeneratorSecondAccreditation,
       ),
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The WASTE_GENERATOR has multiple valid accreditations (should pass - Waste Generator is ignored)',
     },
@@ -460,7 +460,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithParticipantMultipleRoles.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The participant has one valid accreditation as PROCESSOR and one as RECYCLER (should pass)',
     },
@@ -472,7 +472,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
       massIDAuditDocument:
         massIDWithWasteGeneratorButNoAccreditation.massIDAuditDocument,
       resultComment: RESULT_COMMENTS.passed.ALL_ACCREDITATIONS_APPROVED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The WASTE_GENERATOR event exists but no accreditation document provided (should pass - Waste Generator is ignored)',
     },
@@ -491,7 +491,7 @@ export const participantAccreditationsAndVerificationsRequirementsTestCases: Par
           processorOriginalAccreditation.primaryParticipant.id,
           PROCESSOR,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The MassID document has a PROCESSOR with multiple valid accreditations (should fail)',
     },

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -96,7 +96,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       return {
         resultComment:
           RESULT_COMMENTS.failed.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -106,7 +106,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
           RESULT_COMMENTS.failed.MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE(
             wasteSubtype,
           ),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -150,7 +150,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         ...(othersIfOrganicAudit && { othersIfOrganicAudit }),
         preventedCo2e: preventedEmissions,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.ts
@@ -31,7 +31,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { getYear } from 'date-fns';
 
@@ -79,7 +78,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         },
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.processorErrors.getResultCommentFromError(error),
       });
     }
@@ -97,7 +96,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
       return {
         resultComment:
           RESULT_COMMENTS.failed.MISSING_EXCEEDING_EMISSION_COEFFICIENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -107,7 +106,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
           RESULT_COMMENTS.failed.MISSING_RECYCLING_BASELINE_FOR_WASTE_SUBTYPE(
             wasteSubtype,
           ),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -151,7 +150,7 @@ export class PreventedEmissionsProcessor extends RuleDataProcessor {
         ...(othersIfOrganicAudit && { othersIfOrganicAudit }),
         preventedCo2e: preventedEmissions,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -15,7 +15,6 @@ import {
   MassIDOrganicSubtype,
   MethodologyBaseline,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { type AnyObject } from '@carrot-fndn/shared/types';
 import { addYears } from 'date-fns';
 
@@ -163,7 +162,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The exceeding emission coefficient is undefined (missing)',
     subtype,
   },
@@ -196,7 +195,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario:
       'The calculated prevented emissions would be negative, so they are clamped to zero',
     subtype,
@@ -219,7 +218,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The exceeding emission coefficient is null (non-positive)',
     subtype,
   },
@@ -248,7 +247,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'The calculation is correct with all required attributes',
     subtype,
   },
@@ -307,7 +306,7 @@ export const preventedEmissionsTestCases = [
           wasteSubtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
         },
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `Others (if organic) calculates factor dynamically for baseline "${othersBaseline}" and local waste classification "${othersIfOrganicLocalWasteClassificationCode}"`,
       subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
     };
@@ -333,7 +332,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
       },
     },
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The Recycler Accreditation document does not have the "${BASELINES}" info for the waste subtype "${MassIDOrganicSubtype.DOMESTIC_SLUDGE}"`,
     subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
   },
@@ -362,7 +361,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario:
       'The exceeding emission coefficient is zero (no exceeding emissions)',
     subtype,
@@ -386,7 +385,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The exceeding emission coefficient is negative',
     subtype,
   },
@@ -457,7 +456,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       massIDAuditDocument,
       resultComment:
         processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID document has an invalid subtype',
     },
     {
@@ -473,7 +472,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The Recycler Accreditation document does not have the Greenhouse Gas Type (GHG) attribute',
     },
@@ -481,7 +480,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       documents: [...participantsAccreditationDocuments.values()],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_MASS_ID_DOCUMENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID document was not found',
     },
     {
@@ -489,7 +488,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       massIDAuditDocument,
       resultComment:
         processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The Recycler accreditation document was not found',
     },
     {
@@ -506,7 +505,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.INVALID_BASELINES,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The Recycler Accreditation document has no valid baselines',
     },
     {
@@ -537,7 +536,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The Others (if organic) does not provide Local Waste Classification ID on PICK_UP',
     },
@@ -569,7 +568,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'Others (if organic) has an unknown Local Waste Classification ID (not an accepted local waste classification code (Ibama, Brazil))',
     },
@@ -604,7 +603,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
         processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
           '02 02 99',
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'Others (if organic) has a valid 8.7D local waste classification code (Ibama, Brazil) but carbon fraction is not configured',
     },

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -162,7 +162,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The exceeding emission coefficient is undefined (missing)',
     subtype,
   },
@@ -195,7 +195,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario:
       'The calculated prevented emissions would be negative, so they are clamped to zero',
     subtype,
@@ -218,7 +218,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The exceeding emission coefficient is null (non-positive)',
     subtype,
   },
@@ -247,7 +247,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'The calculation is correct with all required attributes',
     subtype,
   },
@@ -306,7 +306,7 @@ export const preventedEmissionsTestCases = [
           wasteSubtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
         },
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: `Others (if organic) calculates factor dynamically for baseline "${othersBaseline}" and local waste classification "${othersIfOrganicLocalWasteClassificationCode}"`,
       subtype: MassIDOrganicSubtype.OTHERS_IF_ORGANIC,
     };
@@ -332,7 +332,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
       },
     },
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The Recycler Accreditation document does not have the "${BASELINES}" info for the waste subtype "${MassIDOrganicSubtype.DOMESTIC_SLUDGE}"`,
     subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
   },
@@ -361,7 +361,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario:
       'The exceeding emission coefficient is zero (no exceeding emissions)',
     subtype,
@@ -385,7 +385,7 @@ export const preventedEmissionsTestCases = [
         wasteSubtype: subtype,
       },
     },
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The exceeding emission coefficient is negative',
     subtype,
   },
@@ -456,7 +456,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       massIDAuditDocument,
       resultComment:
         processorErrors.ERROR_MESSAGE.INVALID_MASS_ID_DOCUMENT_SUBTYPE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID document has an invalid subtype',
     },
     {
@@ -472,7 +472,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_GREENHOUSE_GAS_TYPE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The Recycler Accreditation document does not have the Greenhouse Gas Type (GHG) attribute',
     },
@@ -480,7 +480,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       documents: [...participantsAccreditationDocuments.values()],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_MASS_ID_DOCUMENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID document was not found',
     },
     {
@@ -488,7 +488,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       massIDAuditDocument,
       resultComment:
         processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The Recycler accreditation document was not found',
     },
     {
@@ -505,7 +505,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.INVALID_BASELINES,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The Recycler Accreditation document has no valid baselines',
     },
     {
@@ -536,7 +536,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The Others (if organic) does not provide Local Waste Classification ID on PICK_UP',
     },
@@ -568,7 +568,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
       ],
       massIDAuditDocument,
       resultComment: processorErrors.ERROR_MESSAGE.INVALID_CLASSIFICATION_ID,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'Others (if organic) has an unknown Local Waste Classification ID (not an accepted local waste classification code (Ibama, Brazil))',
     },
@@ -603,7 +603,7 @@ export const preventedEmissionsErrorTestCases: PreventedEmissionsErrorTestCase[]
         processorErrors.ERROR_MESSAGE.MISSING_CARBON_FRACTION_FOR_LOCAL_WASTE_CLASSIFICATION_CODE(
           '02 02 99',
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'Others (if organic) has a valid 8.7D local waste classification code (Ibama, Brazil) but carbon fraction is not configured',
     },

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.processor.ts
@@ -29,20 +29,20 @@ export class ProcessorIdentificationProcessor extends ParentDocumentRuleProcesso
     if (!isNonEmptyArray(processorActorEvents)) {
       return {
         resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (processorActorEvents.length > 1) {
       return {
         resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.processor.ts
@@ -11,7 +11,6 @@ import {
   type DocumentEvent,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './processor-identification.constants';
@@ -30,20 +29,20 @@ export class ProcessorIdentificationProcessor extends ParentDocumentRuleProcesso
     if (!isNonEmptyArray(processorActorEvents)) {
       return {
         resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (processorActorEvents.length > 1) {
       return {
         resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.test-cases.ts
@@ -18,7 +18,7 @@ export const processorIdentificationTestCases: ProcessorIdentificationTestCase[]
     {
       events: new Map([[`${ACTOR}-${PROCESSOR}`, undefined]]),
       resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The MassID document has no "${PROCESSOR}" actor event`,
     },
     {
@@ -26,7 +26,7 @@ export const processorIdentificationTestCases: ProcessorIdentificationTestCase[]
         [`${ACTOR}-${PROCESSOR}`, stubActorEventWithLabel(PROCESSOR)],
       ]),
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: `The MassID document has a "${PROCESSOR}" actor event`,
     },
     {
@@ -35,7 +35,7 @@ export const processorIdentificationTestCases: ProcessorIdentificationTestCase[]
         [`${ACTOR}-${PROCESSOR}-2`, stubActorEventWithLabel(PROCESSOR)],
       ]),
       resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The MassID document has multiple "${PROCESSOR}" actor events`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/processor-identification.test-cases.ts
@@ -2,7 +2,6 @@ import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 
 import { stubActorEventWithLabel } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './processor-identification.constants';
@@ -19,7 +18,7 @@ export const processorIdentificationTestCases: ProcessorIdentificationTestCase[]
     {
       events: new Map([[`${ACTOR}-${PROCESSOR}`, undefined]]),
       resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The MassID document has no "${PROCESSOR}" actor event`,
     },
     {
@@ -27,7 +26,7 @@ export const processorIdentificationTestCases: ProcessorIdentificationTestCase[]
         [`${ACTOR}-${PROCESSOR}`, stubActorEventWithLabel(PROCESSOR)],
       ]),
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `The MassID document has a "${PROCESSOR}" actor event`,
     },
     {
@@ -36,7 +35,7 @@ export const processorIdentificationTestCases: ProcessorIdentificationTestCase[]
         [`${ACTOR}-${PROCESSOR}-2`, stubActorEventWithLabel(PROCESSOR)],
       ]),
       resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The MassID document has multiple "${PROCESSOR}" actor events`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.spec.ts
@@ -96,7 +96,7 @@ describe('ProjectBoundaryProcessor', () => {
         responseUrl: ruleInput.responseUrl,
         resultComment: RESULT_COMMENTS.failed.DISTANCE_CALCULATION_FAILED,
         resultContent: undefined,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
 
       expect(ruleOutput).toEqual(expectedRuleOutput);

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.spec.ts
@@ -6,10 +6,7 @@ import {
   stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import {
-  type RuleOutput,
-  RuleOutputStatus,
-} from '@carrot-fndn/shared/rule/types';
+import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 
 import { RESULT_COMMENTS } from './project-boundary.constants';
@@ -99,7 +96,7 @@ describe('ProjectBoundaryProcessor', () => {
         responseUrl: ruleInput.responseUrl,
         resultComment: RESULT_COMMENTS.failed.DISTANCE_CALCULATION_FAILED,
         resultContent: undefined,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
 
       expect(ruleOutput).toEqual(expectedRuleOutput);

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.ts
@@ -8,7 +8,6 @@ import {
   type DocumentEvent,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { convertDistance } from 'geolib';
 
 import { RESULT_COMMENTS } from './project-boundary.constants';
@@ -28,14 +27,14 @@ export class ProjectBoundaryProcessor extends ParentDocumentRuleProcessor<RuleSu
     if (isNil(pickUpEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (isNil(dropOffEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -53,12 +52,12 @@ export class ProjectBoundaryProcessor extends ParentDocumentRuleProcessor<RuleSu
         resultContent: {
           distance,
         },
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     } catch {
       return {
         resultComment: RESULT_COMMENTS.failed.DISTANCE_CALCULATION_FAILED,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.processor.ts
@@ -27,14 +27,14 @@ export class ProjectBoundaryProcessor extends ParentDocumentRuleProcessor<RuleSu
     if (isNil(pickUpEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (isNil(dropOffEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -52,12 +52,12 @@ export class ProjectBoundaryProcessor extends ParentDocumentRuleProcessor<RuleSu
         resultContent: {
           distance,
         },
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     } catch {
       return {
         resultComment: RESULT_COMMENTS.failed.DISTANCE_CALCULATION_FAILED,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
   }

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
@@ -9,7 +9,6 @@ import {
   stubBoldMassIDPickUpEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { faker } from '@faker-js/faker';
 import { convertDistance } from 'geolib';
 
@@ -38,7 +37,7 @@ export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
       [DROP_OFF]: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has no "${DROP_OFF}" event`,
   },
   {
@@ -46,7 +45,7 @@ export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
       [PICK_UP]: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has no "${PICK_UP}" event`,
   },
   {
@@ -73,7 +72,7 @@ export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
     resultContent: {
       distance: distanceInKm,
     },
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The MassID document has multiple "${DROP_OFF}" events and all criteria are met`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-boundary/src/project-boundary.test-cases.ts
@@ -37,7 +37,7 @@ export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
       [DROP_OFF]: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has no "${DROP_OFF}" event`,
   },
   {
@@ -45,7 +45,7 @@ export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
       [PICK_UP]: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has no "${PICK_UP}" event`,
   },
   {
@@ -72,7 +72,7 @@ export const projectBoundaryTestCases: ProjectBoundaryTestCase[] = [
     resultContent: {
       distance: distanceInKm,
     },
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The MassID document has multiple "${DROP_OFF}" events and all criteria are met`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.spec.ts
@@ -71,7 +71,7 @@ describe('ProjectPeriodLimitProcessor', () => {
 
     expect(ruleOutput).toMatchObject({
       resultComment: RESULT_COMMENTS.failed.MISSING_RECYCLED_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     });
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.spec.ts
@@ -4,7 +4,6 @@ import {
   stubBoldMassIDRecycledEvent,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 
 import { RESULT_COMMENTS } from './project-period-limit.constants';
@@ -72,7 +71,7 @@ describe('ProjectPeriodLimitProcessor', () => {
 
     expect(ruleOutput).toMatchObject({
       resultComment: RESULT_COMMENTS.failed.MISSING_RECYCLED_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     });
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.ts
@@ -25,7 +25,7 @@ export class ProjectPeriodLimitProcessor extends ParentDocumentRuleProcessor<Rul
     if (isNil(recycledEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_RECYCLED_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.processor.ts
@@ -7,7 +7,6 @@ import {
   type Document,
   type DocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { UTCDate } from '@date-fns/utc';
 import { isAfter, isEqual } from 'date-fns';
 
@@ -26,7 +25,7 @@ export class ProjectPeriodLimitProcessor extends ParentDocumentRuleProcessor<Rul
     if (isNil(recycledEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_RECYCLED_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -39,9 +38,7 @@ export class ProjectPeriodLimitProcessor extends ParentDocumentRuleProcessor<Rul
       resultComment: isEligible
         ? RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE
         : RESULT_COMMENTS.failed.INVALID_RECYCLED_EVENT_DATE,
-      resultStatus: isEligible
-        ? RuleOutputStatus.PASSED
-        : RuleOutputStatus.FAILED,
+      resultStatus: isEligible ? 'PASSED' : 'FAILED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.test-cases.ts
@@ -1,7 +1,6 @@
 import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { addDays, addHours, subDays, subSeconds } from 'date-fns';
 
 import { RESULT_COMMENTS } from './project-period-limit.constants';
@@ -34,31 +33,31 @@ export const projectPeriodLimitTestCases: ProjectPeriodLimitTestCase[] = [
   {
     externalCreatedAt: addDays(getEligibleDate(), 1).toISOString(),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${RECYCLED}" event was created after the eligible date`,
   },
   {
     externalCreatedAt: subDays(getEligibleDate(), 1).toISOString(),
     resultComment: RESULT_COMMENTS.failed.INVALID_RECYCLED_EVENT_DATE,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${RECYCLED}" event was created before the eligible date`,
   },
   {
     externalCreatedAt: getEligibleDate().toISOString(),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${RECYCLED}" event was created on the eligible date`,
   },
   {
     externalCreatedAt: createBRTDateString(subSeconds(getEligibleDate(), 1)),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${RECYCLED}" event was created 1 second before the eligible date in UTC but appears after in BRT timezone`,
   },
   {
     externalCreatedAt: createBRTDateString(getEligibleDate()),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${RECYCLED}" event was created exactly at the eligible date (BRT timezone)`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/src/project-period-limit.test-cases.ts
@@ -33,31 +33,31 @@ export const projectPeriodLimitTestCases: ProjectPeriodLimitTestCase[] = [
   {
     externalCreatedAt: addDays(getEligibleDate(), 1).toISOString(),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${RECYCLED}" event was created after the eligible date`,
   },
   {
     externalCreatedAt: subDays(getEligibleDate(), 1).toISOString(),
     resultComment: RESULT_COMMENTS.failed.INVALID_RECYCLED_EVENT_DATE,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${RECYCLED}" event was created before the eligible date`,
   },
   {
     externalCreatedAt: getEligibleDate().toISOString(),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${RECYCLED}" event was created on the eligible date`,
   },
   {
     externalCreatedAt: createBRTDateString(subSeconds(getEligibleDate(), 1)),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${RECYCLED}" event was created 1 second before the eligible date in UTC but appears after in BRT timezone`,
   },
   {
     externalCreatedAt: createBRTDateString(getEligibleDate()),
     resultComment: RESULT_COMMENTS.passed.VALID_RECYCLED_EVENT_DATE,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${RECYCLED}" event was created exactly at the eligible date (BRT timezone)`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.processor.ts
@@ -11,7 +11,6 @@ import {
   type DocumentEvent,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './recycler-identification.constants';
@@ -30,20 +29,20 @@ export class RecyclerIdentificationProcessor extends ParentDocumentRuleProcessor
     if (!isNonEmptyArray(recyclerActorEvents)) {
       return {
         resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (recyclerActorEvents.length > 1) {
       return {
         resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.processor.ts
@@ -29,20 +29,20 @@ export class RecyclerIdentificationProcessor extends ParentDocumentRuleProcessor
     if (!isNonEmptyArray(recyclerActorEvents)) {
       return {
         resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (recyclerActorEvents.length > 1) {
       return {
         resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.test-cases.ts
@@ -18,7 +18,7 @@ export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
     {
       events: new Map([[`${ACTOR}-${RECYCLER}`, undefined]]),
       resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The MassID document has no "${RECYCLER}" actor event`,
     },
     {
@@ -26,7 +26,7 @@ export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
         [`${ACTOR}-${RECYCLER}`, stubActorEventWithLabel(RECYCLER)],
       ]),
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: `The MassID document has a "${RECYCLER}" actor event`,
     },
     {
@@ -35,7 +35,7 @@ export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
         [`${ACTOR}-${RECYCLER}-2`, stubActorEventWithLabel(RECYCLER)],
       ]),
       resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The MassID document has multiple "${RECYCLER}" actor events`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/src/recycler-identification.test-cases.ts
@@ -2,7 +2,6 @@ import type { RuleTestCase } from '@carrot-fndn/shared/rule/types';
 
 import { stubActorEventWithLabel } from '@carrot-fndn/shared/methodologies/bold/testing';
 import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './recycler-identification.constants';
@@ -19,7 +18,7 @@ export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
     {
       events: new Map([[`${ACTOR}-${RECYCLER}`, undefined]]),
       resultComment: RESULT_COMMENTS.failed.NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The MassID document has no "${RECYCLER}" actor event`,
     },
     {
@@ -27,7 +26,7 @@ export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
         [`${ACTOR}-${RECYCLER}`, stubActorEventWithLabel(RECYCLER)],
       ]),
       resultComment: RESULT_COMMENTS.passed.SINGLE_EVENT,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `The MassID document has a "${RECYCLER}" actor event`,
     },
     {
@@ -36,7 +35,7 @@ export const recyclerIdentificationTestCases: RecyclerIdentificationTestCase[] =
         [`${ACTOR}-${RECYCLER}-2`, stubActorEventWithLabel(RECYCLER)],
       ]),
       resultComment: RESULT_COMMENTS.failed.MULTIPLE_EVENTS,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The MassID document has multiple "${RECYCLER}" actor events`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -127,7 +127,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
     return {
       resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
       resultContent: subject,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 
@@ -161,7 +161,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
     return {
       resultComment,
       ...(resultContent && { resultContent }),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -19,7 +19,6 @@ import {
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/utils';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   type AnyObject,
   type MethodologyDocumentEventAttributeValue,
@@ -128,7 +127,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
     return {
       resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
       resultContent: subject,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 
@@ -162,7 +161,7 @@ export class RegionalWasteClassificationProcessor extends ParentDocumentRuleProc
     return {
       resultComment,
       ...(resultContent && { resultContent }),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -14,7 +14,6 @@ import {
   MassIDOrganicSubtype,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { WASTE_CLASSIFICATION_CODES } from '@carrot-fndn/shared/methodologies/bold/utils';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   type AnyObject,
   MethodologyDocumentEventLabel,
@@ -80,7 +79,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The local waste classification ID and description match a local waste classification code with matching subtype',
     },
@@ -107,7 +106,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The local waste classification ID and description match the local waste classification code without spaces with matching subtype',
     },
@@ -134,7 +133,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The local waste classification description has leading/trailing special characters but matches after normalization with matching subtype',
     },
@@ -161,7 +160,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The local waste classification ID is missing',
     },
     {
@@ -184,7 +183,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The local waste classification description is missing',
     },
     {
@@ -211,7 +210,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The local waste classification description matches after normalization (accent stripped)',
     },
@@ -236,7 +235,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The local waste classification description does not match the expected local waste classification code',
     },
@@ -260,7 +259,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'US',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The recycler is not from Brazil',
     },
     {
@@ -283,7 +282,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The local waste classification ID is not valid',
     },
     {
@@ -309,7 +308,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The subtype does not match the CDM_CODE for the provided classification ID',
     },
@@ -336,7 +335,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The subtype matches the CDM_CODE for the provided classification ID',
     },
@@ -363,7 +362,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario:
         'The subtype matches the CDM_CODE 8.1 for Wood and Wood Products',
     },
@@ -390,7 +389,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
       },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'The subtype matches the CDM_CODE 8.7C for Domestic Sludge',
     },
     {
@@ -416,7 +415,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.TOBACCO,
       },
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario:
         'The subtype does not map to a valid CDM_CODE (TOBACCO has no mapping)',
     },
@@ -438,7 +437,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
       },
       resultComment: 'Rule not applicable',
       resultContent: undefined,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: 'The document does not have a subtype (rule not applicable)',
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -79,7 +79,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The local waste classification ID and description match a local waste classification code with matching subtype',
     },
@@ -106,7 +106,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The local waste classification ID and description match the local waste classification code without spaces with matching subtype',
     },
@@ -133,7 +133,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The local waste classification description has leading/trailing special characters but matches after normalization with matching subtype',
     },
@@ -160,7 +160,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The local waste classification ID is missing',
     },
     {
@@ -183,7 +183,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The local waste classification description is missing',
     },
     {
@@ -210,7 +210,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The local waste classification description matches after normalization (accent stripped)',
     },
@@ -235,7 +235,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The local waste classification description does not match the expected local waste classification code',
     },
@@ -259,7 +259,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'US',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The recycler is not from Brazil',
     },
     {
@@ -282,7 +282,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The local waste classification ID is not valid',
     },
     {
@@ -308,7 +308,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The subtype does not match the CDM_CODE for the provided classification ID',
     },
@@ -335,7 +335,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The subtype matches the CDM_CODE for the provided classification ID',
     },
@@ -362,7 +362,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.WOOD_AND_WOOD_PRODUCTS,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario:
         'The subtype matches the CDM_CODE 8.1 for Wood and Wood Products',
     },
@@ -389,7 +389,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.DOMESTIC_SLUDGE,
       },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'The subtype matches the CDM_CODE 8.7C for Domestic Sludge',
     },
     {
@@ -415,7 +415,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         recyclerCountryCode: 'BR',
         subtype: MassIDOrganicSubtype.TOBACCO,
       },
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario:
         'The subtype does not map to a valid CDM_CODE (TOBACCO has no mapping)',
     },
@@ -437,7 +437,7 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
       },
       resultComment: 'Rule not applicable',
       resultContent: undefined,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: 'The document does not have a subtype (rule not applicable)',
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.processor.ts
@@ -18,7 +18,6 @@ import {
   DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './vehicle-identification.constants';
 
@@ -140,7 +139,7 @@ export class VehicleIdentificationProcessor extends ParentDocumentRuleProcessor<
   ): EvaluateResultOutput {
     return {
       resultComment,
-      resultStatus: passed ? RuleOutputStatus.PASSED : RuleOutputStatus.FAILED,
+      resultStatus: passed ? 'PASSED' : 'FAILED',
     };
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
@@ -7,7 +7,6 @@ import {
   DocumentEventName,
   DocumentEventVehicleType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './vehicle-identification.constants';
 import { VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES } from './vehicle-identification.processor';
@@ -34,7 +33,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     resultComment: RESULT_COMMENTS.failed.INVALID_VEHICLE_TYPE(
       'INVALID_VEHICLE_TYPE',
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is not a valid vehicle type`,
   },
   {
@@ -47,7 +46,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.failed.VEHICLE_TYPE_MISSING,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is not present`,
   },
   {
@@ -63,7 +62,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.failed.VEHICLE_DESCRIPTION_MISSING(OTHERS),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${OTHERS} but the "${VEHICLE_DESCRIPTION}" attribute is not present`,
   },
   {
@@ -81,13 +80,13 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     manifestExample: true,
     resultComment:
       RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITH_DESCRIPTION(OTHERS),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${OTHERS} and the "${VEHICLE_DESCRIPTION}" attribute is present`,
   },
   {
     events: new Map([[PICK_UP, undefined]]),
     resultComment: RESULT_COMMENTS.failed.PICK_UP_EVENT_MISSING,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${PICK_UP}" event is not present`,
   },
   ...[...VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES].map((vehicleType) => ({
@@ -103,7 +102,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITHOUT_LICENSE_PLATE(
         vehicleType,
       ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${vehicleType} and no license plate is needed`,
   })),
   {
@@ -120,7 +119,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     ]),
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.LICENSE_PLATE_MISSING(TRUCK),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is not exempt from license plate requirement but no license plate is provided`,
   },
   {
@@ -136,7 +135,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITH_LICENSE_PLATE,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${VEHICLE_TYPE}" attribute is not exempt from license plate requirement and license plate is provided`,
   },
   {
@@ -152,7 +151,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.failed.INVALID_LICENSE_PLATE_FORMAT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_LICENSE_PLATE}" attribute is not a valid license plate`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
@@ -33,7 +33,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     resultComment: RESULT_COMMENTS.failed.INVALID_VEHICLE_TYPE(
       'INVALID_VEHICLE_TYPE',
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_TYPE}" attribute is not a valid vehicle type`,
   },
   {
@@ -46,7 +46,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.failed.VEHICLE_TYPE_MISSING,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_TYPE}" attribute is not present`,
   },
   {
@@ -62,7 +62,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.failed.VEHICLE_DESCRIPTION_MISSING(OTHERS),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${OTHERS} but the "${VEHICLE_DESCRIPTION}" attribute is not present`,
   },
   {
@@ -80,13 +80,13 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     manifestExample: true,
     resultComment:
       RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITH_DESCRIPTION(OTHERS),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${OTHERS} and the "${VEHICLE_DESCRIPTION}" attribute is present`,
   },
   {
     events: new Map([[PICK_UP, undefined]]),
     resultComment: RESULT_COMMENTS.failed.PICK_UP_EVENT_MISSING,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${PICK_UP}" event is not present`,
   },
   ...[...VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES].map((vehicleType) => ({
@@ -102,7 +102,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITHOUT_LICENSE_PLATE(
         vehicleType,
       ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${vehicleType} and no license plate is needed`,
   })),
   {
@@ -119,7 +119,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     ]),
     manifestExample: true,
     resultComment: RESULT_COMMENTS.failed.LICENSE_PLATE_MISSING(TRUCK),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_TYPE}" attribute is not exempt from license plate requirement but no license plate is provided`,
   },
   {
@@ -135,7 +135,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITH_LICENSE_PLATE,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${VEHICLE_TYPE}" attribute is not exempt from license plate requirement and license plate is provided`,
   },
   {
@@ -151,7 +151,7 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
       ],
     ]),
     resultComment: RESULT_COMMENTS.failed.INVALID_LICENSE_PLATE_FORMAT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_LICENSE_PLATE}" attribute is not a valid license plate`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.ts
@@ -89,7 +89,7 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
           totalDuplicates,
           validDuplicatesCount,
         ),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -99,13 +99,13 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
           totalDuplicates,
           cancelledCount,
         ),
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.NO_DUPLICATES_FOUND,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.processor.ts
@@ -22,7 +22,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyDocumentEventLabel,
@@ -56,7 +55,7 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
       const document = await this.loadDocument(ruleInput);
 
       if (isNil(document)) {
-        return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+        return mapToRuleOutput(ruleInput, 'FAILED', {
           resultComment: this.errorProcessor.getResultCommentFromError(
             this.errorProcessor.getKnownError(
               this.errorProcessor.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
@@ -73,7 +72,7 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
         resultComment: getOrUndefined(resultComment),
       });
     } catch (error: unknown) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.errorProcessor.getResultCommentFromError(error),
       });
     }
@@ -90,7 +89,7 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
           totalDuplicates,
           validDuplicatesCount,
         ),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -100,13 +99,13 @@ export class WasteMassIsUniqueProcessor extends ParentDocumentRuleProcessor<Rule
           totalDuplicates,
           cancelledCount,
         ),
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.passed.NO_DUPLICATES_FOUND,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
@@ -9,7 +9,6 @@ import {
   DocumentEventAttributeName,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyDocumentEventLabel,
   MethodologyDocumentStatus,
@@ -33,14 +32,14 @@ export const wasteMassIsUniqueTestCases: WasteMassIsUniqueTestCase[] = [
     newDuplicateDocuments: [],
     oldDuplicateDocuments: [],
     resultComment: RESULT_COMMENTS.passed.NO_DUPLICATES_FOUND,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'The document is unique',
   },
   {
     newDuplicateDocuments: [{ status: CANCELLED }, { status: CANCELLED }],
     oldDuplicateDocuments: [],
     resultComment: RESULT_COMMENTS.passed.ONLY_CANCELLED_DUPLICATES(2, 2),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'Only cancelled duplicates were found',
   },
   {
@@ -51,21 +50,21 @@ export const wasteMassIsUniqueTestCases: WasteMassIsUniqueTestCase[] = [
     ],
     oldDuplicateDocuments: [],
     resultComment: RESULT_COMMENTS.failed.VALID_DUPLICATE_FOUND(3, 2),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'Valid duplicates were found',
   },
   {
     newDuplicateDocuments: [],
     oldDuplicateDocuments: [{ status: OPEN }, { status: OPEN }],
     resultComment: RESULT_COMMENTS.failed.VALID_DUPLICATE_FOUND(2, 2),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'Valid duplicates were found in old format',
   },
   {
     newDuplicateDocuments: [{ status: OPEN }, { status: OPEN }],
     oldDuplicateDocuments: [{ status: CANCELLED }],
     resultComment: RESULT_COMMENTS.failed.VALID_DUPLICATE_FOUND(3, 2),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'Valid duplicates were found in both formats',
   },
 ];
@@ -88,7 +87,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
       massIDAuditDocument,
       massIDDocument: undefined,
       resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: 'The MassID document is missing',
     },
     {
@@ -100,7 +99,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
         ),
       },
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_DROP_OFF_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${DROP_OFF}" event is missing`,
     },
     {
@@ -112,7 +111,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
         ),
       },
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_PICK_UP_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${PICK_UP}" event is missing`,
     },
     {
@@ -125,7 +124,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
       },
       resultComment:
         processorErrors.ERROR_MESSAGE.MISSING_WASTE_GENERATOR_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${WASTE_GENERATOR}" event is missing`,
     },
     {
@@ -137,7 +136,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
         ),
       },
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${RECYCLER}" event is missing`,
     },
     {
@@ -155,7 +154,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
       },
       resultComment:
         processorErrors.ERROR_MESSAGE.MISSING_VEHICLE_LICENSE_PLATE,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${VEHICLE_LICENSE_PLATE}" attribute is missing`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.test-cases.ts
@@ -32,14 +32,14 @@ export const wasteMassIsUniqueTestCases: WasteMassIsUniqueTestCase[] = [
     newDuplicateDocuments: [],
     oldDuplicateDocuments: [],
     resultComment: RESULT_COMMENTS.passed.NO_DUPLICATES_FOUND,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'The document is unique',
   },
   {
     newDuplicateDocuments: [{ status: CANCELLED }, { status: CANCELLED }],
     oldDuplicateDocuments: [],
     resultComment: RESULT_COMMENTS.passed.ONLY_CANCELLED_DUPLICATES(2, 2),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'Only cancelled duplicates were found',
   },
   {
@@ -50,21 +50,21 @@ export const wasteMassIsUniqueTestCases: WasteMassIsUniqueTestCase[] = [
     ],
     oldDuplicateDocuments: [],
     resultComment: RESULT_COMMENTS.failed.VALID_DUPLICATE_FOUND(3, 2),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'Valid duplicates were found',
   },
   {
     newDuplicateDocuments: [],
     oldDuplicateDocuments: [{ status: OPEN }, { status: OPEN }],
     resultComment: RESULT_COMMENTS.failed.VALID_DUPLICATE_FOUND(2, 2),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'Valid duplicates were found in old format',
   },
   {
     newDuplicateDocuments: [{ status: OPEN }, { status: OPEN }],
     oldDuplicateDocuments: [{ status: CANCELLED }],
     resultComment: RESULT_COMMENTS.failed.VALID_DUPLICATE_FOUND(3, 2),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'Valid duplicates were found in both formats',
   },
 ];
@@ -87,7 +87,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
       massIDAuditDocument,
       massIDDocument: undefined,
       resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: 'The MassID document is missing',
     },
     {
@@ -99,7 +99,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
         ),
       },
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_DROP_OFF_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${DROP_OFF}" event is missing`,
     },
     {
@@ -111,7 +111,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
         ),
       },
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_PICK_UP_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${PICK_UP}" event is missing`,
     },
     {
@@ -124,7 +124,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
       },
       resultComment:
         processorErrors.ERROR_MESSAGE.MISSING_WASTE_GENERATOR_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${WASTE_GENERATOR}" event is missing`,
     },
     {
@@ -136,7 +136,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
         ),
       },
       resultComment: processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${RECYCLER}" event is missing`,
     },
     {
@@ -154,7 +154,7 @@ export const wasteMassIsUniqueErrorTestCases: WasteMassIsUniqueErrorTestCase[] =
       },
       resultComment:
         processorErrors.ERROR_MESSAGE.MISSING_VEHICLE_LICENSE_PLATE,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${VEHICLE_LICENSE_PLATE}" attribute is missing`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.processor.ts
@@ -15,7 +15,6 @@ import {
   DocumentEventAttributeValue,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './waste-origin-identification.constants';
 
@@ -35,7 +34,7 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
     if (isNil(pickUpEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -45,7 +44,7 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
     ) {
       return {
         resultComment: RESULT_COMMENTS.failed.MULTIPLE_WASTE_GENERATOR_EVENTS,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -59,27 +58,27 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
     if (!isUnidentified && hasWasteGenerator) {
       return {
         resultComment: RESULT_COMMENTS.passed.WASTE_ORIGIN_IDENTIFIED,
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
     if (isUnidentified && !hasWasteGenerator) {
       return {
         resultComment: RESULT_COMMENTS.passed.UNIDENTIFIED_WASTE_ORIGIN,
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       };
     }
 
     if (!isUnidentified && !hasWasteGenerator) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_WASTE_GENERATOR_EVENT,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.failed.WASTE_ORIGIN_CONFLICT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.processor.ts
@@ -34,7 +34,7 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
     if (isNil(pickUpEvent)) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -44,7 +44,7 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
     ) {
       return {
         resultComment: RESULT_COMMENTS.failed.MULTIPLE_WASTE_GENERATOR_EVENTS,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -58,27 +58,27 @@ export class WasteOriginIdentificationProcessor extends ParentDocumentRuleProces
     if (!isUnidentified && hasWasteGenerator) {
       return {
         resultComment: RESULT_COMMENTS.passed.WASTE_ORIGIN_IDENTIFIED,
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
     if (isUnidentified && !hasWasteGenerator) {
       return {
         resultComment: RESULT_COMMENTS.passed.UNIDENTIFIED_WASTE_ORIGIN,
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       };
     }
 
     if (!isUnidentified && !hasWasteGenerator) {
       return {
         resultComment: RESULT_COMMENTS.failed.MISSING_WASTE_GENERATOR_EVENT,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     return {
       resultComment: RESULT_COMMENTS.failed.WASTE_ORIGIN_CONFLICT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
   }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
@@ -30,7 +30,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${PICK_UP}" event is missing`,
     },
     {
@@ -42,7 +42,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.passed.UNIDENTIFIED_WASTE_ORIGIN,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: `The "${PICK_UP}" event has the metadata "${WASTE_ORIGIN}" with the value "${UNIDENTIFIED}"`,
     },
     {
@@ -57,7 +57,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.WASTE_ORIGIN_CONFLICT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${PICK_UP}" event has the metadata "${WASTE_ORIGIN}" with the value "${UNIDENTIFIED}" and the "${WASTE_GENERATOR}" event is defined`,
     },
     {
@@ -72,7 +72,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.passed.WASTE_ORIGIN_IDENTIFIED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
       scenario: `The "${PICK_UP}" event without "${WASTE_ORIGIN}" metadata and the "${WASTE_GENERATOR}" event is defined`,
     },
     {
@@ -82,7 +82,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.MISSING_WASTE_GENERATOR_EVENT,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The "${PICK_UP}" event without "${WASTE_ORIGIN}" metadata and no "${WASTE_GENERATOR}" event`,
     },
     {
@@ -99,7 +99,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.MULTIPLE_WASTE_GENERATOR_EVENTS,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
       scenario: `The MassID document with multiple "${WASTE_GENERATOR}" events`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/src/waste-origin-identification.test-cases.ts
@@ -9,7 +9,6 @@ import {
   DocumentEventAttributeValue,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { MethodologyDocumentEventLabel } from '@carrot-fndn/shared/types';
 
 import { RESULT_COMMENTS } from './waste-origin-identification.constants';
@@ -31,7 +30,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.MISSING_PICK_UP_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${PICK_UP}" event is missing`,
     },
     {
@@ -43,7 +42,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.passed.UNIDENTIFIED_WASTE_ORIGIN,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `The "${PICK_UP}" event has the metadata "${WASTE_ORIGIN}" with the value "${UNIDENTIFIED}"`,
     },
     {
@@ -58,7 +57,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.WASTE_ORIGIN_CONFLICT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${PICK_UP}" event has the metadata "${WASTE_ORIGIN}" with the value "${UNIDENTIFIED}" and the "${WASTE_GENERATOR}" event is defined`,
     },
     {
@@ -73,7 +72,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.passed.WASTE_ORIGIN_IDENTIFIED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
       scenario: `The "${PICK_UP}" event without "${WASTE_ORIGIN}" metadata and the "${WASTE_GENERATOR}" event is defined`,
     },
     {
@@ -83,7 +82,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.MISSING_WASTE_GENERATOR_EVENT,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The "${PICK_UP}" event without "${WASTE_ORIGIN}" metadata and no "${WASTE_GENERATOR}" event`,
     },
     {
@@ -100,7 +99,7 @@ export const wasteOriginIdentificationTestCases: WasteOriginIdentificationTestCa
       },
       manifestExample: true,
       resultComment: RESULT_COMMENTS.failed.MULTIPLE_WASTE_GENERATOR_EVENTS,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
       scenario: `The MassID document with multiple "${WASTE_GENERATOR}" events`,
     },
   ];

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -28,7 +28,6 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import {
   MethodologyAdditionalVerification,
@@ -84,7 +83,7 @@ export class WeighingProcessor extends RuleDataProcessor {
         message: `Error in weighing processor for document ${ruleInput.documentId}`,
       });
 
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.processorErrors.getResultCommentFromError(error),
       });
     }
@@ -163,7 +162,7 @@ export class WeighingProcessor extends RuleDataProcessor {
       if (twoStepValidationMessages.errors.length > 0) {
         return {
           resultComment: twoStepValidationMessages.errors.join(' '),
-          resultStatus: RuleOutputStatus.FAILED,
+          resultStatus: 'FAILED' as const,
         };
       }
     }
@@ -182,7 +181,7 @@ export class WeighingProcessor extends RuleDataProcessor {
     if (validationMessages.errors.length > 0) {
       return {
         resultComment: validationMessages.errors.join(' '),
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -216,7 +215,7 @@ export class WeighingProcessor extends RuleDataProcessor {
 
     return {
       resultComment: passMessage,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 
@@ -283,7 +282,7 @@ export class WeighingProcessor extends RuleDataProcessor {
       return {
         errorResult: {
           resultComment: scaleTicketValidation.errors.join(' '),
-          resultStatus: RuleOutputStatus.FAILED,
+          resultStatus: 'FAILED' as const,
         },
         validated: false,
       };
@@ -379,14 +378,14 @@ export class WeighingProcessor extends RuleDataProcessor {
     if (isNil(weighingEvents) || weighingEvents.length === 0) {
       return {
         resultComment: NOT_FOUND_RESULT_COMMENTS.NO_WEIGHING_EVENTS,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
     if (weighingEvents.length > 2) {
       return {
         resultComment: NOT_FOUND_RESULT_COMMENTS.MORE_THAN_TWO_WEIGHING_EVENTS,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.processor.ts
@@ -162,7 +162,7 @@ export class WeighingProcessor extends RuleDataProcessor {
       if (twoStepValidationMessages.errors.length > 0) {
         return {
           resultComment: twoStepValidationMessages.errors.join(' '),
-          resultStatus: 'FAILED' as const,
+          resultStatus: 'FAILED',
         };
       }
     }
@@ -181,7 +181,7 @@ export class WeighingProcessor extends RuleDataProcessor {
     if (validationMessages.errors.length > 0) {
       return {
         resultComment: validationMessages.errors.join(' '),
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -215,7 +215,7 @@ export class WeighingProcessor extends RuleDataProcessor {
 
     return {
       resultComment: passMessage,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 
@@ -282,7 +282,7 @@ export class WeighingProcessor extends RuleDataProcessor {
       return {
         errorResult: {
           resultComment: scaleTicketValidation.errors.join(' '),
-          resultStatus: 'FAILED' as const,
+          resultStatus: 'FAILED',
         },
         validated: false,
       };
@@ -378,14 +378,14 @@ export class WeighingProcessor extends RuleDataProcessor {
     if (isNil(weighingEvents) || weighingEvents.length === 0) {
       return {
         resultComment: NOT_FOUND_RESULT_COMMENTS.NO_WEIGHING_EVENTS,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
     if (weighingEvents.length > 2) {
       return {
         resultComment: NOT_FOUND_RESULT_COMMENTS.MORE_THAN_TWO_WEIGHING_EVENTS,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -20,7 +20,6 @@ import {
   DocumentEventWeighingCaptureMethod,
   MassIDDocumentActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { stubEnumValue } from '@carrot-fndn/shared/testing';
 import {
   ApprovedException,
@@ -276,7 +275,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: undefined,
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.NO_WEIGHING_EVENTS,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document does not have "${WEIGHING}" events`,
   },
   {
@@ -286,7 +285,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [`${WEIGHING}-3`]: stubBoldMassIDWeighingEvent(),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.MORE_THAN_TWO_WEIGHING_EVENTS,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document has more than two "${WEIGHING}" events`,
   },
   {
@@ -309,7 +308,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       }),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.ACCREDITATION_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The Recycler Accreditation document does not have a "${SCALE_TYPE}" attribute`,
   },
   {
@@ -322,7 +321,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_CAPACITY} ${INVALID_RESULT_COMMENTS.CONTAINER_CAPACITY_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${CONTAINER_CAPACITY}" attribute is missing`,
   },
   {
@@ -336,7 +335,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_QUANTITY,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${CONTAINER_QUANTITY}" attribute is missing and the "${CONTAINER_TYPE}" is "${DocumentEventContainerType.BAG}"`,
   },
   {
@@ -358,7 +357,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.ACCREDITATION_EVENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${ACCREDITATION_RESULT}" event is missing`,
   },
   {
@@ -372,7 +371,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: INVALID_RESULT_COMMENTS.CONTAINER_QUANTITY,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${CONTAINER_QUANTITY}" attribute is defined, but the "${CONTAINER_TYPE}" is "${DocumentEventContainerType.TRUCK}"`,
   },
   {
@@ -383,7 +382,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.GROSS_WEIGHT(undefined as unknown)} ${INVALID_RESULT_COMMENTS.GROSS_WEIGHT_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${GROSS_WEIGHT}" attribute is missing`,
   },
   {
@@ -392,7 +391,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: createWeighingEvent(validWeighingAttributes, 0),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.EVENT_VALUE(0),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The event value field is missing',
   },
   {
@@ -403,7 +402,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE(undefined as unknown)} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${TARE}" attribute is missing`,
   },
   {
@@ -414,7 +413,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.DESCRIPTION,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${DESCRIPTION}" attribute is missing`,
   },
   {
@@ -425,7 +424,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.DESCRIPTION,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${DESCRIPTION}" attribute is an empty string`,
   },
   {
@@ -442,7 +441,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       scaleTypeMismatch,
       scaleType,
     )} ${INVALID_RESULT_COMMENTS.SCALE_TYPE(scaleTypeMismatch)}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${SCALE_TYPE}" attribute is not equal to the "${SCALE_TYPE}" attribute in the Recycler Accreditation document and is not supported by the methodology`,
   },
   {
@@ -458,7 +457,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: INVALID_RESULT_COMMENTS.WEIGHING_CAPTURE_METHOD(
       weighingCaptureMethodMismatch,
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${WEIGHING_CAPTURE_METHOD}" attribute is not supported by the methodology`,
   },
   {
@@ -471,7 +470,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_FORMAT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${VEHICLE_LICENSE_PLATE}" attribute is missing`,
   },
   {
@@ -482,7 +481,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_TYPE,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${CONTAINER_TYPE}" attribute is missing`,
   },
   {
@@ -495,7 +494,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: createWeighingEvent(manifestWeighingAttributes),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The one step "${WEIGHING}" event is valid`,
   },
   {
@@ -508,7 +507,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_SCALE_TICKET_VALIDATION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The one step "${WEIGHING}" event is valid with scale ticket verification configured`,
   },
   {
@@ -519,7 +518,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: createWeighingEvent(validWeighingAttributes),
     },
     resultComment: 'Scale ticket mismatch',
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scaleTicketVerificationError: 'Scale ticket mismatch',
     scenario: `Scale ticket verification fails for "${WEIGHING}" event`,
   },
@@ -537,7 +536,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The one step "${WEIGHING}" event is valid with container capacity exception`,
   },
   {
@@ -556,7 +555,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       PASSED_RESULT_COMMENTS.PASSED_WITH_CONTAINER_QUANTITY_EXCEPTION(
         PASSED_RESULT_COMMENTS.SINGLE_STEP,
       ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The one step "${WEIGHING}" event is valid with container quantity exception for non-TRUCK container`,
   },
   {
@@ -583,7 +582,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     },
     resultComment:
       INVALID_RESULT_COMMENTS.TWO_STEP_WEIGHING_EVENT_PARTICIPANT_IDS,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The two step "${WEIGHING}" event participant ids do not match`,
   },
   {
@@ -599,7 +598,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(
       PASSED_RESULT_COMMENTS.TWO_STEP,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The two step "${WEIGHING}" events are valid with container capacity exception`,
   },
   {
@@ -613,7 +612,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       MANIFEST_TWO_STEP_PARTICIPANT,
     ),
     resultComment: PASSED_RESULT_COMMENTS.TWO_STEP,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The two step "${WEIGHING}" events are valid`,
   },
   {
@@ -631,7 +630,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       firstValue: 2,
       secondValue: 1,
     }),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The two step "${WEIGHING}" event "${CONTAINER_CAPACITY}" attribute values do not match`,
   },
   {
@@ -645,7 +644,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: INVALID_RESULT_COMMENTS.TWO_STEP_WEIGHING_EVENT_SCALE_TYPE(
       DocumentEventScaleType.CONVEYOR_BELT_SCALE,
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The two step "${WEIGHING}" event scale type is not "${DocumentEventScaleType.WEIGHBRIDGE}"`,
   },
   {
@@ -673,7 +672,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: INVALID_RESULT_COMMENTS.TWO_STEP_CONTAINER_TYPE(
       DocumentEventContainerType.BAG,
     ),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The two step "${WEIGHING}" event container type is not "${DocumentEventContainerType.TRUCK}"`,
   },
   {
@@ -692,7 +691,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: PASSED_RESULT_COMMENTS.TRANSPORT_MANIFEST,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING_CAPTURE_METHOD}" attribute is "${DocumentEventWeighingCaptureMethod.TRANSPORT_MANIFEST}" and the "${WEIGHING}" event is valid`,
   },
   {
@@ -711,7 +710,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       grossWeight: 100,
       tare: 1,
     }),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: 'The calculated net weight is not equal to the mass net weight',
   },
   {
@@ -731,7 +730,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and missing Tare`,
   },
   {
@@ -747,7 +746,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined' as unknown)} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${WEIGHING}" event fails for TRUCK container without tare exception and missing Tare`,
   },
   {
@@ -767,7 +766,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING}" event is valid for non-TRUCK (BIN) container with tare exception and missing Tare`,
   },
   {
@@ -794,7 +793,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       grossWeight: 100,
       tare: 1,
     }),
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${WEIGHING}" event fails for non-TRUCK (BIN) container with tare exception when net weight calculation fails`,
   },
   {
@@ -812,7 +811,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and Tare provided`,
   },
   {
@@ -830,7 +829,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and missing Gross Weight`,
   },
   {
@@ -850,7 +849,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and both Tare and Gross Weight missing`,
   },
   {
@@ -869,7 +868,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined')} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${WEIGHING}" event fails for TRUCK container with expired tare exception (Valid Until in past) and missing Tare`,
   },
   {
@@ -888,7 +887,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined')} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The "${WEIGHING}" event fails for TRUCK container with invalid tare exception Valid Until date format and missing Tare`,
   },
   {
@@ -904,7 +903,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: `The "${WEIGHING}" event is valid for TRUCK container without tare exception and both Tare and Gross Weight provided`,
   },
 ];
@@ -932,7 +931,7 @@ export const weighingErrorTestCases: WeighingErrorTestCase[] = [
     documents: [...participantsAccreditationDocuments.values()],
     massIDAuditDocument,
     resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The MassID document was not found`,
   },
   {
@@ -940,7 +939,7 @@ export const weighingErrorTestCases: WeighingErrorTestCase[] = [
     massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
-    resultStatus: RuleOutputStatus.FAILED,
+    resultStatus: 'FAILED' as const,
     scenario: `The Recycler accreditation document was not found`,
   },
 ];

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -275,7 +275,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: undefined,
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.NO_WEIGHING_EVENTS,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document does not have "${WEIGHING}" events`,
   },
   {
@@ -285,7 +285,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [`${WEIGHING}-3`]: stubBoldMassIDWeighingEvent(),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.MORE_THAN_TWO_WEIGHING_EVENTS,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document has more than two "${WEIGHING}" events`,
   },
   {
@@ -308,7 +308,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       }),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.ACCREDITATION_EVENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The Recycler Accreditation document does not have a "${SCALE_TYPE}" attribute`,
   },
   {
@@ -321,7 +321,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_CAPACITY} ${INVALID_RESULT_COMMENTS.CONTAINER_CAPACITY_FORMAT}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${CONTAINER_CAPACITY}" attribute is missing`,
   },
   {
@@ -335,7 +335,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_QUANTITY,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${CONTAINER_QUANTITY}" attribute is missing and the "${CONTAINER_TYPE}" is "${DocumentEventContainerType.BAG}"`,
   },
   {
@@ -357,7 +357,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: NOT_FOUND_RESULT_COMMENTS.ACCREDITATION_EVENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${ACCREDITATION_RESULT}" event is missing`,
   },
   {
@@ -371,7 +371,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: INVALID_RESULT_COMMENTS.CONTAINER_QUANTITY,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${CONTAINER_QUANTITY}" attribute is defined, but the "${CONTAINER_TYPE}" is "${DocumentEventContainerType.TRUCK}"`,
   },
   {
@@ -382,7 +382,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.GROSS_WEIGHT(undefined as unknown)} ${INVALID_RESULT_COMMENTS.GROSS_WEIGHT_FORMAT}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${GROSS_WEIGHT}" attribute is missing`,
   },
   {
@@ -391,7 +391,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: createWeighingEvent(validWeighingAttributes, 0),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.EVENT_VALUE(0),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The event value field is missing',
   },
   {
@@ -402,7 +402,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE(undefined as unknown)} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${TARE}" attribute is missing`,
   },
   {
@@ -413,7 +413,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.DESCRIPTION,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${DESCRIPTION}" attribute is missing`,
   },
   {
@@ -424,7 +424,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.DESCRIPTION,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${DESCRIPTION}" attribute is an empty string`,
   },
   {
@@ -441,7 +441,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       scaleTypeMismatch,
       scaleType,
     )} ${INVALID_RESULT_COMMENTS.SCALE_TYPE(scaleTypeMismatch)}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${SCALE_TYPE}" attribute is not equal to the "${SCALE_TYPE}" attribute in the Recycler Accreditation document and is not supported by the methodology`,
   },
   {
@@ -457,7 +457,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: INVALID_RESULT_COMMENTS.WEIGHING_CAPTURE_METHOD(
       weighingCaptureMethodMismatch,
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${WEIGHING_CAPTURE_METHOD}" attribute is not supported by the methodology`,
   },
   {
@@ -470,7 +470,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: INVALID_RESULT_COMMENTS.VEHICLE_LICENSE_PLATE_FORMAT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${VEHICLE_LICENSE_PLATE}" attribute is missing`,
   },
   {
@@ -481,7 +481,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: WRONG_FORMAT_RESULT_COMMENTS.CONTAINER_TYPE,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${CONTAINER_TYPE}" attribute is missing`,
   },
   {
@@ -494,7 +494,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: createWeighingEvent(manifestWeighingAttributes),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The one step "${WEIGHING}" event is valid`,
   },
   {
@@ -507,7 +507,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_SCALE_TICKET_VALIDATION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The one step "${WEIGHING}" event is valid with scale ticket verification configured`,
   },
   {
@@ -518,7 +518,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       [WEIGHING]: createWeighingEvent(validWeighingAttributes),
     },
     resultComment: 'Scale ticket mismatch',
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scaleTicketVerificationError: 'Scale ticket mismatch',
     scenario: `Scale ticket verification fails for "${WEIGHING}" event`,
   },
@@ -536,7 +536,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The one step "${WEIGHING}" event is valid with container capacity exception`,
   },
   {
@@ -555,7 +555,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       PASSED_RESULT_COMMENTS.PASSED_WITH_CONTAINER_QUANTITY_EXCEPTION(
         PASSED_RESULT_COMMENTS.SINGLE_STEP,
       ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The one step "${WEIGHING}" event is valid with container quantity exception for non-TRUCK container`,
   },
   {
@@ -582,7 +582,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     },
     resultComment:
       INVALID_RESULT_COMMENTS.TWO_STEP_WEIGHING_EVENT_PARTICIPANT_IDS,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The two step "${WEIGHING}" event participant ids do not match`,
   },
   {
@@ -598,7 +598,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_EXCEPTION(
       PASSED_RESULT_COMMENTS.TWO_STEP,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The two step "${WEIGHING}" events are valid with container capacity exception`,
   },
   {
@@ -612,7 +612,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       MANIFEST_TWO_STEP_PARTICIPANT,
     ),
     resultComment: PASSED_RESULT_COMMENTS.TWO_STEP,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The two step "${WEIGHING}" events are valid`,
   },
   {
@@ -630,7 +630,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       firstValue: 2,
       secondValue: 1,
     }),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The two step "${WEIGHING}" event "${CONTAINER_CAPACITY}" attribute values do not match`,
   },
   {
@@ -644,7 +644,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: INVALID_RESULT_COMMENTS.TWO_STEP_WEIGHING_EVENT_SCALE_TYPE(
       DocumentEventScaleType.CONVEYOR_BELT_SCALE,
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The two step "${WEIGHING}" event scale type is not "${DocumentEventScaleType.WEIGHBRIDGE}"`,
   },
   {
@@ -672,7 +672,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: INVALID_RESULT_COMMENTS.TWO_STEP_CONTAINER_TYPE(
       DocumentEventContainerType.BAG,
     ),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The two step "${WEIGHING}" event container type is not "${DocumentEventContainerType.TRUCK}"`,
   },
   {
@@ -691,7 +691,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ),
     },
     resultComment: PASSED_RESULT_COMMENTS.TRANSPORT_MANIFEST,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING_CAPTURE_METHOD}" attribute is "${DocumentEventWeighingCaptureMethod.TRANSPORT_MANIFEST}" and the "${WEIGHING}" event is valid`,
   },
   {
@@ -710,7 +710,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       grossWeight: 100,
       tare: 1,
     }),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: 'The calculated net weight is not equal to the mass net weight',
   },
   {
@@ -730,7 +730,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and missing Tare`,
   },
   {
@@ -746,7 +746,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined' as unknown)} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${WEIGHING}" event fails for TRUCK container without tare exception and missing Tare`,
   },
   {
@@ -766,7 +766,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING}" event is valid for non-TRUCK (BIN) container with tare exception and missing Tare`,
   },
   {
@@ -793,7 +793,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       grossWeight: 100,
       tare: 1,
     }),
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${WEIGHING}" event fails for non-TRUCK (BIN) container with tare exception when net weight calculation fails`,
   },
   {
@@ -811,7 +811,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and Tare provided`,
   },
   {
@@ -829,7 +829,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and missing Gross Weight`,
   },
   {
@@ -849,7 +849,7 @@ export const weighingTestCases: WeighingTestCase[] = [
     resultComment: PASSED_RESULT_COMMENTS.PASSED_WITH_TARE_EXCEPTION(
       PASSED_RESULT_COMMENTS.SINGLE_STEP,
     ),
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING}" event is valid for TRUCK container with tare exception and both Tare and Gross Weight missing`,
   },
   {
@@ -868,7 +868,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined')} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${WEIGHING}" event fails for TRUCK container with expired tare exception (Valid Until in past) and missing Tare`,
   },
   {
@@ -887,7 +887,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: `${WRONG_FORMAT_RESULT_COMMENTS.TARE('undefined')} ${INVALID_RESULT_COMMENTS.TARE_FORMAT}`,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The "${WEIGHING}" event fails for TRUCK container with invalid tare exception Valid Until date format and missing Tare`,
   },
   {
@@ -903,7 +903,7 @@ export const weighingTestCases: WeighingTestCase[] = [
       ]),
     },
     resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: `The "${WEIGHING}" event is valid for TRUCK container without tare exception and both Tare and Gross Weight provided`,
   },
 ];
@@ -931,7 +931,7 @@ export const weighingErrorTestCases: WeighingErrorTestCase[] = [
     documents: [...participantsAccreditationDocuments.values()],
     massIDAuditDocument,
     resultComment: processorErrors.ERROR_MESSAGE.MASS_ID_DOCUMENT_NOT_FOUND,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The MassID document was not found`,
   },
   {
@@ -939,7 +939,7 @@ export const weighingErrorTestCases: WeighingErrorTestCase[] = [
     massIDAuditDocument,
     resultComment:
       processorErrors.ERROR_MESSAGE.MISSING_RECYCLER_ACCREDITATION_DOCUMENT,
-    resultStatus: 'FAILED' as const,
+    resultStatus: 'FAILED',
     scenario: `The Recycler accreditation document was not found`,
   },
 ];

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
@@ -4,7 +4,6 @@ import { STSClient } from '@aws-sdk/client-sts';
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
 import { getSentryDsn } from '@carrot-fndn/shared/env';
 import { logger } from '@carrot-fndn/shared/helpers';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import {
   stubContext,
   stubRuleInput,
@@ -60,7 +59,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
   it('should work', async () => {
     const response = {
       ...stubRuleOutput(),
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
 
     class Wrapped extends RuleDataProcessor {
@@ -80,7 +79,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
   it('should convert REVIEW_REQUIRED to FAILED before reporting and returning', async () => {
     const response = {
       ...stubRuleOutput(),
-      resultStatus: RuleOutputStatus.REVIEW_REQUIRED,
+      resultStatus: 'REVIEW_REQUIRED' as const,
     };
 
     class Wrapped extends RuleDataProcessor {
@@ -96,7 +95,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
 
     expect(result).toEqual({
       ...response,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     });
   });
 
@@ -134,7 +133,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
 
     const response = {
       ...stubRuleOutput(),
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
 
     class Wrapped extends RuleDataProcessor {
@@ -186,7 +185,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
 
     const response = {
       ...stubRuleOutput(),
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
 
     class Wrapped extends RuleDataProcessor {

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -10,10 +10,7 @@ import {
 } from '@carrot-fndn/shared/env';
 import { logger } from '@carrot-fndn/shared/helpers';
 import { reportRuleResults } from '@carrot-fndn/shared/rule/result';
-import {
-  RuleInputSchema,
-  RuleOutputStatus,
-} from '@carrot-fndn/shared/rule/types';
+import { RuleInputSchema } from '@carrot-fndn/shared/rule/types';
 import { AWSLambda, setTags } from '@sentry/serverless';
 
 const mapEventToRuleInput = (event: MethodologyRuleEvent): RuleInput =>
@@ -24,8 +21,8 @@ const mapRuleOutputToLambdaResult = (ruleOutput: RuleOutput): unknown =>
 
 // TODO: remove once Smaug supports REVIEW_REQUIRED
 const toUpstreamCompatibleOutput = (ruleOutput: RuleOutput): RuleOutput =>
-  ruleOutput.resultStatus === RuleOutputStatus.REVIEW_REQUIRED
-    ? { ...ruleOutput, resultStatus: RuleOutputStatus.FAILED }
+  ruleOutput.resultStatus === 'REVIEW_REQUIRED'
+    ? { ...ruleOutput, resultStatus: 'FAILED' as const }
     : ruleOutput;
 
 const setRuleSentryTags = ({

--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.ts
@@ -22,7 +22,7 @@ const mapRuleOutputToLambdaResult = (ruleOutput: RuleOutput): unknown =>
 // TODO: remove once Smaug supports REVIEW_REQUIRED
 const toUpstreamCompatibleOutput = (ruleOutput: RuleOutput): RuleOutput =>
   ruleOutput.resultStatus === 'REVIEW_REQUIRED'
-    ? { ...ruleOutput, resultStatus: 'FAILED' as const }
+    ? { ...ruleOutput, resultStatus: 'FAILED' }
     : ruleOutput;
 
 const setRuleSentryTags = ({

--- a/libs/shared/methodologies/bold/processors/src/parent-document-rule-processor.spec.ts
+++ b/libs/shared/methodologies/bold/processors/src/parent-document-rule-processor.spec.ts
@@ -4,10 +4,7 @@ import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-dat
 import { isNil } from '@carrot-fndn/shared/helpers';
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
 import { stubDocument } from '@carrot-fndn/shared/methodologies/bold/testing';
-import {
-  type RuleInput,
-  RuleOutputStatus,
-} from '@carrot-fndn/shared/rule/types';
+import { type RuleInput } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 
 import { ParentDocumentRuleProcessor } from './parent-document-rule-processor';
@@ -22,9 +19,7 @@ describe('ParentDocumentRuleProcessor', () => {
   > {
     evaluateResult(data: []): EvaluateResultOutput {
       return {
-        resultStatus: isNil(data)
-          ? RuleOutputStatus.FAILED
-          : RuleOutputStatus.PASSED,
+        resultStatus: isNil(data) ? 'FAILED' : 'PASSED',
       };
     }
 

--- a/libs/shared/rule/standard-data-processor/src/rule-standard-data-processor.spec.ts
+++ b/libs/shared/rule/standard-data-processor/src/rule-standard-data-processor.spec.ts
@@ -60,7 +60,7 @@ describe('RuleStandardDataProcessor', () => {
         ruleStandardDataProcessor['getDocumentNotFoundResultComment'](
           parentDocumentId,
         ),
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -84,7 +84,7 @@ describe('RuleStandardDataProcessor', () => {
       responseUrl: ruleInput.responseUrl,
       resultComment:
         ruleStandardDataProcessor['getMissingRuleSubjectResultComment'](),
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -102,7 +102,7 @@ describe('RuleStandardDataProcessor', () => {
       requestId: ruleInput.requestId,
       responseToken: ruleInput.responseToken,
       responseUrl: ruleInput.responseUrl,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -112,7 +112,7 @@ describe('RuleStandardDataProcessor', () => {
     const ruleInput = stubRuleInput();
 
     (ruleStandardDataProcessor as any)['evaluateResult'] = vi.fn(() => ({
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     }));
 
     const result = await ruleStandardDataProcessor.process({
@@ -124,7 +124,7 @@ describe('RuleStandardDataProcessor', () => {
       requestId: ruleInput.requestId,
       responseToken: ruleInput.responseToken,
       responseUrl: ruleInput.responseUrl,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -135,7 +135,7 @@ describe('RuleStandardDataProcessor', () => {
 
     (ruleStandardDataProcessor as any)['evaluateResult'] = vi.fn(() => ({
       resultComment: 'Failed',
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     }));
 
     const result = await ruleStandardDataProcessor.process({
@@ -148,7 +148,7 @@ describe('RuleStandardDataProcessor', () => {
       responseToken: ruleInput.responseToken,
       responseUrl: ruleInput.responseUrl,
       resultComment: 'Failed',
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -161,7 +161,7 @@ describe('RuleStandardDataProcessor', () => {
     (ruleStandardDataProcessor as any)['evaluateResult'] = vi.fn(() => ({
       resultComment: 'Failed',
       resultContent,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     }));
 
     const result = await ruleStandardDataProcessor.process({
@@ -175,7 +175,7 @@ describe('RuleStandardDataProcessor', () => {
       responseUrl: ruleInput.responseUrl,
       resultComment: 'Failed',
       resultContent,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     };
 
     expect(result).toEqual(expectedRuleOutput);

--- a/libs/shared/rule/standard-data-processor/src/rule-standard-data-processor.spec.ts
+++ b/libs/shared/rule/standard-data-processor/src/rule-standard-data-processor.spec.ts
@@ -2,7 +2,6 @@ import { isNil } from '@carrot-fndn/shared/helpers';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
@@ -19,9 +18,7 @@ describe('RuleStandardDataProcessor', () => {
   > {
     protected evaluateResult(data: string[]): EvaluateResultOutput {
       return {
-        resultStatus: isNil(data)
-          ? RuleOutputStatus.FAILED
-          : RuleOutputStatus.PASSED,
+        resultStatus: isNil(data) ? 'FAILED' : 'PASSED',
       };
     }
 
@@ -63,7 +60,7 @@ describe('RuleStandardDataProcessor', () => {
         ruleStandardDataProcessor['getDocumentNotFoundResultComment'](
           parentDocumentId,
         ),
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -87,7 +84,7 @@ describe('RuleStandardDataProcessor', () => {
       responseUrl: ruleInput.responseUrl,
       resultComment:
         ruleStandardDataProcessor['getMissingRuleSubjectResultComment'](),
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -105,7 +102,7 @@ describe('RuleStandardDataProcessor', () => {
       requestId: ruleInput.requestId,
       responseToken: ruleInput.responseToken,
       responseUrl: ruleInput.responseUrl,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -115,7 +112,7 @@ describe('RuleStandardDataProcessor', () => {
     const ruleInput = stubRuleInput();
 
     (ruleStandardDataProcessor as any)['evaluateResult'] = vi.fn(() => ({
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     }));
 
     const result = await ruleStandardDataProcessor.process({
@@ -127,7 +124,7 @@ describe('RuleStandardDataProcessor', () => {
       requestId: ruleInput.requestId,
       responseToken: ruleInput.responseToken,
       responseUrl: ruleInput.responseUrl,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -138,7 +135,7 @@ describe('RuleStandardDataProcessor', () => {
 
     (ruleStandardDataProcessor as any)['evaluateResult'] = vi.fn(() => ({
       resultComment: 'Failed',
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     }));
 
     const result = await ruleStandardDataProcessor.process({
@@ -151,7 +148,7 @@ describe('RuleStandardDataProcessor', () => {
       responseToken: ruleInput.responseToken,
       responseUrl: ruleInput.responseUrl,
       resultComment: 'Failed',
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
 
     expect(result).toEqual(expectedRuleOutput);
@@ -164,7 +161,7 @@ describe('RuleStandardDataProcessor', () => {
     (ruleStandardDataProcessor as any)['evaluateResult'] = vi.fn(() => ({
       resultComment: 'Failed',
       resultContent,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     }));
 
     const result = await ruleStandardDataProcessor.process({
@@ -178,7 +175,7 @@ describe('RuleStandardDataProcessor', () => {
       responseUrl: ruleInput.responseUrl,
       resultComment: 'Failed',
       resultContent,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     };
 
     expect(result).toEqual(expectedRuleOutput);

--- a/libs/shared/rule/standard-data-processor/src/rule-standard-data-processor.ts
+++ b/libs/shared/rule/standard-data-processor/src/rule-standard-data-processor.ts
@@ -6,7 +6,7 @@ import { mapToRuleOutput } from '@carrot-fndn/shared/rule/result';
 import {
   type RuleInput,
   type RuleOutput,
-  RuleOutputStatus,
+  type RuleOutputStatus,
 } from '@carrot-fndn/shared/rule/types';
 
 export interface EvaluateResultOutput {
@@ -23,7 +23,7 @@ export abstract class RuleStandardDataProcessor<
     const document = await this.loadDocument(ruleInput);
 
     if (isNil(document)) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.FAILED, {
+      return mapToRuleOutput(ruleInput, 'FAILED', {
         resultComment: this.getDocumentNotFoundResultComment(
           ruleInput.parentDocumentId as string,
         ),
@@ -33,7 +33,7 @@ export abstract class RuleStandardDataProcessor<
     const ruleSubject = await this.getRuleSubject(document);
 
     if (isNil(ruleSubject)) {
-      return mapToRuleOutput(ruleInput, RuleOutputStatus.PASSED, {
+      return mapToRuleOutput(ruleInput, 'PASSED', {
         resultComment: this.getMissingRuleSubjectResultComment(),
       });
     }

--- a/libs/shared/rule/types/src/rule.types.spec.ts
+++ b/libs/shared/rule/types/src/rule.types.spec.ts
@@ -1,7 +1,6 @@
 import {
   RuleInputSchema,
   RuleOutputSchema,
-  RuleOutputStatus,
   RuleOutputStatusSchema,
 } from './rule.types';
 
@@ -128,7 +127,7 @@ describe('RuleOutputSchema', () => {
     requestId: 'req-123',
     responseToken: 'token-abc',
     responseUrl: 'https://example.com/callback',
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
   };
 
   it('should accept a valid input with required fields', () => {

--- a/libs/shared/rule/types/src/rule.types.spec.ts
+++ b/libs/shared/rule/types/src/rule.types.spec.ts
@@ -127,7 +127,7 @@ describe('RuleOutputSchema', () => {
     requestId: 'req-123',
     responseToken: 'token-abc',
     responseUrl: 'https://example.com/callback',
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
   };
 
   it('should accept a valid input with required fields', () => {

--- a/tools/create-rule.js
+++ b/tools/create-rule.js
@@ -104,7 +104,6 @@ export const ${camelCase}Lambda = wrapRuleIntoLambdaHandler(instance);\n`,
 import { isNil } from '@carrot-fndn/shared/helpers';
 import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/bold/processors';
 import { type Document } from '@carrot-fndn/shared/methodologies/bold/types';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { ${pascalCase}ProcessorErrors } from './${fileName}.errors';
 
@@ -127,7 +126,7 @@ export class ${pascalCase}Processor extends ParentDocumentRuleProcessor<Document
       return {
         resultComment:
           this.processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
-        resultStatus: RuleOutputStatus.FAILED,
+        resultStatus: 'FAILED' as const,
       };
     }
 
@@ -145,7 +144,7 @@ export class ${pascalCase}Processor extends ParentDocumentRuleProcessor<Document
 
     return {
       resultComment: this.RESULT_COMMENT.PASSED,
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     };
   }
 
@@ -170,7 +169,7 @@ export class ${pascalCase}ProcessorErrors extends BaseProcessorErrors {
     content: `import type { Document } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { type RuleOutput, RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
+import { type RuleOutput, type RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 
 import { ${pascalCase}Processor } from './${fileName}.processor';
@@ -216,7 +215,6 @@ describe('${pascalCase}Processor', () => {
   {
     name: `${fileName}.test-cases.ts`,
     content: `import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import { RESULT_COMMENTS } from './${fileName}.processor';
 
@@ -226,7 +224,7 @@ export const ${camelCase}TestCases = [
   {
     document: stubs.massIdDocumentStub,
     resultComment: RESULT_COMMENTS.PASSED,
-    resultStatus: RuleOutputStatus.PASSED,
+    resultStatus: 'PASSED' as const,
     scenario: 'all the criteria are met',
   },
   // Add more test cases as needed

--- a/tools/create-rule.js
+++ b/tools/create-rule.js
@@ -126,7 +126,7 @@ export class ${pascalCase}Processor extends ParentDocumentRuleProcessor<Document
       return {
         resultComment:
           this.processorErrors.ERROR_MESSAGE.DOCUMENT_TYPE_NOT_FOUND,
-        resultStatus: 'FAILED' as const,
+        resultStatus: 'FAILED',
       };
     }
 
@@ -144,7 +144,7 @@ export class ${pascalCase}Processor extends ParentDocumentRuleProcessor<Document
 
     return {
       resultComment: this.RESULT_COMMENT.PASSED,
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     };
   }
 
@@ -224,7 +224,7 @@ export const ${camelCase}TestCases = [
   {
     document: stubs.massIdDocumentStub,
     resultComment: RESULT_COMMENTS.PASSED,
-    resultStatus: 'PASSED' as const,
+    resultStatus: 'PASSED',
     scenario: 'all the criteria are met',
   },
   // Add more test cases as needed

--- a/tools/rule-runner-cli/src/commands/dry-run.handler.spec.ts
+++ b/tools/rule-runner-cli/src/commands/dry-run.handler.spec.ts
@@ -81,7 +81,7 @@ const mockRuleOutput: RuleOutput = {
   responseToken: 'cli-placeholder-token',
   responseUrl: 'https://localhost/placeholder' as RuleOutput['responseUrl'],
   resultComment: 'Test passed',
-  resultStatus: 'PASSED' as const,
+  resultStatus: 'PASSED',
 };
 
 describe('handleDryRun', () => {
@@ -159,7 +159,7 @@ describe('handleDryRun', () => {
   it('should return review_required status for REVIEW_REQUIRED rule output', async () => {
     mockProcess.mockResolvedValue({
       ...mockRuleOutput,
-      resultStatus: 'REVIEW_REQUIRED' as const,
+      resultStatus: 'REVIEW_REQUIRED',
     });
 
     const result = await handleDryRun('some/path', baseOptions);
@@ -170,7 +170,7 @@ describe('handleDryRun', () => {
   it('should return failed status for FAILED rule output', async () => {
     mockProcess.mockResolvedValue({
       ...mockRuleOutput,
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     });
 
     const result = await handleDryRun('some/path', baseOptions);

--- a/tools/rule-runner-cli/src/commands/dry-run.handler.spec.ts
+++ b/tools/rule-runner-cli/src/commands/dry-run.handler.spec.ts
@@ -1,7 +1,6 @@
 import type { RuleOutput } from '@carrot-fndn/shared/rule/types';
 
 import { logger } from '@carrot-fndn/shared/helpers';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 import type { DryRunOptions } from './dry-run.command';
 
@@ -82,7 +81,7 @@ const mockRuleOutput: RuleOutput = {
   responseToken: 'cli-placeholder-token',
   responseUrl: 'https://localhost/placeholder' as RuleOutput['responseUrl'],
   resultComment: 'Test passed',
-  resultStatus: RuleOutputStatus.PASSED,
+  resultStatus: 'PASSED' as const,
 };
 
 describe('handleDryRun', () => {
@@ -160,7 +159,7 @@ describe('handleDryRun', () => {
   it('should return review_required status for REVIEW_REQUIRED rule output', async () => {
     mockProcess.mockResolvedValue({
       ...mockRuleOutput,
-      resultStatus: RuleOutputStatus.REVIEW_REQUIRED,
+      resultStatus: 'REVIEW_REQUIRED' as const,
     });
 
     const result = await handleDryRun('some/path', baseOptions);
@@ -171,7 +170,7 @@ describe('handleDryRun', () => {
   it('should return failed status for FAILED rule output', async () => {
     mockProcess.mockResolvedValue({
       ...mockRuleOutput,
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     });
 
     const result = await handleDryRun('some/path', baseOptions);

--- a/tools/rule-runner-cli/src/commands/dry-run.handler.ts
+++ b/tools/rule-runner-cli/src/commands/dry-run.handler.ts
@@ -1,8 +1,10 @@
-import type { RuleOutput } from '@carrot-fndn/shared/rule/types';
+import type {
+  RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
 
 import { formatAsJson } from '@carrot-fndn/shared/cli';
 import { logger } from '@carrot-fndn/shared/helpers';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import path from 'node:path';
 
 import type { DryRunOptions } from './dry-run.command';
@@ -107,15 +109,15 @@ const mapOutputStatus = (
   status: RuleOutputStatus,
 ): DryRunRuleResult['status'] => {
   switch (status) {
-    case RuleOutputStatus.FAILED: {
+    case 'FAILED': {
       return 'failed';
     }
 
-    case RuleOutputStatus.PASSED: {
+    case 'PASSED': {
       return 'passed';
     }
 
-    case RuleOutputStatus.REVIEW_REQUIRED: {
+    case 'REVIEW_REQUIRED': {
       return 'review_required';
     }
   }

--- a/tools/rule-runner-cli/src/commands/run-batch.handler.ts
+++ b/tools/rule-runner-cli/src/commands/run-batch.handler.ts
@@ -9,7 +9,6 @@ import {
   yellow,
 } from '@carrot-fndn/shared/cli';
 import { logger } from '@carrot-fndn/shared/helpers';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -178,9 +177,9 @@ export const handleRunBatch = async (
       logger.error(`Error [${entry.methodologyExecutionId}]: ${error}`);
     },
     onItemSuccess: (entry, { elapsedMs, output }) => {
-      if (output.resultStatus === RuleOutputStatus.PASSED) {
+      if (output.resultStatus === 'PASSED') {
         passedCount++;
-      } else if (output.resultStatus === RuleOutputStatus.REVIEW_REQUIRED) {
+      } else if (output.resultStatus === 'REVIEW_REQUIRED') {
         reviewRequiredCount++;
         reviewRequiredResults.push({
           entry,

--- a/tools/rule-runner-cli/src/formatters/human.formatter.spec.ts
+++ b/tools/rule-runner-cli/src/formatters/human.formatter.spec.ts
@@ -1,5 +1,3 @@
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
-
 import { formatAsHuman } from './human.formatter';
 
 describe('formatAsHuman', () => {
@@ -10,7 +8,7 @@ describe('formatAsHuman', () => {
         responseToken: 'token',
         responseUrl: 'https://localhost/placeholder' as never,
         resultComment: 'All checks passed',
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       },
       { elapsedMs: 150 },
     );
@@ -26,7 +24,7 @@ describe('formatAsHuman', () => {
       responseToken: 'token',
       responseUrl: 'https://localhost/placeholder' as never,
       resultComment: 'Validation failed',
-      resultStatus: RuleOutputStatus.FAILED,
+      resultStatus: 'FAILED' as const,
     });
 
     expect(output).toContain('✗ FAILED');
@@ -39,7 +37,7 @@ describe('formatAsHuman', () => {
       responseToken: 'token',
       responseUrl: 'https://localhost/placeholder' as never,
       resultComment: 'Review required: vehicle plate mismatch',
-      resultStatus: RuleOutputStatus.REVIEW_REQUIRED,
+      resultStatus: 'REVIEW_REQUIRED' as const,
     });
 
     expect(output).toContain('⚠ REVIEW_REQUIRED');
@@ -52,7 +50,7 @@ describe('formatAsHuman', () => {
       responseToken: 'token',
       responseUrl: 'https://localhost/placeholder' as never,
       resultContent: { distance: 42 },
-      resultStatus: RuleOutputStatus.PASSED,
+      resultStatus: 'PASSED' as const,
     });
 
     expect(output).toContain('Result Content');
@@ -65,7 +63,7 @@ describe('formatAsHuman', () => {
         requestId: 'req-1',
         responseToken: 'token',
         responseUrl: 'https://localhost/placeholder' as never,
-        resultStatus: RuleOutputStatus.PASSED,
+        resultStatus: 'PASSED' as const,
       },
       { debug: true },
     );

--- a/tools/rule-runner-cli/src/formatters/human.formatter.spec.ts
+++ b/tools/rule-runner-cli/src/formatters/human.formatter.spec.ts
@@ -8,7 +8,7 @@ describe('formatAsHuman', () => {
         responseToken: 'token',
         responseUrl: 'https://localhost/placeholder' as never,
         resultComment: 'All checks passed',
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       },
       { elapsedMs: 150 },
     );
@@ -24,7 +24,7 @@ describe('formatAsHuman', () => {
       responseToken: 'token',
       responseUrl: 'https://localhost/placeholder' as never,
       resultComment: 'Validation failed',
-      resultStatus: 'FAILED' as const,
+      resultStatus: 'FAILED',
     });
 
     expect(output).toContain('✗ FAILED');
@@ -37,7 +37,7 @@ describe('formatAsHuman', () => {
       responseToken: 'token',
       responseUrl: 'https://localhost/placeholder' as never,
       resultComment: 'Review required: vehicle plate mismatch',
-      resultStatus: 'REVIEW_REQUIRED' as const,
+      resultStatus: 'REVIEW_REQUIRED',
     });
 
     expect(output).toContain('⚠ REVIEW_REQUIRED');
@@ -50,7 +50,7 @@ describe('formatAsHuman', () => {
       responseToken: 'token',
       responseUrl: 'https://localhost/placeholder' as never,
       resultContent: { distance: 42 },
-      resultStatus: 'PASSED' as const,
+      resultStatus: 'PASSED',
     });
 
     expect(output).toContain('Result Content');
@@ -63,7 +63,7 @@ describe('formatAsHuman', () => {
         requestId: 'req-1',
         responseToken: 'token',
         responseUrl: 'https://localhost/placeholder' as never,
-        resultStatus: 'PASSED' as const,
+        resultStatus: 'PASSED',
       },
       { debug: true },
     );

--- a/tools/rule-runner-cli/src/formatters/human.formatter.ts
+++ b/tools/rule-runner-cli/src/formatters/human.formatter.ts
@@ -1,7 +1,9 @@
-import type { RuleOutput } from '@carrot-fndn/shared/rule/types';
+import type {
+  RuleOutput,
+  RuleOutputStatus,
+} from '@carrot-fndn/shared/rule/types';
 
 import { blue, bold, gray, green, red, yellow } from '@carrot-fndn/shared/cli';
-import { RuleOutputStatus } from '@carrot-fndn/shared/rule/types';
 
 interface HumanFormatOptions {
   debug?: boolean;
@@ -12,9 +14,9 @@ const STATUS_DISPLAY: Record<
   RuleOutputStatus,
   { color: (text: string) => string; icon: string }
 > = {
-  [RuleOutputStatus.FAILED]: { color: red, icon: '✗' },
-  [RuleOutputStatus.PASSED]: { color: green, icon: '✓' },
-  [RuleOutputStatus.REVIEW_REQUIRED]: { color: yellow, icon: '⚠' },
+  FAILED: { color: red, icon: '✗' },
+  PASSED: { color: green, icon: '✓' },
+  REVIEW_REQUIRED: { color: yellow, icon: '⚠' },
 };
 
 export const formatAsHuman = (


### PR DESCRIPTION
## Summary

- Replace `RuleOutputStatus.PASSED`/`FAILED`/`REVIEW_REQUIRED` with string literals across 61 consumer files
- Remove unused `RuleOutputStatus` value imports, convert to `import type` where only used as type
- Add `as const` assertions where needed to preserve narrow literal types (`.map()` callbacks, spread objects)
- Update `create-rule.js` templates to generate the new pattern
- Keep `RuleOutputStatus` constant only where required:
  - `typeof` expressions (discriminated unions)
  - `Record<RuleOutputStatus, ...>` type keys
  - Destructuring for template strings (`bold-mass-id-audit.stubs.ts`)
  - Dynamic access (`stubEnumValue`, `rule-result.helpers.spec.ts`)

## Files changed (61)

42 rule processors, 22 test-cases/spec files, CLI handlers, formatters, `create-rule.js` template

## Test plan

- [x] `pnpm ts:affected` — 79+ projects typecheck pass
- [x] `pnpm lint:affected` — 102 projects pass
- [x] `pnpm test:affected` — 97 projects pass
- [x] Pre-commit hooks (cspell, eslint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)