### PR TITLE
Migrate the methodology document event types to zod

### DIFF
--- a/libs/shared/types/src/methodology/methodology-document-event.types.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.types.ts
@@ -1,64 +1,119 @@
 import { z } from 'zod';
 
-import type { UnknownObject } from '../common.types';
-import type {
-  MethodologyDocumentEventAttributeFormat,
-  MethodologyDocumentEventAttributeType,
-} from './methodology-enum.types';
-
 import { DateTimeSchema } from '../common.types';
 import { NonNegativeFloatSchema } from '../number.types';
-import { type NonEmptyString, NonEmptyStringSchema } from '../string.types';
+import { NonEmptyStringSchema } from '../string.types';
 import { MethodologyAddressSchema } from './methodology-address.types';
+import {
+  MethodologyDocumentEventAttributeFormatSchema,
+  MethodologyDocumentEventAttributeTypeSchema,
+} from './methodology-enum.types';
 import {
   MethodologyAuthorSchema,
   MethodologyParticipantSchema,
 } from './methodology-participant.types';
 
-export interface ApprovedException {
-  'Attribute Location': {
-    Asset: {
-      Category: NonEmptyString;
-    };
-    Event: NonEmptyString;
-  };
-  'Attribute Name': NonEmptyString;
-  'Exception Type': NonEmptyString;
-  Reason: NonEmptyString;
-  'Valid Until'?: string;
-}
+export const ApprovedExceptionSchema = z.object({
+  'Attribute Location': z.object({
+    Asset: z.object({ Category: NonEmptyStringSchema }),
+    Event: NonEmptyStringSchema,
+  }),
+  'Attribute Name': NonEmptyStringSchema,
+  'Exception Type': NonEmptyStringSchema,
+  Reason: NonEmptyStringSchema,
+  'Valid Until': z.string().optional(),
+});
+export type ApprovedException = z.infer<typeof ApprovedExceptionSchema>;
 
-export type ApprovedExceptionAttributeValue = ApprovedException[];
+export const ApprovedExceptionAttributeValueSchema = z.array(
+  ApprovedExceptionSchema,
+);
+export type ApprovedExceptionAttributeValue = z.infer<
+  typeof ApprovedExceptionAttributeValueSchema
+>;
 
-export interface MethodologyAdditionalVerification {
-  'Layout IDs'?: NonEmptyString[];
-  'Verification Type': string;
-}
+export const MethodologyAdditionalVerificationSchema = z.object({
+  'Layout IDs': z.array(NonEmptyStringSchema).optional(),
+  'Verification Type': z.string(),
+});
+export type MethodologyAdditionalVerification = z.infer<
+  typeof MethodologyAdditionalVerificationSchema
+>;
 
-export type MethodologyAdditionalVerificationAttributeValue =
-  MethodologyAdditionalVerification[];
+export const MethodologyAdditionalVerificationAttributeValueSchema = z.array(
+  MethodologyAdditionalVerificationSchema,
+);
+export type MethodologyAdditionalVerificationAttributeValue = z.infer<
+  typeof MethodologyAdditionalVerificationAttributeValueSchema
+>;
 
-const MethodologyDocumentEventAttachmentBaseSchema = z.object({
+export const MethodologyDocumentEventAttributeReferenceSchema = z.object({
+  documentId: NonEmptyStringSchema,
+  eventId: NonEmptyStringSchema.optional(),
+});
+export type MethodologyDocumentEventAttributeReference = z.infer<
+  typeof MethodologyDocumentEventAttributeReferenceSchema
+>;
+
+export const MethodologyDocumentEventAttributeValueSchema = z.union([
+  ApprovedExceptionAttributeValueSchema,
+  MethodologyAdditionalVerificationAttributeValueSchema,
+  MethodologyDocumentEventAttributeReferenceSchema,
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.unknown()),
+  z.record(z.string(), z.unknown()),
+]);
+export type MethodologyDocumentEventAttributeValue = z.infer<
+  typeof MethodologyDocumentEventAttributeValueSchema
+>;
+
+export const MethodologyDocumentEventAttributeSchema = z.object({
+  format: MethodologyDocumentEventAttributeFormatSchema.optional(),
+  isPublic: z.boolean(),
+  name: z.string(),
+  sensitive: z.boolean().optional(),
+  type: MethodologyDocumentEventAttributeTypeSchema.optional(),
+  value: MethodologyDocumentEventAttributeValueSchema.optional(),
+  valuePrefix: NonEmptyStringSchema.optional(),
+  valueSuffix: NonEmptyStringSchema.optional(),
+});
+export type MethodologyDocumentEventAttribute = z.infer<
+  typeof MethodologyDocumentEventAttributeSchema
+>;
+
+export const MethodologyDocumentEventAttachmentSchema = z.object({
   attachmentId: NonEmptyStringSchema,
   contentLength: NonNegativeFloatSchema,
   isPublic: z.boolean(),
   label: z.string(),
 });
+export type MethodologyDocumentEventAttachment = z.infer<
+  typeof MethodologyDocumentEventAttachmentSchema
+>;
 
-const MethodologyDocumentEventMetadataBaseSchema = z.object({
-  attributes: z.array(z.unknown()).optional(),
+export const MethodologyDocumentEventMetadataSchema = z.object({
+  attributes: z.array(MethodologyDocumentEventAttributeSchema).optional(),
 });
+export type MethodologyDocumentEventMetadata = z.infer<
+  typeof MethodologyDocumentEventMetadataSchema
+>;
 
-const MethodologyDocumentRelationBaseSchema = z.object({
+export const MethodologyDocumentRelationSchema = z.object({
   category: z.string().optional(),
   documentId: NonEmptyStringSchema,
   subtype: z.string().optional(),
   type: z.string().optional(),
 });
+export type MethodologyDocumentRelation = z.infer<
+  typeof MethodologyDocumentRelationSchema
+>;
 
 export const MethodologyDocumentEventSchema = z.looseObject({
   address: MethodologyAddressSchema,
-  attachments: z.array(MethodologyDocumentEventAttachmentBaseSchema).optional(),
+  attachments: z.array(MethodologyDocumentEventAttachmentSchema).optional(),
   author: MethodologyAuthorSchema,
   deduplicationId: z.string().optional(),
   documentSideEffectUpdates: z.record(z.string(), z.unknown()).optional(),
@@ -67,13 +122,13 @@ export const MethodologyDocumentEventSchema = z.looseObject({
   id: NonEmptyStringSchema,
   isPublic: z.boolean(),
   label: z.string().optional(),
-  metadata: MethodologyDocumentEventMetadataBaseSchema.optional(),
+  metadata: MethodologyDocumentEventMetadataSchema.optional(),
   name: z.string(),
   participant: MethodologyParticipantSchema,
   preserveSensitiveData: z.boolean().optional(),
   propagatedFrom: z.record(z.string(), z.unknown()).optional(),
   propagateEvent: z.boolean().optional(),
-  relatedDocument: MethodologyDocumentRelationBaseSchema.optional(),
+  relatedDocument: MethodologyDocumentRelationSchema.optional(),
   target: z.record(z.string(), z.unknown()).optional(),
   updates: z.record(z.string(), z.unknown()).optional(),
   value: z.number().optional(),
@@ -81,50 +136,5 @@ export const MethodologyDocumentEventSchema = z.looseObject({
 export type MethodologyDocumentEvent = z.infer<
   typeof MethodologyDocumentEventSchema
 >;
-
-export interface MethodologyDocumentEventAttachment {
-  attachmentId: string;
-  contentLength: number;
-  isPublic: boolean;
-  label: string;
-}
-
-export interface MethodologyDocumentEventAttribute {
-  format?: MethodologyDocumentEventAttributeFormat | undefined;
-  isPublic: boolean;
-  name: string;
-  sensitive?: boolean | undefined;
-  type?: MethodologyDocumentEventAttributeType | undefined;
-  value: MethodologyDocumentEventAttributeValue | undefined;
-  valuePrefix?: NonEmptyString | undefined;
-  valueSuffix?: NonEmptyString | undefined;
-}
-
-export interface MethodologyDocumentEventAttributeReference {
-  documentId: string;
-  eventId?: string | undefined;
-}
-
-export type MethodologyDocumentEventAttributeValue =
-  | ApprovedExceptionAttributeValue
-  | boolean
-  | MethodologyAdditionalVerificationAttributeValue
-  | MethodologyDocumentEventAttributeReference
-  | null
-  | number
-  | string
-  | unknown[]
-  | UnknownObject;
-
-export interface MethodologyDocumentEventMetadata {
-  attributes?: MethodologyDocumentEventAttribute[] | undefined;
-}
-
-export interface MethodologyDocumentRelation {
-  category?: string | undefined;
-  documentId: string;
-  subtype?: string | undefined;
-  type?: string | undefined;
-}
 
 export type MethodologyVerificationType = 'CDF' | 'MTR' | 'Scale Ticket';

--- a/libs/shared/types/src/methodology/methodology-document-event.validators.ts
+++ b/libs/shared/types/src/methodology/methodology-document-event.validators.ts
@@ -1,25 +1,6 @@
-import { z } from 'zod';
-
 import type { ApprovedExceptionAttributeValue } from './methodology-document-event.types';
 
-import { NonEmptyStringSchema } from '../string.types';
-
-const ApprovedExceptionSchema = z.object({
-  'Attribute Location': z.object({
-    Asset: z.object({
-      Category: NonEmptyStringSchema,
-    }),
-    Event: NonEmptyStringSchema,
-  }),
-  'Attribute Name': NonEmptyStringSchema,
-  'Exception Type': NonEmptyStringSchema,
-  Reason: NonEmptyStringSchema,
-  'Valid Until': z.string().optional(),
-});
-
-export const ApprovedExceptionAttributeValueSchema = z.array(
-  ApprovedExceptionSchema,
-);
+import { ApprovedExceptionAttributeValueSchema } from './methodology-document-event.types';
 
 export const isApprovedExceptionAttributeValue = (
   v: unknown,

--- a/libs/shared/types/src/methodology/methodology-enum.types.ts
+++ b/libs/shared/types/src/methodology/methodology-enum.types.ts
@@ -24,16 +24,28 @@ export enum MethodologyApprovedExceptionType {
   MANDATORY_ATTRIBUTE = 'Exemption for Mandatory Attribute',
 }
 
-export enum MethodologyDocumentEventAttributeFormat {
-  CUBIC_METER = 'CUBIC_METER',
-  DATE = 'DATE',
-  KILOGRAM = 'KILOGRAM',
-  LITER = 'LITER',
-}
+export const MethodologyDocumentEventAttributeFormatSchema = z.enum([
+  'CUBIC_METER',
+  'DATE',
+  'KILOGRAM',
+  'LITER',
+]);
+export type MethodologyDocumentEventAttributeFormat = z.infer<
+  typeof MethodologyDocumentEventAttributeFormatSchema
+>;
+// eslint-disable-next-line no-redeclare -- intentional declaration merging: type + const share the name to preserve enum-like dot-notation
+export const MethodologyDocumentEventAttributeFormat =
+  MethodologyDocumentEventAttributeFormatSchema.enum;
 
-export enum MethodologyDocumentEventAttributeType {
-  REFERENCE = 'REFERENCE',
-}
+export const MethodologyDocumentEventAttributeTypeSchema = z.enum([
+  'REFERENCE',
+]);
+export type MethodologyDocumentEventAttributeType = z.infer<
+  typeof MethodologyDocumentEventAttributeTypeSchema
+>;
+// eslint-disable-next-line no-redeclare -- intentional declaration merging: type + const share the name to preserve enum-like dot-notation
+export const MethodologyDocumentEventAttributeType =
+  MethodologyDocumentEventAttributeTypeSchema.enum;
 
 export enum MethodologyDocumentEventLabel {
   AUDITOR = MethodologyActorType.AUDITOR,
@@ -89,9 +101,13 @@ export type MethodologyDocumentStatus = z.infer<
 // eslint-disable-next-line no-redeclare -- intentional declaration merging: type + const share the name to preserve enum-like dot-notation
 export const MethodologyDocumentStatus = MethodologyDocumentStatusSchema.enum;
 
-export enum MethodologyEvaluationResult {
-  PASSED = 'PASSED',
-}
+export const MethodologyEvaluationResultSchema = z.enum(['PASSED']);
+export type MethodologyEvaluationResult = z.infer<
+  typeof MethodologyEvaluationResultSchema
+>;
+// eslint-disable-next-line no-redeclare -- intentional declaration merging: type + const share the name to preserve enum-like dot-notation
+export const MethodologyEvaluationResult =
+  MethodologyEvaluationResultSchema.enum;
 
 export enum MethodologyParticipantType {
   ACTOR = 'ACTOR',


### PR DESCRIPTION
## Summary

Restores enum type safety for `MethodologyDocumentEventAttributeFormat`, `MethodologyDocumentEventAttributeType`, and `MethodologyEvaluationResult` by migrating them from TypeScript enums to Zod-first schemas with companion const objects that preserve dot-notation access (e.g. `MethodologyDocumentEventAttributeFormat.DATE`).

## Changes

- **methodology-document-event.types.ts**: Migrated all remaining manual interfaces (`ApprovedException`, `MethodologyAdditionalVerification`, `MethodologyDocumentEventAttribute`, `MethodologyDocumentEventAttributeReference`, `MethodologyDocumentEventAttachment`, `MethodologyDocumentEventMetadata`, `MethodologyDocumentRelation`) to Zod-first schemas with inferred types. Replaced `z.unknown()` in metadata attributes with the typed `MethodologyDocumentEventAttributeSchema`.
- **methodology-document-event.validators.ts**: Removed duplicated `ApprovedExceptionSchema` definition; now re-exports from the types module.
- **methodology-enum.types.ts**: Converted `MethodologyDocumentEventAttributeFormat`, `MethodologyDocumentEventAttributeType`, and `MethodologyEvaluationResult` from TS enums to `z.enum` schemas with companion const + type exports.

## Declaration

- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal type definitions and validation schemas for improved consistency and maintainability across methodology document events and related data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->