### PR TITLE
fix(rule): add 1-hour tolerance for composting cycle timeframe boundaries

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.constants.ts
@@ -2,16 +2,27 @@ import { DocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types'
 
 const { DROP_OFF, RECYCLED } = DocumentEventName;
 
+export const COMPOSTING_CYCLE_MAX_DAYS = 180;
+export const COMPOSTING_CYCLE_MIN_DAYS = 60;
+export const HOURS_PER_DAY = 24;
+
+/**
+ * Tolerance applied to the min/max boundary comparison to account for
+ * timestamp jitter from integrators (e.g. events logged a few seconds
+ * after midnight instead of exactly at midnight).
+ */
+export const TOLERANCE_IN_HOURS = 1;
+
 export const RESULT_COMMENTS = {
   failed: {
     MISSING_DROP_OFF_EVENT: `Unable to verify the timeframe because the "${DROP_OFF}" event is missing.`,
     MISSING_RECYCLED_EVENT: `Unable to verify the timeframe because the "${RECYCLED}" event is missing.`,
     TIMEFRAME_OUT_OF_RANGE: (dateDiff: number) =>
-      `The time between the "${DROP_OFF}" and "${RECYCLED}" events is ${dateDiff} days, which is outside the valid range (60-180 days).`,
+      `The time between the "${DROP_OFF}" and "${RECYCLED}" events is ${dateDiff} days, which is outside the valid range (${COMPOSTING_CYCLE_MIN_DAYS}-${COMPOSTING_CYCLE_MAX_DAYS} days).`,
   },
   passed: {
     TIMEFRAME_WITHIN_RANGE: (dateDiff: number) =>
-      `The time between the "${DROP_OFF}" and "${RECYCLED}" events is ${dateDiff} days, within the valid range (60-180 days).`,
+      `The time between the "${DROP_OFF}" and "${RECYCLED}" events is ${dateDiff} days, within the valid range (${COMPOSTING_CYCLE_MIN_DAYS}-${COMPOSTING_CYCLE_MAX_DAYS} days).`,
   },
   reviewRequired: {},
 } as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.spec.ts
@@ -10,9 +10,15 @@ import {
 } from '@carrot-fndn/shared/methodologies/bold/types';
 import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
-import { differenceInDays, parseISO } from 'date-fns';
+import { differenceInDays, differenceInHours, parseISO } from 'date-fns';
 
-import { RESULT_COMMENTS } from './composting-cycle-timeframe.constants';
+import {
+  COMPOSTING_CYCLE_MAX_DAYS,
+  COMPOSTING_CYCLE_MIN_DAYS,
+  HOURS_PER_DAY,
+  RESULT_COMMENTS,
+  TOLERANCE_IN_HOURS,
+} from './composting-cycle-timeframe.constants';
 import { CompostingCycleTimeframeProcessor } from './composting-cycle-timeframe.processor';
 import { compostingCycleTimeframeTestCases } from './composting-cycle-timeframe.test-cases';
 
@@ -32,13 +38,20 @@ describe('CompostingCycleTimeframeProcessor', () => {
       if (!testCase.dropOffEventDate) {
         resultComment = RESULT_COMMENTS.failed.MISSING_DROP_OFF_EVENT;
       } else if (testCase.recycledEventDate) {
-        const difference = differenceInDays(
-          parseISO(testCase.recycledEventDate),
-          parseISO(testCase.dropOffEventDate),
-        );
+        const parsedRecycled = parseISO(testCase.recycledEventDate);
+        const parsedDropOff = parseISO(testCase.dropOffEventDate);
+        const difference = differenceInDays(parsedRecycled, parsedDropOff);
+        const diffInHours = differenceInHours(parsedRecycled, parsedDropOff);
+
+        const meetsMinimum =
+          diffInHours >=
+          COMPOSTING_CYCLE_MIN_DAYS * HOURS_PER_DAY - TOLERANCE_IN_HOURS;
+        const meetsMaximum =
+          diffInHours <=
+          COMPOSTING_CYCLE_MAX_DAYS * HOURS_PER_DAY + TOLERANCE_IN_HOURS;
 
         resultComment =
-          testCase.resultStatus === 'PASSED'
+          meetsMinimum && meetsMaximum
             ? RESULT_COMMENTS.passed.TIMEFRAME_WITHIN_RANGE(difference)
             : RESULT_COMMENTS.failed.TIMEFRAME_OUT_OF_RANGE(difference);
       } else {

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.processor.ts
@@ -8,9 +8,15 @@ import {
   type DocumentEvent,
   DocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { differenceInDays, parseISO } from 'date-fns';
+import { differenceInDays, differenceInHours, parseISO } from 'date-fns';
 
-import { RESULT_COMMENTS } from './composting-cycle-timeframe.constants';
+import {
+  COMPOSTING_CYCLE_MAX_DAYS,
+  COMPOSTING_CYCLE_MIN_DAYS,
+  HOURS_PER_DAY,
+  RESULT_COMMENTS,
+  TOLERANCE_IN_HOURS,
+} from './composting-cycle-timeframe.constants';
 
 const { DROP_OFF, RECYCLED } = DocumentEventName;
 
@@ -41,13 +47,23 @@ export class CompostingCycleTimeframeProcessor extends ParentDocumentRuleProcess
       };
     }
 
-    const difference = differenceInDays(
-      parseISO(recycledDate),
-      parseISO(dropOffDate),
-    );
+    const parsedRecycledDate = parseISO(recycledDate);
+    const parsedDropOffDate = parseISO(dropOffDate);
 
-    const resultStatus =
-      difference >= 60 && difference <= 180 ? 'PASSED' : 'FAILED';
+    const diffInHours = differenceInHours(
+      parsedRecycledDate,
+      parsedDropOffDate,
+    );
+    const difference = differenceInDays(parsedRecycledDate, parsedDropOffDate);
+
+    const meetsMinimum =
+      diffInHours >=
+      COMPOSTING_CYCLE_MIN_DAYS * HOURS_PER_DAY - TOLERANCE_IN_HOURS;
+    const meetsMaximum =
+      diffInHours <=
+      COMPOSTING_CYCLE_MAX_DAYS * HOURS_PER_DAY + TOLERANCE_IN_HOURS;
+
+    const resultStatus = meetsMinimum && meetsMaximum ? 'PASSED' : 'FAILED';
 
     return {
       resultComment:

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/src/composting-cycle-timeframe.test-cases.ts
@@ -20,6 +20,21 @@ const DROP_OFF_DATE_59_DAYS = '2023-12-30T12:00:00.000Z';
 const DROP_OFF_DATE_180_DAYS = '2023-08-31T12:00:00.000Z';
 const DROP_OFF_DATE_181_DAYS = '2023-08-29T12:00:00.000Z';
 
+/**
+ * Simulates timestamp jitter: drop-off at 8 seconds past midnight,
+ * recycled at midnight — 59 days, 23h, 59m, 52s apart (~59.9999 days).
+ * Should PASS with the 1-hour tolerance.
+ */
+const DROP_OFF_DATE_JITTER_MIN = '2023-12-29T00:00:08.000Z';
+const RECYCLED_DATE_JITTER_MIN = '2024-02-27T00:00:00.000Z';
+
+/**
+ * Simulates timestamp jitter at the upper bound: 180 days + ~8 seconds.
+ * Should PASS with the 1-hour tolerance.
+ */
+const DROP_OFF_DATE_JITTER_MAX = '2023-08-31T00:00:00.000Z';
+const RECYCLED_DATE_JITTER_MAX = '2024-02-27T00:00:08.000Z';
+
 const { DROP_OFF, RECYCLED } = DocumentEventName;
 
 export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase[] =
@@ -77,5 +92,23 @@ export const compostingCycleTimeframeTestCases: CompostingCycleTimeframeTestCase
       recycledEventDate: undefined,
       resultStatus: 'FAILED',
       scenario: `The "${RECYCLED}" event date is missing`,
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_JITTER_MIN,
+      recycledEventDate: RECYCLED_DATE_JITTER_MIN,
+      resultComment:
+        'Timestamp jitter near minimum boundary: ~59.9999 days passes with 1-hour tolerance.',
+      resultStatus: 'PASSED',
+      scenario:
+        'Tolerance: drop-off 8s past midnight, recycled at midnight (~59.9999 days)',
+    },
+    {
+      dropOffEventDate: DROP_OFF_DATE_JITTER_MAX,
+      recycledEventDate: RECYCLED_DATE_JITTER_MAX,
+      resultComment:
+        'Timestamp jitter near maximum boundary: ~180.0001 days passes with 1-hour tolerance.',
+      resultStatus: 'PASSED',
+      scenario:
+        'Tolerance: recycled 8s past midnight, drop-off at midnight (~180.0001 days)',
     },
   ];


### PR DESCRIPTION
## Summary

- Adds a 1-hour tolerance to the composting cycle timeframe rule's min/max boundary checks (60-180 days)
- Fixes 12 MassIDs failing with "59 days outside valid range" when the actual duration is ~59.9999 days
- Root cause: integrator timestamps have seconds of jitter around midnight (Drop-off at `00:00:08`, Recycled at `00:00:00`), and `differenceInDays` truncates to 59

## Changes

- **constants**: Extract `COMPOSTING_CYCLE_MIN_DAYS`, `COMPOSTING_CYCLE_MAX_DAYS`, `HOURS_PER_DAY`, and `TOLERANCE_IN_HOURS` constants
- **processor**: Use `differenceInHours` for boundary comparison with ±1h tolerance; keep `differenceInDays` for display
- **test-cases**: Add jitter tolerance scenarios for both min and max boundaries

## Validated against production data

```
MassID: 62c7d0ba-509d-435f-a533-203c119c466d
Drop-off: 2025-01-24T00:00:08-03:00
Recycled: 2025-03-25T00:00:01-03:00
Result:  ✓ PASSED (was FAILED)
```

## Test plan

- [x] All 10 unit tests pass (including 2 new tolerance scenarios)
- [x] 100% code coverage
- [x] Lint, typecheck pass
- [x] Verified against production MassID `62c7d0ba` via `run-rule` CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced composting cycle validation with hour-level precision for improved accuracy.
  * Added 1-hour tolerance window to composting cycle boundaries (60-180 days) to account for minor timing variations.

* **Tests**
  * Expanded test coverage for composting cycle boundary condition validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->