### PR TITLE
feat(types): migrate MethodologyDocument and dependent types to Zod-first schemas

### DIFF
--- a/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
+++ b/libs/shared/lambda/wrapper/src/lambda-wrapper.spec.ts
@@ -59,6 +59,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
   it('should work', async () => {
     const response = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       resultStatus: 'PASSED' as const,
     };
 
@@ -79,6 +80,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
   it('should convert REVIEW_REQUIRED to FAILED before reporting and returning', async () => {
     const response = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       resultStatus: 'REVIEW_REQUIRED' as const,
     };
 
@@ -133,6 +135,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
 
     const response = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       resultStatus: 'PASSED' as const,
     };
 
@@ -185,6 +188,7 @@ describe('wrapRuleIntoLambdaHandler', () => {
 
     const response = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       resultStatus: 'PASSED' as const,
     };
 

--- a/libs/shared/methodologies/bold/io-helpers/src/document-helpers.validators.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document-helpers.validators.ts
@@ -1,24 +1,4 @@
-import { z } from 'zod';
-
-import {
-  MethodologyAddressSchema,
-  MethodologyParticipantSchema,
-} from './document.schemas';
-
-const DocumentSchema = z.looseObject({
-  category: z.string(),
-  createdAt: z.string(),
-  currentValue: z.number(),
-  dataSetName: z.string(),
-  externalCreatedAt: z.string(),
-  id: z.string(),
-  isPubliclySearchable: z.boolean(),
-  measurementUnit: z.string(),
-  primaryAddress: MethodologyAddressSchema,
-  primaryParticipant: MethodologyParticipantSchema,
-  status: z.string(),
-  updatedAt: z.string(),
-});
+import { MethodologyDocumentSchema } from '@carrot-fndn/shared/types';
 
 export const validateDocument = (input: unknown) =>
-  DocumentSchema.safeParse(input);
+  MethodologyDocumentSchema.safeParse(input);

--- a/libs/shared/methodologies/bold/io-helpers/src/document-helpers.validators.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document-helpers.validators.ts
@@ -1,4 +1,6 @@
 import { MethodologyDocumentSchema } from '@carrot-fndn/shared/types';
 
-export const validateDocument = (input: unknown) =>
+export const validateDocument = (
+  input: unknown,
+): ReturnType<typeof MethodologyDocumentSchema.safeParse> =>
   MethodologyDocumentSchema.safeParse(input);

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
@@ -22,7 +22,7 @@ export const loadDocument = async (
     const validation = validateDocument(document);
 
     if (!validation.success) {
-      logger.warn(
+      logger.error(
         { validationErrors: validation.error.issues },
         `[loadDocument] Invalid document ${key}`,
       );

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
@@ -23,8 +23,8 @@ export const loadDocument = async (
 
     if (!validation.success) {
       logger.error(
-        { validationErrors: validation.error.issues },
-        `[loadDocument] Invalid document ${key}`,
+        { documentKey: key, err: validation.error, operation: 'loadDocument' },
+        '[loadDocument] Invalid document',
       );
 
       return undefined;

--- a/libs/shared/methodologies/bold/io-helpers/src/document.schemas.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.schemas.ts
@@ -1,4 +1,0 @@
-export {
-  MethodologyAddressSchema,
-  MethodologyParticipantSchema,
-} from '@carrot-fndn/shared/types';

--- a/libs/shared/methodologies/bold/io-helpers/src/document.schemas.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.schemas.ts
@@ -1,32 +1,4 @@
-import {
-  LatitudeSchema,
-  LongitudeSchema,
-  NonEmptyStringSchema,
+export {
+  MethodologyAddressSchema,
+  MethodologyParticipantSchema,
 } from '@carrot-fndn/shared/types';
-import { z } from 'zod';
-
-export const MethodologyAddressSchema = z.looseObject({
-  city: NonEmptyStringSchema,
-  countryCode: NonEmptyStringSchema,
-  countryState: NonEmptyStringSchema,
-  id: NonEmptyStringSchema,
-  latitude: LatitudeSchema,
-  longitude: LongitudeSchema,
-  neighborhood: NonEmptyStringSchema,
-  number: NonEmptyStringSchema,
-  participantId: NonEmptyStringSchema,
-  piiSnapshotId: NonEmptyStringSchema,
-  street: NonEmptyStringSchema,
-  zipCode: NonEmptyStringSchema,
-});
-
-export const MethodologyParticipantSchema = z.looseObject({
-  businessName: NonEmptyStringSchema.optional(),
-  countryCode: NonEmptyStringSchema,
-  id: NonEmptyStringSchema,
-  name: NonEmptyStringSchema,
-  piiSnapshotId: NonEmptyStringSchema,
-  taxId: NonEmptyStringSchema,
-  taxIdType: NonEmptyStringSchema,
-  type: NonEmptyStringSchema,
-});

--- a/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
@@ -36,7 +36,6 @@ export const isRecycledEvent = (event: DocumentEvent): boolean =>
   eventHasName(event, DocumentEventName.RECYCLED);
 
 export const eventHasActorParticipant = (event: DocumentEvent): boolean =>
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
   event.participant.type === MethodologyParticipantType.ACTOR;
 
 export const eventHasNonEmptyStringAttribute = (

--- a/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
+++ b/libs/shared/methodologies/bold/predicates/src/event.predicates.ts
@@ -36,7 +36,7 @@ export const isRecycledEvent = (event: DocumentEvent): boolean =>
   eventHasName(event, DocumentEventName.RECYCLED);
 
 export const eventHasActorParticipant = (event: DocumentEvent): boolean =>
-  event.participant.type === MethodologyParticipantType.ACTOR;
+  event.participant.type === MethodologyParticipantType.ACTOR.toString();
 
 export const eventHasNonEmptyStringAttribute = (
   event: DocumentEvent,
@@ -107,8 +107,13 @@ export const eventHasMetadataAttribute = (options: {
 export const eventHasCarrotParticipant = (
   event: DocumentEvent,
   dataSetName: DataSetName,
-): boolean =>
-  event.participant.id ===
-    CARROT_PARTICIPANT_BY_ENVIRONMENT.development[dataSetName].id ||
-  event.participant.id ===
-    CARROT_PARTICIPANT_BY_ENVIRONMENT.production[dataSetName].id;
+): boolean => {
+  const development =
+    CARROT_PARTICIPANT_BY_ENVIRONMENT.development[dataSetName];
+  const production = CARROT_PARTICIPANT_BY_ENVIRONMENT.production[dataSetName];
+
+  return (
+    event.participant.id === development.id ||
+    event.participant.id === production.id
+  );
+};

--- a/libs/shared/rule/result/src/rule-result.helpers.spec.ts
+++ b/libs/shared/rule/result/src/rule-result.helpers.spec.ts
@@ -142,8 +142,8 @@ describe('reportRuleResults', () => {
   it('should send a request to the given responseUrl', async () => {
     const ruleOutput = {
       ...stubRuleOutput(),
-      resultContent: { [faker.string.sample()]: faker.string.sample() },
       responseUrl: faker.internet.url(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
     };
 
     vi.spyOn(STSClient.prototype, 'send').mockResolvedValue({
@@ -197,8 +197,8 @@ describe('reportRuleResults', () => {
   it('should throw error when response code is not ok', async () => {
     const ruleOutput = {
       ...stubRuleOutput(),
-      resultContent: { [faker.string.sample()]: faker.string.sample() },
       responseUrl: faker.internet.url(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
     };
 
     vi.spyOn(STSClient.prototype, 'send').mockResolvedValue({
@@ -221,8 +221,8 @@ describe('reportRuleResults', () => {
   it('should throw error when the request throws error', async () => {
     const ruleOutput = {
       ...stubRuleOutput(),
-      resultContent: { [faker.string.sample()]: faker.string.sample() },
       responseUrl: faker.internet.url(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
     };
 
     const errorResponse = new Response();

--- a/libs/shared/rule/result/src/rule-result.helpers.spec.ts
+++ b/libs/shared/rule/result/src/rule-result.helpers.spec.ts
@@ -142,6 +142,7 @@ describe('reportRuleResults', () => {
   it('should send a request to the given responseUrl', async () => {
     const ruleOutput = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       responseUrl: faker.internet.url(),
     };
 
@@ -196,6 +197,7 @@ describe('reportRuleResults', () => {
   it('should throw error when response code is not ok', async () => {
     const ruleOutput = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       responseUrl: faker.internet.url(),
     };
 
@@ -219,6 +221,7 @@ describe('reportRuleResults', () => {
   it('should throw error when the request throws error', async () => {
     const ruleOutput = {
       ...stubRuleOutput(),
+      resultContent: { [faker.string.sample()]: faker.string.sample() },
       responseUrl: faker.internet.url(),
     };
 

--- a/libs/shared/testing/src/stubs/handler.stubs.ts
+++ b/libs/shared/testing/src/stubs/handler.stubs.ts
@@ -21,7 +21,7 @@ export const stubContext = (): Context => ({
   fail: () => {},
   functionName: faker.string.sample(),
   functionVersion: faker.string.sample(),
-  getRemainingTimeInMillis: () => faker.number.int(),
+  getRemainingTimeInMillis: () => faker.number.int({ max: 900_000 }),
   invokedFunctionArn: faker.string.sample(),
   logGroupName: faker.string.sample(),
   logStreamName: faker.string.sample(),

--- a/libs/shared/types/src/methodology/methodology-address.types.ts
+++ b/libs/shared/types/src/methodology/methodology-address.types.ts
@@ -1,14 +1,20 @@
-export interface MethodologyAddress {
-  city: string;
-  countryCode: string;
-  countryState: string;
-  id: string;
-  latitude: number;
-  longitude: number;
-  neighborhood: string;
-  number: string;
-  participantId: string;
-  piiSnapshotId: string;
-  street: string;
-  zipCode: string;
-}
+import { z } from 'zod';
+
+import { LatitudeSchema, LongitudeSchema } from '../number.types';
+import { NonEmptyStringSchema } from '../string.types';
+
+export const MethodologyAddressSchema = z.looseObject({
+  city: NonEmptyStringSchema,
+  countryCode: NonEmptyStringSchema,
+  countryState: NonEmptyStringSchema,
+  id: NonEmptyStringSchema,
+  latitude: LatitudeSchema,
+  longitude: LongitudeSchema,
+  neighborhood: NonEmptyStringSchema,
+  number: NonEmptyStringSchema,
+  participantId: NonEmptyStringSchema,
+  piiSnapshotId: NonEmptyStringSchema,
+  street: NonEmptyStringSchema,
+  zipCode: NonEmptyStringSchema,
+});
+export type MethodologyAddress = z.infer<typeof MethodologyAddressSchema>;

--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -1,17 +1,19 @@
-import type { DateTime, UnknownObject } from '../common.types';
-import type { MethodologyAddress } from './methodology-address.types';
+import { z } from 'zod';
+
+import type { UnknownObject } from '../common.types';
 import type {
   MethodologyDocumentEventAttributeFormat,
   MethodologyDocumentEventAttributeType,
-  MethodologyDocumentEventLabel,
-  MethodologyDocumentEventName,
 } from './methodology-enum.types';
-import type {
-  MethodologyAuthor,
-  MethodologyParticipant,
-} from './methodology-participant.types';
 
-import { type NonEmptyString } from '../string.types';
+import { DateTimeSchema } from '../common.types';
+import { NonNegativeFloatSchema } from '../number.types';
+import { type NonEmptyString, NonEmptyStringSchema } from '../string.types';
+import { MethodologyAddressSchema } from './methodology-address.types';
+import {
+  MethodologyAuthorSchema,
+  MethodologyParticipantSchema,
+} from './methodology-participant.types';
 
 export interface ApprovedException {
   'Attribute Location': {
@@ -36,28 +38,49 @@ export interface MethodologyAdditionalVerification {
 export type MethodologyAdditionalVerificationAttributeValue =
   MethodologyAdditionalVerification[];
 
-export interface MethodologyDocumentEvent {
-  address: MethodologyAddress;
-  attachments?: MethodologyDocumentEventAttachment[] | undefined;
-  author: MethodologyAuthor;
-  deduplicationId?: string | undefined;
-  documentSideEffectUpdates?: undefined | UnknownObject;
-  externalCreatedAt: DateTime;
-  externalId?: string | undefined;
-  id: string;
-  isPublic: boolean;
-  label?: MethodologyDocumentEventLabel | string | undefined;
-  metadata?: MethodologyDocumentEventMetadata | undefined;
-  name: MethodologyDocumentEventName | string;
-  participant: MethodologyParticipant;
-  preserveSensitiveData?: boolean | undefined;
-  propagatedFrom?: undefined | UnknownObject;
-  propagateEvent?: boolean | undefined;
-  relatedDocument?: MethodologyDocumentRelation | undefined;
-  target?: undefined | UnknownObject;
-  updates?: undefined | UnknownObject;
-  value?: number | undefined;
-}
+const MethodologyDocumentEventAttachmentBaseSchema = z.object({
+  attachmentId: NonEmptyStringSchema,
+  contentLength: NonNegativeFloatSchema,
+  isPublic: z.boolean(),
+  label: z.string(),
+});
+
+const MethodologyDocumentEventMetadataBaseSchema = z.object({
+  attributes: z.array(z.unknown()).optional(),
+});
+
+const MethodologyDocumentRelationBaseSchema = z.object({
+  category: z.string().optional(),
+  documentId: NonEmptyStringSchema,
+  subtype: z.string().optional(),
+  type: z.string().optional(),
+});
+
+export const MethodologyDocumentEventSchema = z.looseObject({
+  address: MethodologyAddressSchema,
+  attachments: z.array(MethodologyDocumentEventAttachmentBaseSchema).optional(),
+  author: MethodologyAuthorSchema,
+  deduplicationId: z.string().optional(),
+  documentSideEffectUpdates: z.record(z.string(), z.unknown()).optional(),
+  externalCreatedAt: DateTimeSchema,
+  externalId: z.string().optional(),
+  id: NonEmptyStringSchema,
+  isPublic: z.boolean(),
+  label: z.string().optional(),
+  metadata: MethodologyDocumentEventMetadataBaseSchema.optional(),
+  name: z.string(),
+  participant: MethodologyParticipantSchema,
+  preserveSensitiveData: z.boolean().optional(),
+  propagatedFrom: z.record(z.string(), z.unknown()).optional(),
+  propagateEvent: z.boolean().optional(),
+  relatedDocument: MethodologyDocumentRelationBaseSchema.optional(),
+  target: z.record(z.string(), z.unknown()).optional(),
+  updates: z.record(z.string(), z.unknown()).optional(),
+  value: z.number().optional(),
+});
+export type MethodologyDocumentEvent = z.infer<
+  typeof MethodologyDocumentEventSchema
+>;
 
 export interface MethodologyDocumentEventAttachment {
   attachmentId: string;

--- a/libs/shared/types/src/methodology/methodology-document.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document.types.ts
@@ -1,41 +1,46 @@
-import type { DateTime, UnknownObject } from '../common.types';
-import type { MethodologyAddress } from './methodology-address.types';
+import { z } from 'zod';
+
 import type { MethodologyDocumentEvent } from './methodology-document-event.types';
-import type { MethodologyParticipant } from './methodology-participant.types';
 
+import { DateTimeSchema } from '../common.types';
+import { MethodologyAddressSchema } from './methodology-address.types';
 import {
-  DataSetName,
-  MethodologyDocumentStatus,
+  DataSetNameSchema,
+  MethodologyDocumentStatusSchema,
 } from './methodology-enum.types';
+import { MethodologyParticipantSchema } from './methodology-participant.types';
 
-// TODO: Think about to abstract these generics from the codebase
-export interface MethodologyDocument {
-  attachments?: MethodologyDocumentAttachment[] | undefined;
-  category: string;
-  createdAt: DateTime;
-  currentValue: number;
-  dataSetName: DataSetName;
-  deduplicationId?: string | undefined;
-  externalCreatedAt: DateTime;
-  externalEvents?: MethodologyDocumentEvent[] | undefined;
-  externalId?: string | undefined;
-  id: string;
-  isPublic?: boolean | undefined;
-  isPubliclySearchable: boolean;
-  measurementUnit: string;
-  parentDocumentId?: string | undefined;
-  permissions?: undefined | UnknownObject[];
-  primaryAddress: MethodologyAddress;
-  primaryParticipant: MethodologyParticipant;
-  status: MethodologyDocumentStatus | string;
-  subtype?: string | undefined;
-  tags?: Record<string, null | string | undefined> | undefined;
-  type?: string | undefined;
-  updatedAt: DateTime;
-}
+export const MethodologyDocumentAttachmentSchema = z.looseObject({
+  contentLength: z.number(),
+  fileName: z.string(),
+  id: z.string(),
+});
+export type MethodologyDocumentAttachment = z.infer<
+  typeof MethodologyDocumentAttachmentSchema
+>;
 
-export interface MethodologyDocumentAttachment {
-  contentLength: number;
-  fileName: string;
-  id: string;
-}
+export const MethodologyDocumentSchema = z.looseObject({
+  attachments: z.array(MethodologyDocumentAttachmentSchema).optional(),
+  category: z.string(),
+  createdAt: DateTimeSchema,
+  currentValue: z.number(),
+  dataSetName: DataSetNameSchema,
+  deduplicationId: z.string().optional(),
+  externalCreatedAt: DateTimeSchema,
+  externalEvents: z.array(z.custom<MethodologyDocumentEvent>()).optional(),
+  externalId: z.string().optional(),
+  id: z.string(),
+  isPublic: z.boolean().optional(),
+  isPubliclySearchable: z.boolean(),
+  measurementUnit: z.string(),
+  parentDocumentId: z.string().optional(),
+  permissions: z.array(z.record(z.string(), z.unknown())).optional(),
+  primaryAddress: MethodologyAddressSchema,
+  primaryParticipant: MethodologyParticipantSchema,
+  status: MethodologyDocumentStatusSchema,
+  subtype: z.string().optional(),
+  tags: z.record(z.string(), z.string().nullable().optional()).optional(),
+  type: z.string().optional(),
+  updatedAt: DateTimeSchema,
+});
+export type MethodologyDocument = z.infer<typeof MethodologyDocumentSchema>;

--- a/libs/shared/types/src/methodology/methodology-document.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document.types.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 
-import type { MethodologyDocumentEvent } from './methodology-document-event.types';
-
 import { DateTimeSchema } from '../common.types';
+import { NonNegativeFloatSchema } from '../number.types';
+import { NonEmptyStringSchema } from '../string.types';
 import { MethodologyAddressSchema } from './methodology-address.types';
+import { MethodologyDocumentEventSchema } from './methodology-document-event.types';
 import {
   DataSetNameSchema,
   MethodologyDocumentStatusSchema,
@@ -11,9 +12,9 @@ import {
 import { MethodologyParticipantSchema } from './methodology-participant.types';
 
 export const MethodologyDocumentAttachmentSchema = z.looseObject({
-  contentLength: z.number(),
-  fileName: z.string(),
-  id: z.string(),
+  contentLength: NonNegativeFloatSchema,
+  fileName: NonEmptyStringSchema,
+  id: NonEmptyStringSchema,
 });
 export type MethodologyDocumentAttachment = z.infer<
   typeof MethodologyDocumentAttachmentSchema
@@ -23,13 +24,13 @@ export const MethodologyDocumentSchema = z.looseObject({
   attachments: z.array(MethodologyDocumentAttachmentSchema).optional(),
   category: z.string(),
   createdAt: DateTimeSchema,
-  currentValue: z.number(),
+  currentValue: NonNegativeFloatSchema,
   dataSetName: DataSetNameSchema,
   deduplicationId: z.string().optional(),
   externalCreatedAt: DateTimeSchema,
-  externalEvents: z.array(z.custom<MethodologyDocumentEvent>()).optional(),
+  externalEvents: z.array(MethodologyDocumentEventSchema).optional(),
   externalId: z.string().optional(),
-  id: z.string(),
+  id: NonEmptyStringSchema,
   isPublic: z.boolean().optional(),
   isPubliclySearchable: z.boolean(),
   measurementUnit: z.string(),

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const DataSetNameSchema = z.enum(['PROD', 'PROD_SIMULATION', 'TEST']);
 export type DataSetName = z.infer<typeof DataSetNameSchema>;
-// eslint-disable-next-line no-redeclare
+// eslint-disable-next-line no-redeclare -- intentional declaration merging: type + const share the name to preserve enum-like dot-notation
 export const DataSetName = DataSetNameSchema.enum;
 
 export enum MethodologyActorType {
@@ -78,11 +78,15 @@ export enum MethodologyDocumentEventName {
   WEIGHING = 'Weighing',
 }
 
-export const MethodologyDocumentStatusSchema = z.enum(['CANCELLED', 'OPEN']);
+export const MethodologyDocumentStatusSchema = z.enum([
+  'CANCELLED',
+  'CLOSED',
+  'OPEN',
+]);
 export type MethodologyDocumentStatus = z.infer<
   typeof MethodologyDocumentStatusSchema
 >;
-// eslint-disable-next-line no-redeclare
+// eslint-disable-next-line no-redeclare -- intentional declaration merging: type + const share the name to preserve enum-like dot-notation
 export const MethodologyDocumentStatus = MethodologyDocumentStatusSchema.enum;
 
 export enum MethodologyEvaluationResult {

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -1,8 +1,9 @@
-export enum DataSetName {
-  PROD = 'PROD',
-  PROD_SIMULATION = 'PROD_SIMULATION',
-  TEST = 'TEST',
-}
+import { z } from 'zod';
+
+export const DataSetNameSchema = z.enum(['PROD', 'PROD_SIMULATION', 'TEST']);
+export type DataSetName = z.infer<typeof DataSetNameSchema>;
+// eslint-disable-next-line no-redeclare
+export const DataSetName = DataSetNameSchema.enum;
 
 export enum MethodologyActorType {
   AUDITOR = 'Auditor',
@@ -77,10 +78,12 @@ export enum MethodologyDocumentEventName {
   WEIGHING = 'Weighing',
 }
 
-export enum MethodologyDocumentStatus {
-  CANCELLED = 'CANCELLED',
-  OPEN = 'OPEN',
-}
+export const MethodologyDocumentStatusSchema = z.enum(['CANCELLED', 'OPEN']);
+export type MethodologyDocumentStatus = z.infer<
+  typeof MethodologyDocumentStatusSchema
+>;
+// eslint-disable-next-line no-redeclare
+export const MethodologyDocumentStatus = MethodologyDocumentStatusSchema.enum;
 
 export enum MethodologyEvaluationResult {
   PASSED = 'PASSED',

--- a/libs/shared/types/src/methodology/methodology-participant.types.ts
+++ b/libs/shared/types/src/methodology/methodology-participant.types.ts
@@ -4,9 +4,9 @@ import { NonEmptyStringSchema } from '../string.types';
 import { DataSetNameSchema } from './methodology-enum.types';
 
 export const MethodologyAuthorSchema = z.looseObject({
-  clientId: z.string(),
+  clientId: NonEmptyStringSchema,
   dataSetName: DataSetNameSchema,
-  participantId: z.string(),
+  participantId: NonEmptyStringSchema,
 });
 export type MethodologyAuthor = z.infer<typeof MethodologyAuthorSchema>;
 
@@ -18,6 +18,7 @@ export const MethodologyParticipantSchema = z.looseObject({
   piiSnapshotId: NonEmptyStringSchema,
   taxId: NonEmptyStringSchema,
   taxIdType: NonEmptyStringSchema,
+  // TODO: replace with MethodologyParticipantTypeSchema once migrated to Zod
   type: NonEmptyStringSchema,
 });
 export type MethodologyParticipant = z.infer<

--- a/libs/shared/types/src/methodology/methodology-participant.types.ts
+++ b/libs/shared/types/src/methodology/methodology-participant.types.ts
@@ -1,21 +1,25 @@
-import {
-  DataSetName,
-  MethodologyParticipantType,
-} from './methodology-enum.types';
+import { z } from 'zod';
 
-export interface MethodologyAuthor {
-  clientId: string;
-  dataSetName: DataSetName;
-  participantId: string;
-}
+import { NonEmptyStringSchema } from '../string.types';
+import { DataSetNameSchema } from './methodology-enum.types';
 
-export interface MethodologyParticipant {
-  businessName?: string | undefined;
-  countryCode: string;
-  id: string;
-  name: string;
-  piiSnapshotId: string;
-  taxId: string;
-  taxIdType: string;
-  type: MethodologyParticipantType | string;
-}
+export const MethodologyAuthorSchema = z.looseObject({
+  clientId: z.string(),
+  dataSetName: DataSetNameSchema,
+  participantId: z.string(),
+});
+export type MethodologyAuthor = z.infer<typeof MethodologyAuthorSchema>;
+
+export const MethodologyParticipantSchema = z.looseObject({
+  businessName: NonEmptyStringSchema.optional(),
+  countryCode: NonEmptyStringSchema,
+  id: NonEmptyStringSchema,
+  name: NonEmptyStringSchema,
+  piiSnapshotId: NonEmptyStringSchema,
+  taxId: NonEmptyStringSchema,
+  taxIdType: NonEmptyStringSchema,
+  type: NonEmptyStringSchema,
+});
+export type MethodologyParticipant = z.infer<
+  typeof MethodologyParticipantSchema
+>;


### PR DESCRIPTION
## Summary

- Migrate `MethodologyDocument`, `MethodologyDocumentEvent`, `MethodologyAddress`, `MethodologyParticipant`, `MethodologyAuthor`, and `MethodologyDocumentAttachment` from TypeScript interfaces to Zod-first schemas with inferred types
- Migrate `DataSetName` and `MethodologyDocumentStatus` enums to Zod enums with declaration merging for backward-compatible dot-notation access
- Remove duplicate schemas from `bold/io-helpers` (`document.schemas.ts` deleted) and simplify `document-helpers.validators.ts` to reuse the canonical `MethodologyDocumentSchema`
- Upgrade document validation log level from `warn` to `error` for invalid documents

## Details

This continues the Zod-first migration by converting the core methodology document types. Each schema uses `z.looseObject()` to allow forward-compatible extra fields while enforcing required field types at runtime. The `bold/io-helpers` module now imports directly from `@carrot-fndn/shared/types` instead of maintaining its own schema copies.

- [x] I declare that I have self-reviewed the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 'CLOSED' as a new document status option to support more comprehensive lifecycle tracking

* **Bug Fixes**
  * Unified validation rules across documents, participants, events, and addresses for improved data consistency
  * Enhanced error handling and logging visibility for invalid documents to support troubleshooting and debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->