### PR TITLE
fix(shared): accept timezone offsets in DateTimeSchema validation

### DIFF
--- a/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/helpers/src/accreditation-document.helpers.spec.ts
@@ -225,6 +225,29 @@ describe('Accreditation Document Helpers', () => {
       expect(isAccreditationValid(document)).toBe(false);
     });
 
+    it('should return true when dates use timezone offsets instead of UTC', () => {
+      const pastDate = subDays(new Date(), 5);
+      const futureDate = addDays(new Date(), 5);
+      const offset = '-03:00';
+      const toOffsetISO = (d: Date) =>
+        d.toISOString().replace('Z', offset);
+
+      const document = stubAccreditationDocumentWithExternalEvents({
+        externalEvents: [
+          stubDocumentEventWithMetadataAttributes(
+            { name: ACCREDITATION_RESULT },
+            [
+              [EFFECTIVE_DATE, toOffsetISO(pastDate)],
+              [EXPIRATION_DATE, toOffsetISO(futureDate)],
+              [ACCREDITATION_STATUS, DocumentEventAccreditationStatus.APPROVED],
+            ],
+          ),
+        ],
+      });
+
+      expect(isAccreditationValid(document)).toBe(true);
+    });
+
     it('should return true if the document has a ACCREDITATION_RESULT event with valid effective date but no expiration date', () => {
       const document = stubAccreditationDocumentWithExternalEvents({
         externalEvents: [

--- a/libs/shared/types/src/common.types.ts
+++ b/libs/shared/types/src/common.types.ts
@@ -5,7 +5,7 @@ import { type Latitude, type Longitude } from './number.types';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyObject = Record<string, any>;
 
-export const DateTimeSchema = z.iso.datetime({ local: true, offset: true });
+export const DateTimeSchema = z.iso.datetime({ offset: true });
 export type DateTime = z.infer<typeof DateTimeSchema>;
 
 export interface Geolocation {

--- a/libs/shared/types/src/common.types.ts
+++ b/libs/shared/types/src/common.types.ts
@@ -5,7 +5,7 @@ import { type Latitude, type Longitude } from './number.types';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyObject = Record<string, any>;
 
-export const DateTimeSchema = z.iso.datetime();
+export const DateTimeSchema = z.iso.datetime({ local: true, offset: true });
 export type DateTime = z.infer<typeof DateTimeSchema>;
 
 export interface Geolocation {


### PR DESCRIPTION
## Summary

- Fix `DateTimeSchema` (`z.iso.datetime()`) rejecting timezone offsets like `-03:00`, which caused **all 40 MassID audits** to fail the "Participant Accreditations & Verifications Requirements" rule
- Root cause: commit d4e401b0 (typia-to-zod migration) replaced RFC 3339-compliant `tags.Format<'date-time'>` with `z.iso.datetime()` which only accepts UTC (`Z` suffix)
- Smaug/Palantir produces accreditation dates with Brazilian timezone offsets (`2025-12-23T00:00:00-03:00`), causing `DateTimeSchema.safeParse()` to return `false` and making every accreditation appear invalid
- Fix: add `{ offset: true, local: true }` options to restore RFC 3339 compliance
- Add regression test with timezone offset dates

## Test plan

- [x] Reproduced failure locally against production audit (bdbf18d4) using `run-rule` CLI
- [x] Verified fix passes against the same production audit
- [x] All accreditation helper tests pass (40/40, including new offset test)
- [x] All participant-accreditations rule processor tests pass (15/15)
- [x] `ts:affected` passes (pre-existing failure in rewards-distribution unrelated)
- [x] `lint:affected` passes (same pre-existing failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended test coverage to verify accreditation validation accepts ISO datetime strings that include explicit timezone offsets.

* **Improvements**
  * Improved datetime parsing/validation to properly accept ISO datetime strings with explicit timezone offsets and local-time formats, reducing datetime-related validation surprises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->