### PR TITLE
feat: add type and methodologyReference to framework rules

### DIFF
--- a/libs/methodologies/bold-carbon/rules/src/framework-rules.ts
+++ b/libs/methodologies/bold-carbon/rules/src/framework-rules.ts
@@ -1,340 +1,411 @@
+import type { BaseFrameworkRule } from '@carrot-fndn/shared/rule/types';
+
 export const frameworkRules = [
   {
     description:
       "Validates that the 'Recycled' event occurred within the timeframe allowed by the methodology. The event must have occurred no later than January 1st of the previous year.",
+    methodologyReference: '10.2 Allowable Project Period',
     name: 'Audit Eligibility Check',
     slug: 'audit-eligibility-check',
+    type: 'methodology',
   },
   {
     description:
       'Validates that all participants involved in the supply chain are accredited by the Carrot system. Verifies that accreditation documents exist and that their due dates have not expired.',
     name: 'Check Participants Accreditation',
     slug: 'check-participants-accreditation',
+    type: 'audit',
   },
   {
     description:
       'Verifies that the MassID document does not already have a carbon credit event linked to it, ensuring no double counting of carbon credits (TCC).',
+    methodologyReference: '3.4.2 Avoidance of Double-Counting',
     name: 'TCC Absence',
     slug: 'tcc-absence',
+    type: 'methodology',
   },
   {
     description:
       "Checks the 'Project Size' metadata field in the Recycler's accreditation page. CO2e emission reductions must not exceed 60,000 metric tons (60 kt) over a 12-month period for the MassID to be eligible for TCC generation.",
+    methodologyReference: '3.2.1 Participant Eligibility',
     name: 'Project Size',
     slug: 'project-size',
+    type: 'methodology',
   },
   {
     description:
       'Verifies that the document has a value greater than zero. The document value represents the weight of the mass registered on the platform.',
     name: 'Document Value',
     slug: 'document-value',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the document's measurement unit is kilograms (kg), the standard unit adopted by the Carrot Platform.",
     name: 'Document Measurement Unit',
     slug: 'document-measurement-unit',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the document is declared with the 'MassID' category, as required by the BOLD methodologies for mass verification.",
     name: 'Document Category',
     slug: 'document-category',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the document type is declared as 'Organic'. The BOLD Carbon and BOLD Recycling methodologies are designed for organic waste types.",
+    methodologyReference: '1.1 Summary Table',
     name: 'Document Type',
     slug: 'document-type',
+    type: 'methodology',
   },
   {
     description:
       'Verifies that the MassID organic waste subtype belongs to the group of subtypes approved by the BOLD methodologies, as defined by CDM TOOL04 eligible organic waste type classes.',
+    methodologyReference: '6.2 Baseline Selection',
     name: 'Document Subtype',
     slug: 'document-subtype',
+    type: 'methodology',
   },
   {
     description:
       "The 'Pick-up' event must contain a 'Local Waste Classification ID' attribute with a code from the official waste classification of the jurisdiction where the waste was collected, and a 'Local Waste Classification Desc' attribute with the corresponding description. When the country code is 'BR', the fields must match the Brazilian solid waste list from Ibama.",
     name: 'Local Waste Classification',
     slug: 'local-waste-classification',
+    type: 'structural',
   },
   {
     description:
       "When the country code of the collection address is 'BR', the 'Local Waste Classification ID' must correspond to an organic waste type from CDM Tool 04, mapped according to the Ibama-CDM correspondence table.",
     name: 'Local Waste Classification x CDM',
     slug: 'local-waste-classification-x-cdm',
+    type: 'structural',
   },
   {
     description:
       "The time difference between the 'Drop-Off' and 'Recycled' events must be between 60 and 180 days, ensuring the composting cycle meets quality standards for fertilizer production.",
     name: 'Time Interval Check',
     slug: 'time-interval-check',
+    type: 'audit',
   },
   {
     description:
       "When the waste origin is unknown, the 'Pick-up' event must contain the 'Waste Origin' metadata set to 'Unidentified'. When the origin is known, this metadata must not be present, indicating the waste generator is identified.",
     name: 'Waste Origin Identified',
     slug: 'waste-origin-identified',
+    type: 'audit',
   },
   {
     description:
       "When the 'Waste Origin' metadata is not declared as 'Unidentified' in the 'Pick-up' event, there must be exactly one 'Waste Generator' actor event, identifying the source of the waste in the supply chain.",
+    methodologyReference: 'Participants',
     name: 'One Waste Source',
     slug: 'one-waste-source',
+    type: 'methodology',
   },
   {
     description:
       'The First Identified Participant (also known as primary participant) must be the same participant indicated in the event where the waste was first registered (Pick-up). Validation is performed based on participant IDs.',
     name: 'First Identified Participant - FIP',
     slug: 'first-identified-participant-fip',
+    type: 'structural',
   },
   {
     description:
       'The address identified in the first registration event (Pick-up) must match the address indicated for the First Identified Participant. Address validation is performed based on registered address IDs.',
     name: 'FIP Address',
     slug: 'fip-address',
+    type: 'structural',
   },
   {
     description:
       "The MassID must contain exactly one 'Recycler' actor event, ensuring there is a single identified recycler responsible for transforming the waste and reintroducing it into the economy.",
     name: 'Recycler Actor',
     slug: 'recycler-actor',
+    type: 'structural',
   },
   {
     description:
       "When the 'Vehicle Type' metadata is not 'sludge-pipes' or 'cart', the MassID must contain at least one 'Hauler' actor event identifying the transport participant responsible for moving the waste.",
     name: 'Hauler Identification',
     slug: 'hauler-identification',
+    type: 'structural',
   },
   {
     description:
       "A 'Drop-off' event must be declared in the MassID, confirming that the waste was delivered to the correct destination and transferred to the composting facility.",
     name: 'Drop-off Event',
     slug: 'drop-off-event',
+    type: 'structural',
   },
   {
     description:
       "In the 'Pick-up' event, the geolocation declared in the 'app-gps-latitude' and 'app-gps-longitude' metadata must be compatible with the event address data, within a 2 km radius. If GPS data is unavailable, validation falls back to the address registered in the accreditation.",
     name: 'Pick-up Geolocation Precision',
     slug: 'pick-up-geolocation-precision',
+    type: 'audit',
   },
   {
     description:
       "At least one 'Drop-off' event must have its 'Responsible Party' address matching the address declared for the 'Recycler' actor event. Address validation is performed based on registered address IDs.",
     name: 'Check Recycler and Drop-Off Addresses',
     slug: 'check-recycler-and-drop-off-addresses',
+    type: 'structural',
   },
   {
     description:
       "When a Drop-Off event has a 'Responsible Party' matching a 'Processor' participant, there must be a subsequent Drop-Off event whose 'Responsible Party' matches the 'Recycler' participant, ensuring the waste is forwarded from the processor to the recycling facility.",
     name: 'Processor and Drop-Off',
     slug: 'processor-and-drop-off',
+    type: 'structural',
   },
   {
     description:
       "In the 'Drop-off' event, the geolocation declared in the 'app-gps-latitude' and 'app-gps-longitude' metadata must be compatible with the event address data, within a 2 km radius. If GPS data is unavailable, validation falls back to the address registered in the participant's accreditation.",
     name: 'Drop-off Geolocation Precision',
     slug: 'drop-off-geolocation-precision',
+    type: 'audit',
   },
   {
     description:
       "The 'Drop-off' event must contain the 'Receiving Operator Identifier' metadata, ensuring a responsible operator is registered for receiving the waste at the composting facility, enabling traceability and accountability.",
+    methodologyReference: '9.1 Mass Recording Requirements',
     name: 'Receiving Operator Identifier',
     slug: 'receiving-operator-identifier',
+    type: 'methodology',
   },
   {
     description:
       "Verifies the distance between the 'Pick-up' and 'Drop-off' event geolocations. Distances exceeding 200 km are flagged for review in the Carrot Operations Dashboard, as the project boundary established under UNFCCC AMS-III.F. is 200 km.",
+    methodologyReference: '6.1 Project Boundaries',
     name: 'Methodology Distance Limit',
     slug: 'methodology-distance-limit',
+    type: 'methodology',
   },
   {
     description:
       "In a MassID document, the 'Vehicle Type' metadata is mandatory and must be one of the methodology-approved types: Truck, Car, Mini Van, Bicycle, Motorcycle, Cart, Sludge Pipes, Boat, Cargo Ship, or Others.",
     name: 'Vehicle Type',
     slug: 'vehicle-type',
+    type: 'structural',
   },
   {
     description:
       "When the 'Vehicle Type' metadata is 'Others' in the 'Pick-up' event, a 'Vehicle Description' metadata must be declared, ensuring all non-standard transport means are properly identified and documented.",
     name: 'Vehicle Description',
     slug: 'vehicle-description',
+    type: 'structural',
   },
   {
     description:
       "In the 'Pick-up' event, when the 'Vehicle Type' is not 'Sludge Pipes', 'Cart', or 'Bicycle', the 'Vehicle License Plate' metadata must be declared to enable transport tracking and prevent fraud.",
     name: 'Vehicle License Plate',
     slug: 'vehicle-license-plate',
+    type: 'structural',
   },
   {
     description:
       "When the 'Vehicle Type' is not 'Sludge Pipes', the 'Driver Identifier' metadata must be declared. If identified, the 'Internal DriverID' must be provided. If not identified, a 'Reason Dismissal DriverID' justification is required.",
+    methodologyReference: '9.1 Mass Recording Requirements',
     name: 'Driver Identifier',
     slug: 'driver-identifier',
+    type: 'methodology',
   },
   {
     description:
       "Verifies that the 'Transport Manifest' event is declared in the MassID document, ensuring proof of waste transport is properly documented and traceable.",
+    methodologyReference: '9.4 Processors and the Waste Generator',
     name: 'Has Transport Manifest',
     slug: 'has-transport-manifest',
+    type: 'methodology',
   },
   {
     description:
       "When a 'Transport Manifest' event does not have an 'Exemption Justification' metadata, it must contain an attachment named 'Transport Manifest' as documentary proof of transport.",
+    methodologyReference: '9.4 Processors and the Waste Generator',
     name: 'Transport Manifest Attachment',
     slug: 'transport-manifest-attachment',
+    type: 'methodology',
   },
   {
     description:
       "When a 'Transport Manifest' event does not contain the metadata required by the 'Transport Manifest Fields' rule, an 'Exemption Justification' metadata must be declared with a non-empty value.",
     name: 'Transport Manifest Exemption Justification',
     slug: 'transport-manifest-exemption-justification',
+    type: 'structural',
   },
   {
     description:
       "When a 'Transport Manifest' event has no 'Exemption Justification', the following metadata must be filled: 'Document Type', 'Document Number', 'Document Date Issue', and 'Event Value'. When the Recycler is located in Brazil (country='BR'), the 'Document Type' must be 'MTR'.",
+    methodologyReference: '9.4 Processors and the Waste Generator',
     name: 'Transport Manifest Fields',
     slug: 'transport-manifest-fields',
+    type: 'methodology',
   },
   {
     description:
       "Verifies that the 'Recycling Manifest' event is declared in the MassID document, confirming that the waste was effectively processed at a recycling facility.",
     name: 'Has Recycling Manifest',
     slug: 'has-recycling-manifest',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event does not have an 'Exemption Justification' metadata, it must contain an attachment named 'Recycling Manifest'. The required supporting document may vary by country where the recycler is located.",
     name: 'Recycling Manifest Attachment',
     slug: 'recycling-manifest-attachment',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event does not contain the metadata required by the 'Recycling Manifest Fields' rule, an 'Exemption Justification' metadata must be declared with a non-empty value.",
     name: 'Recycling Manifest Exemption Justification',
     slug: 'recycling-manifest-exemption-justification',
+    type: 'structural',
   },
   {
     description:
       "The address declared in the 'Recycling Manifest' event must match the address of the 'Recycler' actor, ensuring the waste was processed at the correct location. Address validation is performed based on registered address IDs.",
     name: 'Recycling Manifest Address',
     slug: 'recycling-manifest-address',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event has no 'Exemption Justification', the following metadata must be filled: 'Document Type', 'Document Number', and 'Document Date Issue'. When the Recycler is located in Brazil (country='BR'), the 'Document Type' must be 'CDF'.",
     name: 'Recycling Manifest Fields',
     slug: 'recycling-manifest-fields',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event has no 'Exemption Justification', the 'Event Value' metadata must exactly match the 'value' declared in the document, preventing discrepancies in the recycling record.",
     name: 'Recycling Manifest Value',
     slug: 'recycling-manifest-value',
+    type: 'audit',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Weight Capture Method' metadata must be present with one of the following values: Digital, Photo (Scale+Cargo), Manual, or Transport Manifest.",
     name: 'Weight Capture Method',
     slug: 'weight-capture-method',
+    type: 'structural',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Scale Type' metadata must be declared and identified as one of the approved types: Weighbridge (Truck Scale), Floor Scale, Pallet Scale, Forklift Scale, Conveyor Belt Scale, Hanging/Crane Scale, Bin Scale, Portable Axle Weigher, Onboard Truck Scale, Precision/Bench Scale, or Two-bin Lateral Scale.",
     name: 'Scale Type',
     slug: 'scale-type',
+    type: 'audit',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Container Type' metadata must be present with one of the following values: Bag, Bin, Drum, Pail, Street Bin, Waste Box, or Truck.",
     name: 'Container Type',
     slug: 'container-type',
+    type: 'structural',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Scale Accreditation' metadata must be present with a link to the scale validation event in the accreditation of the participant responsible for weighing.",
     name: 'Scale Accreditation',
     slug: 'scale-accreditation',
+    type: 'audit',
   },
   {
     description:
       "The MassID must have at least one 'WEIGHING' event with the following metadata: 'Gross Weight' (decimal > 0, in kg), 'Container Capacity' (decimal > 0, in KILOGRAM, LITER, or CUBIC_METER), 'Tare' (decimal >= 0, in kg), 'Mass Net Weight' (decimal > 0, in kg), and 'Container Quantity' (integer >= 1, required when Container Type is not 'Truck').",
     name: 'Weighing Fields',
     slug: 'weighing-fields',
+    type: 'structural',
   },
   {
     description:
       "In the 'WEIGHING' event, when the 'Container Type' is 'Truck', a 'Vehicle License Plate' attribute must be present.",
     name: 'Truck Weighing',
     slug: 'truck-weighing',
+    type: 'structural',
   },
   {
     description:
       "When a 'WEIGHING' event lacks 'Mass Net Weight' and 'Tare', it must have 'Gross Weight' and 'Container Capacity'. A second 'WEIGHING' event must then follow with matching 'Gross Weight', 'Container Capacity', 'Scale Type', 'Scale Accreditation', 'Container Type', and 'Vehicle License Plate' values, plus all other fields per the 'Weighing Fields' rule.",
     name: 'Weighing in two steps',
     slug: 'weighing-in-two-steps',
+    type: 'structural',
   },
   {
     description:
       "When a 'WEIGHING' event satisfies the 'Weighing Fields' rule, the following calculation is verified: Mass Net Weight = Gross Weight - (Tare * Container Quantity). If 'Container Quantity' is not provided, a value of 1 is assumed.",
     name: 'Net Weight Verification',
     slug: 'net-weight-verification',
+    type: 'structural',
   },
   {
     description:
       "A 'Sorting' event must be declared after all 'Weighing' events in the MassID document.",
     name: 'Mass Sorting Event',
     slug: 'mass-sorting-event',
+    type: 'structural',
   },
   {
     description:
       "The 'Sorting' event must contain a 'value' metadata, and the 'value' field of the 'Sorting' event must update the MassID document value.",
     name: 'Sorting Value Field',
     slug: 'sorting-value-field',
+    type: 'structural',
   },
   {
     description:
       "Verifies that the sorting calculation is correct by executing the equation: document value * (100% - conversion factor) = mass sorting value, and comparing the result with the value declared in the 'Sorting' event.",
     name: 'Sorting Calculation',
     slug: 'sorting-calculation',
+    type: 'audit',
   },
   {
     description:
       "Checks the monthly waste generation ceiling in the source's accreditation page. If the sum of masses from the same generator in the same month exceeds the ceiling by more than 20%, the MassID is blocked for credit generation until reviewed by the operations department.",
     name: 'Double-checking Source Emitted Masses',
     slug: 'double-checking-source-emitted-masses',
+    type: 'audit',
   },
   {
     description:
       "Checks the operational capacity in the recycler's accreditation page. If the sum of masses processed by the same recycler in the same month exceeds the operational capacity by more than 3%, the MassID is blocked for credit generation until approved by the operations department.",
     name: 'Double-checking Recycler Emitted Masses',
     slug: 'double-checking-recycler-emitted-masses',
+    type: 'audit',
   },
   {
     description:
       'Verifies that no other mass documents exist with the same document value, same date and time of receipt at the recycling yard, same generator, and same vehicle. Duplicate documents are rejected to prevent inconsistencies.',
     name: 'Duplicate Check',
     slug: 'duplicate-check',
+    type: 'audit',
   },
   {
     description:
       "Checks the compensation index for the waste type in the recycler's accreditation page and executes the TCC calculation: document-value * compensation index = GasID, ensuring carbon credits are correctly calculated based on waste type and volume.",
+    methodologyReference: '7.4 Project Emission Calculation (PEy)',
     name: 'GasID Output',
     slug: 'gas-id-output',
+    type: 'methodology',
   },
   {
     description:
       "Verifies that the date, time of the 'Drop-Off' event, and 'vehicle-license-plate' of the audited MassID are unique. If there is a conflict with another MassID, the mass is rejected to prevent duplicate or inconsistent records.",
     name: 'Route Check',
     slug: 'route-check',
+    type: 'audit',
   },
   {
     description:
       "Verifies the composting fertilizer coefficient in the recycler's accreditation page and checks whether the declared quantity is compatible with the calculation, ensuring accuracy in recycled-to-input conversion reporting.",
     name: 'Recycled-to-Input Conversion',
     slug: 'recycled-to-input-conversion',
+    type: 'audit',
   },
-] as const;
+] as const satisfies readonly BaseFrameworkRule[];
 
 export type FrameworkRuleSlug = (typeof frameworkRules)[number]['slug'];

--- a/libs/methodologies/bold-recycling/rules/src/framework-rules.ts
+++ b/libs/methodologies/bold-recycling/rules/src/framework-rules.ts
@@ -1,328 +1,395 @@
+import type { BaseFrameworkRule } from '@carrot-fndn/shared/rule/types';
+
 export const frameworkRules = [
   {
     description:
       "Validates that the 'Recycled' event occurred within the timeframe allowed by the methodology. The event must have occurred no later than January 1st of the previous year.",
+    methodologyReference: '10.2 Allowable Project Period',
     name: 'Audit Eligibility Check',
     slug: 'audit-eligibility-check',
+    type: 'methodology',
   },
   {
     description:
       'Validates that all participants involved in the supply chain are accredited by the Carrot system. Verifies that accreditation documents exist and that their due dates have not expired.',
     name: 'Check Participants Accreditation',
     slug: 'check-participants-accreditation',
+    type: 'audit',
   },
   {
     description:
       'Verifies that the MassID document does not already have a recycling credit event linked to it, ensuring no double counting of recycling credits (TRC).',
+    methodologyReference: '3.4.2 Avoidance of Double-Counting',
     name: 'TRC Absence',
     slug: 'trc-absence',
+    type: 'methodology',
   },
   {
     description:
       'Verifies that the document has a value greater than zero. The document value represents the weight of the mass registered on the platform.',
     name: 'Document Value',
     slug: 'document-value',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the document's measurement unit is kilograms (kg), the standard unit adopted by the Carrot Platform.",
     name: 'Document Measurement Unit',
     slug: 'document-measurement-unit',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the document is declared with the 'MassID' category, as required by the BOLD methodologies for mass verification.",
     name: 'Document Category',
     slug: 'document-category',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the document type is declared as 'Organic'. The BOLD Carbon and BOLD Recycling methodologies are designed for organic waste types.",
+    methodologyReference: '1.1 Summary Table',
     name: 'Document Type',
     slug: 'document-type',
+    type: 'methodology',
   },
   {
     description:
       'Verifies that the MassID organic waste subtype belongs to the group of subtypes approved by the BOLD methodologies, as defined by CDM TOOL04 eligible organic waste type classes.',
+    methodologyReference: '6.2 Baseline Selection',
     name: 'Document Subtype',
     slug: 'document-subtype',
+    type: 'methodology',
   },
   {
     description:
       "The 'Pick-up' event must contain a 'Local Waste Classification ID' attribute with a code from the official waste classification of the jurisdiction where the waste was collected, and a 'Local Waste Classification Desc' attribute with the corresponding description. When the country code is 'BR', the fields must match the Brazilian solid waste list from Ibama.",
     name: 'Local Waste Classification',
     slug: 'local-waste-classification',
+    type: 'structural',
   },
   {
     description:
       "When the country code of the collection address is 'BR', the 'Local Waste Classification ID' must correspond to an organic waste type from CDM Tool 04, mapped according to the Ibama-CDM correspondence table.",
     name: 'Local Waste Classification x CDM',
     slug: 'local-waste-classification-x-cdm',
+    type: 'structural',
   },
   {
     description:
       "The time difference between the 'Drop-Off' and 'Recycled' events must be between 60 and 180 days, ensuring the composting cycle meets quality standards for fertilizer production.",
     name: 'Time Interval Check',
     slug: 'time-interval-check',
+    type: 'audit',
   },
   {
     description:
       "When the waste origin is unknown, the 'Pick-up' event must contain the 'Waste Origin' metadata set to 'Unidentified'. When the origin is known, this metadata must not be present, indicating the waste generator is identified.",
     name: 'Waste Origin Identified',
     slug: 'waste-origin-identified',
+    type: 'audit',
   },
   {
     description:
       "When the 'Waste Origin' metadata is not declared as 'Unidentified' in the 'Pick-up' event, there must be exactly one 'Waste Generator' actor event, identifying the source of the waste in the supply chain.",
+    methodologyReference: 'Participants',
     name: 'One Waste Source',
     slug: 'one-waste-source',
+    type: 'methodology',
   },
   {
     description:
       'The First Identified Participant (also known as primary participant) must be the same participant indicated in the event where the waste was first registered (Pick-up). Validation is performed based on participant IDs.',
     name: 'First Identified Participant - FIP',
     slug: 'first-identified-participant-fip',
+    type: 'structural',
   },
   {
     description:
       'The address identified in the first registration event (Pick-up) must match the address indicated for the First Identified Participant. Address validation is performed based on registered address IDs.',
     name: 'FIP Address',
     slug: 'fip-address',
+    type: 'structural',
   },
   {
     description:
       "The MassID must contain exactly one 'Recycler' actor event, ensuring there is a single identified recycler responsible for transforming the waste and reintroducing it into the economy.",
     name: 'Recycler Actor',
     slug: 'recycler-actor',
+    type: 'structural',
   },
   {
     description:
       "When the 'Vehicle Type' metadata is not 'sludge-pipes' or 'cart', the MassID must contain at least one 'Hauler' actor event identifying the transport participant responsible for moving the waste.",
     name: 'Hauler Identification',
     slug: 'hauler-identification',
+    type: 'structural',
   },
   {
     description:
       "A 'Drop-off' event must be declared in the MassID, confirming that the waste was delivered to the correct destination and transferred to the composting facility.",
     name: 'Drop-off Event',
     slug: 'drop-off-event',
+    type: 'structural',
   },
   {
     description:
       "In the 'Pick-up' event, the geolocation declared in the 'app-gps-latitude' and 'app-gps-longitude' metadata must be compatible with the event address data, within a 2 km radius. If GPS data is unavailable, validation falls back to the address registered in the accreditation.",
     name: 'Pick-up Geolocation Precision',
     slug: 'pick-up-geolocation-precision',
+    type: 'audit',
   },
   {
     description:
       "At least one 'Drop-off' event must have its 'Responsible Party' address matching the address declared for the 'Recycler' actor event. Address validation is performed based on registered address IDs.",
     name: 'Check Recycler and Drop-Off Addresses',
     slug: 'check-recycler-and-drop-off-addresses',
+    type: 'structural',
   },
   {
     description:
       "When a Drop-Off event has a 'Responsible Party' matching a 'Processor' participant, there must be a subsequent Drop-Off event whose 'Responsible Party' matches the 'Recycler' participant, ensuring the waste is forwarded from the processor to the recycling facility.",
     name: 'Processor and Drop-Off',
     slug: 'processor-and-drop-off',
+    type: 'structural',
   },
   {
     description:
       "In the 'Drop-off' event, the geolocation declared in the 'app-gps-latitude' and 'app-gps-longitude' metadata must be compatible with the event address data, within a 2 km radius. If GPS data is unavailable, validation falls back to the address registered in the participant's accreditation.",
     name: 'Drop-off Geolocation Precision',
     slug: 'drop-off-geolocation-precision',
+    type: 'audit',
   },
   {
     description:
       "The 'Drop-off' event must contain the 'Receiving Operator Identifier' metadata, ensuring a responsible operator is registered for receiving the waste at the composting facility, enabling traceability and accountability.",
+    methodologyReference: '9.1 Mass Recording Requirements',
     name: 'Receiving Operator Identifier',
     slug: 'receiving-operator-identifier',
+    type: 'methodology',
   },
   {
     description:
       "Verifies the distance between the 'Pick-up' and 'Drop-off' event geolocations. Distances exceeding 200 km are flagged for review in the Carrot Operations Dashboard, as the project boundary established under UNFCCC AMS-III.F. is 200 km.",
+    methodologyReference: '6.1 Project Boundaries',
     name: 'Methodology Distance Limit',
     slug: 'methodology-distance-limit',
+    type: 'methodology',
   },
   {
     description:
       "In a MassID document, the 'Vehicle Type' metadata is mandatory and must be one of the methodology-approved types: Truck, Car, Mini Van, Bicycle, Motorcycle, Cart, Sludge Pipes, Boat, Cargo Ship, or Others.",
     name: 'Vehicle Type',
     slug: 'vehicle-type',
+    type: 'structural',
   },
   {
     description:
       "When the 'Vehicle Type' metadata is 'Others' in the 'Pick-up' event, a 'Vehicle Description' metadata must be declared, ensuring all non-standard transport means are properly identified and documented.",
     name: 'Vehicle Description',
     slug: 'vehicle-description',
+    type: 'structural',
   },
   {
     description:
       "In the 'Pick-up' event, when the 'Vehicle Type' is not 'Sludge Pipes', 'Cart', or 'Bicycle', the 'Vehicle License Plate' metadata must be declared to enable transport tracking and prevent fraud.",
     name: 'Vehicle License Plate',
     slug: 'vehicle-license-plate',
+    type: 'structural',
   },
   {
     description:
       "When the 'Vehicle Type' is not 'Sludge Pipes', the 'Driver Identifier' metadata must be declared. If identified, the 'Internal DriverID' must be provided. If not identified, a 'Reason Dismissal DriverID' justification is required.",
+    methodologyReference: '9.1 Mass Recording Requirements',
     name: 'Driver Identifier',
     slug: 'driver-identifier',
+    type: 'methodology',
   },
   {
     description:
       "Verifies that the 'Transport Manifest' event is declared in the MassID document, ensuring proof of waste transport is properly documented and traceable.",
+    methodologyReference: '9.4 Processors and the Waste Generator',
     name: 'Has Transport Manifest',
     slug: 'has-transport-manifest',
+    type: 'methodology',
   },
   {
     description:
       "When a 'Transport Manifest' event does not have an 'Exemption Justification' metadata, it must contain an attachment named 'Transport Manifest' as documentary proof of transport.",
+    methodologyReference: '9.4 Processors and the Waste Generator',
     name: 'Transport Manifest Attachment',
     slug: 'transport-manifest-attachment',
+    type: 'methodology',
   },
   {
     description:
       "When a 'Transport Manifest' event does not contain the metadata required by the 'Transport Manifest Fields' rule, an 'Exemption Justification' metadata must be declared with a non-empty value.",
     name: 'Transport Manifest Exemption Justification',
     slug: 'transport-manifest-exemption-justification',
+    type: 'structural',
   },
   {
     description:
       "When a 'Transport Manifest' event has no 'Exemption Justification', the following metadata must be filled: 'Document Type', 'Document Number', 'Document Date Issue', and 'Event Value'. When the Recycler is located in Brazil (country='BR'), the 'Document Type' must be 'MTR'.",
+    methodologyReference: '9.4 Processors and the Waste Generator',
     name: 'Transport Manifest Fields',
     slug: 'transport-manifest-fields',
+    type: 'methodology',
   },
   {
     description:
       "Verifies that the 'Recycling Manifest' event is declared in the MassID document, confirming that the waste was effectively processed at a recycling facility.",
     name: 'Has Recycling Manifest',
     slug: 'has-recycling-manifest',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event does not have an 'Exemption Justification' metadata, it must contain an attachment named 'Recycling Manifest'. The required supporting document may vary by country where the recycler is located.",
     name: 'Recycling Manifest Attachment',
     slug: 'recycling-manifest-attachment',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event does not contain the metadata required by the 'Recycling Manifest Fields' rule, an 'Exemption Justification' metadata must be declared with a non-empty value.",
     name: 'Recycling Manifest Exemption Justification',
     slug: 'recycling-manifest-exemption-justification',
+    type: 'structural',
   },
   {
     description:
       "The address declared in the 'Recycling Manifest' event must match the address of the 'Recycler' actor, ensuring the waste was processed at the correct location. Address validation is performed based on registered address IDs.",
     name: 'Recycling Manifest Address',
     slug: 'recycling-manifest-address',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event has no 'Exemption Justification', the following metadata must be filled: 'Document Type', 'Document Number', and 'Document Date Issue'. When the Recycler is located in Brazil (country='BR'), the 'Document Type' must be 'CDF'.",
     name: 'Recycling Manifest Fields',
     slug: 'recycling-manifest-fields',
+    type: 'structural',
   },
   {
     description:
       "When a 'Recycling Manifest' event has no 'Exemption Justification', the 'Event Value' metadata must exactly match the 'value' declared in the document, preventing discrepancies in the recycling record.",
     name: 'Recycling Manifest Value',
     slug: 'recycling-manifest-value',
+    type: 'audit',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Weight Capture Method' metadata must be present with one of the following values: Digital, Photo (Scale+Cargo), Manual, or Transport Manifest.",
     name: 'Weight Capture Method',
     slug: 'weight-capture-method',
+    type: 'structural',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Scale Type' metadata must be declared and identified as one of the approved types: Weighbridge (Truck Scale), Floor Scale, Pallet Scale, Forklift Scale, Conveyor Belt Scale, Hanging/Crane Scale, Bin Scale, Portable Axle Weigher, Onboard Truck Scale, Precision/Bench Scale, or Two-bin Lateral Scale.",
     name: 'Scale Type',
     slug: 'scale-type',
+    type: 'audit',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Container Type' metadata must be present with one of the following values: Bag, Bin, Drum, Pail, Street Bin, Waste Box, or Truck.",
     name: 'Container Type',
     slug: 'container-type',
+    type: 'structural',
   },
   {
     description:
       "In the 'WEIGHING' event, the 'Scale Accreditation' metadata must be present with a link to the scale validation event in the accreditation of the participant responsible for weighing.",
     name: 'Scale Accreditation',
     slug: 'scale-accreditation',
+    type: 'audit',
   },
   {
     description:
       "The MassID must have at least one 'WEIGHING' event with the following metadata: 'Gross Weight' (decimal > 0, in kg), 'Container Capacity' (decimal > 0, in KILOGRAM, LITER, or CUBIC_METER), 'Tare' (decimal >= 0, in kg), 'Mass Net Weight' (decimal > 0, in kg), and 'Container Quantity' (integer >= 1, required when Container Type is not 'Truck').",
     name: 'Weighing Fields',
     slug: 'weighing-fields',
+    type: 'structural',
   },
   {
     description:
       "In the 'WEIGHING' event, when the 'Container Type' is 'Truck', a 'Vehicle License Plate' attribute must be present.",
     name: 'Truck Weighing',
     slug: 'truck-weighing',
+    type: 'structural',
   },
   {
     description:
       "When a 'WEIGHING' event lacks 'Mass Net Weight' and 'Tare', it must have 'Gross Weight' and 'Container Capacity'. A second 'WEIGHING' event must then follow with matching 'Gross Weight', 'Container Capacity', 'Scale Type', 'Scale Accreditation', 'Container Type', and 'Vehicle License Plate' values, plus all other fields per the 'Weighing Fields' rule.",
     name: 'Weighing in two steps',
     slug: 'weighing-in-two-steps',
+    type: 'structural',
   },
   {
     description:
       "When a 'WEIGHING' event satisfies the 'Weighing Fields' rule, the following calculation is verified: Mass Net Weight = Gross Weight - (Tare * Container Quantity). If 'Container Quantity' is not provided, a value of 1 is assumed.",
     name: 'Net Weight Verification',
     slug: 'net-weight-verification',
+    type: 'structural',
   },
   {
     description:
       "A 'Sorting' event must be declared after all 'Weighing' events in the MassID document.",
     name: 'Mass Sorting Event',
     slug: 'mass-sorting-event',
+    type: 'structural',
   },
   {
     description:
       "The 'Sorting' event must contain a 'value' metadata, and the 'value' field of the 'Sorting' event must update the MassID document value.",
     name: 'Sorting Value Field',
     slug: 'sorting-value-field',
+    type: 'structural',
   },
   {
     description:
       "Verifies that the sorting calculation is correct by executing the equation: document value * (100% - conversion factor) = mass sorting value, and comparing the result with the value declared in the 'Sorting' event.",
     name: 'Sorting Calculation',
     slug: 'sorting-calculation',
+    type: 'audit',
   },
   {
     description:
       "Checks the monthly waste generation ceiling in the source's accreditation page. If the sum of masses from the same generator in the same month exceeds the ceiling by more than 20%, the MassID is blocked for credit generation until reviewed by the operations department.",
     name: 'Double-checking Source Emitted Masses',
     slug: 'double-checking-source-emitted-masses',
+    type: 'audit',
   },
   {
     description:
       "Checks the operational capacity in the recycler's accreditation page. If the sum of masses processed by the same recycler in the same month exceeds the operational capacity by more than 3%, the MassID is blocked for credit generation until approved by the operations department.",
     name: 'Double-checking Recycler Emitted Masses',
     slug: 'double-checking-recycler-emitted-masses',
+    type: 'audit',
   },
   {
     description:
       'Verifies that no other mass documents exist with the same document value, same date and time of receipt at the recycling yard, same generator, and same vehicle. Duplicate documents are rejected to prevent inconsistencies.',
     name: 'Duplicate Check',
     slug: 'duplicate-check',
+    type: 'audit',
   },
   {
     description:
       "Verifies that the date, time of the 'Drop-Off' event, and 'vehicle-license-plate' of the audited MassID are unique. If there is a conflict with another MassID, the mass is rejected to prevent duplicate or inconsistent records.",
     name: 'Route Check',
     slug: 'route-check',
+    type: 'audit',
   },
   {
     description:
       "Verifies the composting fertilizer coefficient in the recycler's accreditation page and checks whether the declared quantity is compatible with the calculation, ensuring accuracy in recycled-to-input conversion reporting.",
     name: 'Recycled-to-Input Conversion',
     slug: 'recycled-to-input-conversion',
+    type: 'audit',
   },
-] as const;
+] as const satisfies readonly BaseFrameworkRule[];
 
 export type FrameworkRuleSlug = (typeof frameworkRules)[number]['slug'];

--- a/libs/shared/rule/types/src/framework-rule.types.ts
+++ b/libs/shared/rule/types/src/framework-rule.types.ts
@@ -1,0 +1,15 @@
+export const FRAMEWORK_RULE_TYPES = [
+  'structural',
+  'methodology',
+  'audit',
+] as const;
+
+export interface BaseFrameworkRule {
+  description: string;
+  methodologyReference?: string;
+  name: string;
+  slug: string;
+  type: FrameworkRuleType;
+}
+
+export type FrameworkRuleType = (typeof FRAMEWORK_RULE_TYPES)[number];

--- a/libs/shared/rule/types/src/index.ts
+++ b/libs/shared/rule/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './evaluate-result-output.types';
+export * from './framework-rule.types';
 export * from './rule-definition.types';
 export * from './rule-test-case.types';
 export * from './rule.types';

--- a/scripts/generate-framework-rules-manifest.ts
+++ b/scripts/generate-framework-rules-manifest.ts
@@ -9,9 +9,11 @@
  */
 
 import type { BaseFrameworkRule } from '@carrot-fndn/shared/rule/types';
+import { FRAMEWORK_RULE_TYPES } from '../libs/shared/rule/types/src/framework-rule.types';
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
 
 const ROOT = path.resolve(__dirname, '..');
 const DIST_FRAMEWORK = path.join(ROOT, 'dist', 'framework-rules');
@@ -35,6 +37,14 @@ if (METHODOLOGY_DIRS.length === 0) {
   process.exit(1);
 }
 
+const BaseFrameworkRuleSchema = z.object({
+  description: z.string().min(1),
+  methodologyReference: z.string().min(1).optional(),
+  name: z.string().min(1),
+  slug: z.string().regex(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/),
+  type: z.enum(FRAMEWORK_RULE_TYPES),
+});
+
 function loadFrameworkRules(methodology: string): BaseFrameworkRule[] {
   const filePath = path.join(
     LIBS_METHODOLOGIES,
@@ -47,6 +57,23 @@ function loadFrameworkRules(methodology: string): BaseFrameworkRule[] {
   const { frameworkRules } = require(filePath) as {
     frameworkRules: BaseFrameworkRule[];
   };
+
+  // Validate each rule against the schema
+  for (const rule of frameworkRules) {
+    BaseFrameworkRuleSchema.parse(rule);
+  }
+
+  // Check for duplicate slugs
+  const slugs = new Set<string>();
+  for (const rule of frameworkRules) {
+    if (slugs.has(rule.slug)) {
+      throw new Error(
+        `FATAL: Duplicate framework rule slug "${rule.slug}" in ${methodology}`,
+      );
+    }
+    slugs.add(rule.slug);
+  }
+
   return frameworkRules;
 }
 
@@ -72,7 +99,7 @@ function main(): void {
         number: index + 1,
         description: rule.description,
         type: rule.type,
-        ...(rule.methodologyReference && {
+        ...(rule.methodologyReference !== undefined && {
           methodologyReference: rule.methodologyReference,
         }),
       })),

--- a/scripts/generate-framework-rules-manifest.ts
+++ b/scripts/generate-framework-rules-manifest.ts
@@ -8,6 +8,8 @@
  * Output: dist/framework-rules/bold-carbon.json, dist/framework-rules/bold-recycling.json
  */
 
+import type { BaseFrameworkRule } from '@carrot-fndn/shared/rule/types';
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -33,9 +35,7 @@ if (METHODOLOGY_DIRS.length === 0) {
   process.exit(1);
 }
 
-function loadFrameworkRules(
-  methodology: string,
-): Array<{ name: string; description: string; slug: string }> {
+function loadFrameworkRules(methodology: string): BaseFrameworkRule[] {
   const filePath = path.join(
     LIBS_METHODOLOGIES,
     methodology,
@@ -45,7 +45,7 @@ function loadFrameworkRules(
   );
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { frameworkRules } = require(filePath) as {
-    frameworkRules: Array<{ name: string; description: string; slug: string }>;
+    frameworkRules: BaseFrameworkRule[];
   };
   return frameworkRules;
 }
@@ -71,6 +71,10 @@ function main(): void {
         name: rule.name,
         number: index + 1,
         description: rule.description,
+        type: rule.type,
+        ...(rule.methodologyReference && {
+          methodologyReference: rule.methodologyReference,
+        }),
       })),
     };
 

--- a/scripts/generate-rule-readmes.ts
+++ b/scripts/generate-rule-readmes.ts
@@ -73,8 +73,10 @@ const BaseRuleDefinitionSchema = z.object({
 
 const FrameworkRuleSchema = z.object({
   description: z.string(),
+  methodologyReference: z.string().optional(),
   name: z.string(),
   slug: z.string(),
+  type: z.enum(['structural', 'methodology', 'audit']),
 });
 
 type FrameworkRule = z.infer<typeof FrameworkRuleSchema>;

--- a/scripts/generate-rule-readmes.ts
+++ b/scripts/generate-rule-readmes.ts
@@ -9,6 +9,7 @@
  */
 
 import type { BaseRuleDefinition } from '@carrot-fndn/shared/rule/types';
+import { FRAMEWORK_RULE_TYPES } from '../libs/shared/rule/types/src/framework-rule.types';
 
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
@@ -73,10 +74,10 @@ const BaseRuleDefinitionSchema = z.object({
 
 const FrameworkRuleSchema = z.object({
   description: z.string(),
-  methodologyReference: z.string().optional(),
+  methodologyReference: z.string().min(1).optional(),
   name: z.string(),
   slug: z.string(),
-  type: z.enum(['structural', 'methodology', 'audit']),
+  type: z.enum(FRAMEWORK_RULE_TYPES),
 });
 
 type FrameworkRule = z.infer<typeof FrameworkRuleSchema>;


### PR DESCRIPTION
## Summary

- Add `type` (`structural` | `methodology` | `audit`) and optional `methodologyReference` fields to all framework rule definitions for both BOLD Carbon (56 rules) and BOLD Recycling (54 rules)
- Create shared `FrameworkRuleType` union and `BaseFrameworkRule` interface in `@carrot-fndn/shared/rule/types`
- Update generate scripts to pass through new fields with Zod validation and slug uniqueness checks

## Details

The MvF specification defines three categories of validation rules — structural, methodological, and audit — and links each rule to a specific methodology document section. These fields were tracked in an internal CSV but missing from the data model. This PR adds them as first-class fields.

**Data source:** `carrot-docs/local/mvf-rules.csv`

### Changes

| Area | Files |
|---|---|
| Shared types | `libs/shared/rule/types/src/framework-rule.types.ts` (new) |
| Bold Carbon | `libs/methodologies/bold-carbon/rules/src/framework-rules.ts` |
| Bold Recycling | `libs/methodologies/bold-recycling/rules/src/framework-rules.ts` |
| Generate scripts | `scripts/generate-framework-rules-manifest.ts`, `scripts/generate-rule-readmes.ts` |

### Companion PR

The carrot-docs UI changes (schema, component, i18n) are in a separate PR: carrot-foundation/docs — `feat/framework-rules-type-and-reference-ui`. The JSON manifests will sync via CI once this PR lands on `main`.

## Test plan

- [x] `pnpm generate:framework-rules` produces correct JSON with `type` and `methodologyReference` fields
- [x] `pnpm generate:readmes` passes Zod validation with new fields
- [x] Zod runtime validation catches invalid rules (tested slug format, empty strings)
- [x] Slug uniqueness check prevents duplicates
- [x] All pre-commit hooks pass (eslint, cspell, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced framework rules with classification metadata. Rules now include type information (methodology, audit, or structural classification) and optional methodology references for richer context.
  * Improved validation and type safety for framework rules across the system to ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->