### PR TITLE
fix(script): scope slug uniqueness by methodology and processor scope

### DIFF
--- a/tools/versioning/bump-application-versions.ts
+++ b/tools/versioning/bump-application-versions.ts
@@ -336,8 +336,9 @@ function analyzeMethodologyBumps(ruleBumps: RuleBump[]): AnalysisResult {
 
     // Collect rule bumps that belong to this methodology
     const currentSlugSet = new Set(currentSlugs);
-    const matchingRuleBumps = ruleBumps.filter((rb) =>
-      currentSlugSet.has(rb.slug),
+    const matchingRuleBumps = ruleBumps.filter(
+      (rb) =>
+        rb.methodology === methodology.key && currentSlugSet.has(rb.slug),
     );
 
     if (matchingRuleBumps.length > 0) {

--- a/tools/versioning/bump-application-versions.ts
+++ b/tools/versioning/bump-application-versions.ts
@@ -336,9 +336,8 @@ function analyzeMethodologyBumps(ruleBumps: RuleBump[]): AnalysisResult {
 
     // Collect rule bumps that belong to this methodology
     const currentSlugSet = new Set(currentSlugs);
-    const matchingRuleBumps = ruleBumps.filter(
-      (rb) =>
-        rb.methodology === methodology.key && currentSlugSet.has(rb.slug),
+    const matchingRuleBumps = ruleBumps.filter((rb) =>
+      currentSlugSet.has(rb.slug),
     );
 
     if (matchingRuleBumps.length > 0) {

--- a/tools/versioning/bump-rule-versions.ts
+++ b/tools/versioning/bump-rule-versions.ts
@@ -14,6 +14,7 @@ const LIBS_METHODOLOGIES = path.join(ROOT, 'libs', 'methodologies');
 const DRY_RUN = process.argv.includes('--dry-run');
 
 interface DiscoveredRule {
+  compositeKey: string;
   filePath: string;
   methodology: string;
   ruleDir: string;
@@ -22,10 +23,17 @@ interface DiscoveredRule {
   version: string;
 }
 
-function getLatestMvaTag(): string | undefined {
+function getLatestMvaTagForMethodology(
+  methodology: string,
+): string | undefined {
   const output = execFileSync(
     'git',
-    ['tag', '--list', 'methodology-application/*', '--sort=-creatordate'],
+    [
+      'tag',
+      '--list',
+      `methodology-application/${methodology}@*`,
+      '--sort=-creatordate',
+    ],
     { cwd: ROOT, encoding: 'utf8' },
   ).trim();
 
@@ -55,10 +63,10 @@ function getCommitsSince(ref?: string): string[] {
   }
 }
 
-function collectCommitsPerSlug(
+function collectCommitsPerScope(
   commitMessages: string[],
 ): Map<string, string[]> {
-  const commitsPerSlug = new Map<string, string[]>();
+  const commitsPerScope = new Map<string, string[]>();
 
   for (const message of commitMessages) {
     const header = message.split('\n')[0];
@@ -66,12 +74,12 @@ function collectCommitsPerSlug(
     if (!match?.[2]) continue;
 
     const scope = match[2];
-    const existing = commitsPerSlug.get(scope) ?? [];
+    const existing = commitsPerScope.get(scope) ?? [];
     existing.push(message);
-    commitsPerSlug.set(scope, existing);
+    commitsPerScope.set(scope, existing);
   }
 
-  return commitsPerSlug;
+  return commitsPerScope;
 }
 
 function discoverRuleDefinitions(): DiscoveredRule[] {
@@ -144,6 +152,7 @@ function discoverRuleDefinitions(): DiscoveredRule[] {
         compositeKeyLocations.set(compositeKey, filePath);
 
         rules.push({
+          compositeKey,
           filePath,
           methodology,
           ruleDir: path.join(scopeDir, ruleDir),
@@ -221,58 +230,51 @@ function main(): void {
     DRY_RUN ? '=== DRY RUN (no files will be changed) ===' : '=== Bumping rule versions ===',
   );
 
-  const tag = getLatestMvaTag();
-  console.log(tag ? `Latest MvA tag: ${tag}` : 'No MvA tags found, scanning all commits');
-
-  const commitMessages = getCommitsSince(tag);
-  console.log(`Found ${String(commitMessages.length)} commits to analyze`);
-
-  if (commitMessages.length === 0) {
-    console.log('No commits to process. Exiting.');
-
-    if (!DRY_RUN) {
-      const distDir = path.join(ROOT, 'dist');
-      if (!fs.existsSync(distDir)) {
-        fs.mkdirSync(distDir, { recursive: true });
-      }
-
-      const outputPath = path.join(distDir, 'rule-bumps.json');
-      fs.writeFileSync(outputPath, JSON.stringify([], null, 2), 'utf8');
-      console.log(`Wrote empty rule-bumps.json to ${outputPath}`);
-    }
-
-    return;
-  }
-
-  const ruleBumpsMap = parseCommitsForRules(commitMessages);
-  console.log(`Detected bumps for ${String(ruleBumpsMap.size)} rule(s)`);
-
-  const commitsPerSlug = collectCommitsPerSlug(commitMessages);
   const discoveredRules = discoverRuleDefinitions();
   console.log(`Discovered ${String(discoveredRules.length)} rule definitions`);
 
-  const rulesBySlug = new Map<string, DiscoveredRule[]>();
+  // Group discovered rules by methodology
+  const rulesByMethodology = new Map<string, DiscoveredRule[]>();
   for (const rule of discoveredRules) {
-    const existing = rulesBySlug.get(rule.slug) ?? [];
+    const existing = rulesByMethodology.get(rule.methodology) ?? [];
     existing.push(rule);
-    rulesBySlug.set(rule.slug, existing);
+    rulesByMethodology.set(rule.methodology, existing);
   }
 
   const results: RuleBump[] = [];
 
-  for (const [slug, bumpLevel] of ruleBumpsMap) {
-    const rules = rulesBySlug.get(slug);
-    if (!rules?.length) {
-      console.log(`  SKIP ${slug}: no matching rule-definition.ts found`);
-      continue;
+  for (const [methodology, methodologyRules] of rulesByMethodology) {
+    const tag = getLatestMvaTagForMethodology(methodology);
+    console.log(
+      tag
+        ? `\n${methodology}: latest tag ${tag}`
+        : `\n${methodology}: no tags found, scanning all commits`,
+    );
+
+    const commitMessages = getCommitsSince(tag);
+    console.log(`  Found ${String(commitMessages.length)} commits to analyze`);
+
+    if (commitMessages.length === 0) continue;
+
+    const ruleBumpsMap = parseCommitsForRules(commitMessages);
+    console.log(`  Detected bumps for ${String(ruleBumpsMap.size)} scope(s)`);
+
+    const commitsPerScope = collectCommitsPerScope(commitMessages);
+
+    // Index rules by composite key for O(1) lookup
+    const rulesByKey = new Map<string, DiscoveredRule>();
+    for (const rule of methodologyRules) {
+      rulesByKey.set(rule.compositeKey, rule);
     }
 
-    const ruleCommits = commitsPerSlug.get(slug) ?? [];
+    for (const [scope, bumpLevel] of ruleBumpsMap) {
+      const rule = rulesByKey.get(scope);
+      if (!rule) continue;
 
-    for (const rule of rules) {
       const newVersion = bumpVersion(rule.version, bumpLevel);
+      const ruleCommits = commitsPerScope.get(scope) ?? [];
 
-      console.log(`  ${rule.methodology}/${rule.scope}/${slug}: ${rule.version} -> ${newVersion} (${bumpLevel})`);
+      console.log(`  ${rule.compositeKey}: ${rule.version} -> ${newVersion} (${bumpLevel})`);
 
       if (!DRY_RUN) {
         updateRuleDefinitionVersion(rule.filePath, rule.version, newVersion);
@@ -286,7 +288,7 @@ function main(): void {
         newVersion,
         previousVersion: rule.version,
         scope: rule.scope,
-        slug,
+        slug: rule.slug,
       });
     }
   }
@@ -299,7 +301,7 @@ function main(): void {
   const outputPath = path.join(distDir, 'rule-bumps.json');
 
   if (results.length === 0) {
-    console.log('No rule bumps to apply.');
+    console.log('\nNo rule bumps to apply.');
 
     if (!DRY_RUN) {
       fs.writeFileSync(outputPath, JSON.stringify([], null, 2), 'utf8');
@@ -308,6 +310,7 @@ function main(): void {
 
     return;
   }
+
   if (!DRY_RUN) {
     fs.writeFileSync(outputPath, JSON.stringify(results, null, 2), 'utf8');
     console.log(`\nWrote ${String(results.length)} bump(s) to ${outputPath}`);

--- a/tools/versioning/bump-rule-versions.ts
+++ b/tools/versioning/bump-rule-versions.ts
@@ -10,18 +10,14 @@ import type { RuleBump } from './shared/types';
 import { bumpVersion } from './shared/version-utils';
 
 const ROOT = path.resolve(__dirname, '../..');
-const LIB_RULE_PROCESSORS = path.join(
-  ROOT,
-  'libs',
-  'methodologies',
-  'bold',
-  'rule-processors',
-);
+const LIBS_METHODOLOGIES = path.join(ROOT, 'libs', 'methodologies');
 const DRY_RUN = process.argv.includes('--dry-run');
 
 interface DiscoveredRule {
   filePath: string;
+  methodology: string;
   ruleDir: string;
+  scope: string;
   slug: string;
   version: string;
 }
@@ -82,59 +78,80 @@ function discoverRuleDefinitions(): DiscoveredRule[] {
   const rules: DiscoveredRule[] = [];
   const slugRegex = /slug:\s*['"`]([^'"`]+)['"`]/;
   const versionRegex = /version:\s*['"`]([^'"`]+)['"`]/;
-  const slugLocations = new Map<string, string>();
+  const compositeKeyLocations = new Map<string, string>();
 
-  const scopes = fs
-    .readdirSync(LIB_RULE_PROCESSORS, { withFileTypes: true })
+  const methodologyDirs = fs
+    .readdirSync(LIBS_METHODOLOGIES, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name);
 
-  for (const scope of scopes) {
-    const scopeDir = path.join(LIB_RULE_PROCESSORS, scope);
-    const ruleDirs = fs
-      .readdirSync(scopeDir, { withFileTypes: true })
+  for (const methodology of methodologyDirs) {
+    const ruleProcessorsDir = path.join(
+      LIBS_METHODOLOGIES,
+      methodology,
+      'rule-processors',
+    );
+
+    if (!fs.existsSync(ruleProcessorsDir)) {
+      console.log(`  ${methodology}/: no rule-processors/ directory, skipping`);
+      continue;
+    }
+
+    const scopes = fs
+      .readdirSync(ruleProcessorsDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
 
-    for (const ruleDir of ruleDirs) {
-      const srcDir = path.join(scopeDir, ruleDir, 'src');
-      if (!fs.existsSync(srcDir)) continue;
+    for (const scope of scopes) {
+      const scopeDir = path.join(ruleProcessorsDir, scope);
+      const ruleDirs = fs
+        .readdirSync(scopeDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
 
-      const files = fs.readdirSync(srcDir);
-      const defFile = files.find((f) => f.endsWith('.rule-definition.ts'));
-      if (!defFile) continue;
+      for (const ruleDir of ruleDirs) {
+        const srcDir = path.join(scopeDir, ruleDir, 'src');
+        if (!fs.existsSync(srcDir)) continue;
 
-      const filePath = path.join(srcDir, defFile);
-      const content = fs.readFileSync(filePath, 'utf8');
+        const files = fs.readdirSync(srcDir);
+        const defFile = files.find((f) => f.endsWith('.rule-definition.ts'));
+        if (!defFile) continue;
 
-      const slugMatch = slugRegex.exec(content);
-      const versionMatch = versionRegex.exec(content);
+        const filePath = path.join(srcDir, defFile);
+        const content = fs.readFileSync(filePath, 'utf8');
 
-      if (!slugMatch?.[1] || !versionMatch?.[1]) {
-        console.warn(
-          `  SKIP ${filePath}: slug=${slugMatch?.[1] ?? 'NOT FOUND'}, version=${versionMatch?.[1] ?? 'NOT FOUND'}`,
-        );
-        continue;
+        const slugMatch = slugRegex.exec(content);
+        const versionMatch = versionRegex.exec(content);
+
+        if (!slugMatch?.[1] || !versionMatch?.[1]) {
+          console.warn(
+            `  SKIP ${filePath}: slug=${slugMatch?.[1] ?? 'NOT FOUND'}, version=${versionMatch?.[1] ?? 'NOT FOUND'}`,
+          );
+          continue;
+        }
+
+        const slug = slugMatch[1];
+        const compositeKey = `${methodology}/${scope}/${slug}`;
+        const previousLocation = compositeKeyLocations.get(compositeKey);
+
+        if (previousLocation) {
+          throw new Error(
+            `Duplicate rule "${compositeKey}" found in ${filePath} and ${previousLocation}. ` +
+              'Slugs must be unique within the same methodology and processor scope.',
+          );
+        }
+
+        compositeKeyLocations.set(compositeKey, filePath);
+
+        rules.push({
+          filePath,
+          methodology,
+          ruleDir: path.join(scopeDir, ruleDir),
+          scope,
+          slug,
+          version: versionMatch[1],
+        });
       }
-
-      const slug = slugMatch[1];
-      const previousLocation = slugLocations.get(slug);
-
-      if (previousLocation) {
-        throw new Error(
-          `Duplicate slug "${slug}" found in ${filePath} and ${previousLocation}. ` +
-            'Slugs must be unique across all processor scopes.',
-        );
-      }
-
-      slugLocations.set(slug, filePath);
-
-      rules.push({
-        filePath,
-        ruleDir: path.join(scopeDir, ruleDir),
-        slug,
-        version: versionMatch[1],
-      });
     }
   }
 
@@ -254,9 +271,8 @@ function main(): void {
 
     for (const rule of rules) {
       const newVersion = bumpVersion(rule.version, bumpLevel);
-      const scope = path.basename(path.dirname(rule.ruleDir));
 
-      console.log(`  ${scope}/${slug}: ${rule.version} -> ${newVersion} (${bumpLevel})`);
+      console.log(`  ${rule.methodology}/${rule.scope}/${slug}: ${rule.version} -> ${newVersion} (${bumpLevel})`);
 
       if (!DRY_RUN) {
         updateRuleDefinitionVersion(rule.filePath, rule.version, newVersion);
@@ -266,8 +282,10 @@ function main(): void {
       results.push({
         bumpLevel,
         commits: ruleCommits,
+        methodology: rule.methodology,
         newVersion,
         previousVersion: rule.version,
+        scope: rule.scope,
         slug,
       });
     }

--- a/tools/versioning/shared/commit-parser.spec.ts
+++ b/tools/versioning/shared/commit-parser.spec.ts
@@ -109,6 +109,32 @@ describe('parseCommitsForRules', () => {
     expect(parseCommitsForRules([''])).toEqual(new Map());
   });
 
+  it('should parse a composite key scope (methodology/scope/slug)', () => {
+    const commits = [
+      'feat(bold/credit-order/rewards-distribution): add calculation',
+    ];
+    const result = parseCommitsForRules(commits);
+
+    expect(result).toEqual(
+      new Map([['bold/credit-order/rewards-distribution', 'minor']]),
+    );
+  });
+
+  it('should track composite key scopes independently', () => {
+    const commits = [
+      'fix(bold/credit-order/rewards-distribution): fix rounding',
+      'feat(bold/mass-id-certificate/rewards-distribution): add validation',
+    ];
+    const result = parseCommitsForRules(commits);
+
+    expect(result).toEqual(
+      new Map([
+        ['bold/credit-order/rewards-distribution', 'patch'],
+        ['bold/mass-id-certificate/rewards-distribution', 'minor'],
+      ]),
+    );
+  });
+
   it('should handle multiple rules in one batch', () => {
     const commits = [
       'fix(audit-eligibility-check): fix date parsing',

--- a/tools/versioning/shared/commit-parser.ts
+++ b/tools/versioning/shared/commit-parser.ts
@@ -7,7 +7,7 @@ const BUMP_PRECEDENCE: Record<BumpLevel, number> = {
   patch: 1,
 };
 
-export const HEADER_PATTERN = /^(\w*)(?:\(([\w$.* -]*)\))?(!?): (.*)$/;
+export const HEADER_PATTERN = /^(\w*)(?:\(([\w$.* /-]*)\))?(!?): (.*)$/;
 
 interface ParsedCommit {
   isBreaking: boolean;

--- a/tools/versioning/shared/types.ts
+++ b/tools/versioning/shared/types.ts
@@ -5,8 +5,10 @@ export type BumpLevel = 'major' | 'minor' | 'patch';
 export const RuleBumpSchema = z.object({
   bumpLevel: z.enum(['major', 'minor', 'patch']),
   commits: z.array(z.string()),
+  methodology: z.string(),
   newVersion: z.string(),
   previousVersion: z.string(),
+  scope: z.string(),
   slug: z.string(),
 });
 


### PR DESCRIPTION
## Summary

- Fixes `pnpm bump:rules` CI failure caused by duplicate slug `"rewards-distribution"` across `mass-id-certificate` and `credit-order` processor scopes
- Changes slug uniqueness key from global (`slug`) to composite (`methodology/scope/slug`), allowing the same slug in different scopes
- Scans all methodologies for rule-processors instead of hardcoding `bold`
- Adds `methodology` and `scope` fields to `RuleBump` schema for precise downstream matching
- Filters application bumps by methodology in `bump-application-versions.ts` to prevent cross-scope misattribution

## Test plan

- [x] `pnpm bump:rules --dry-run` succeeds (previously threw `Duplicate slug` error)
- [x] Skipped methodologies (`bold-carbon`, `bold-recycling`) are logged in output
- [x] All 30 versioning shared tests pass
- [x] Pre-commit hooks (eslint, cspell, lint-staged) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced internal versioning infrastructure to support multi-methodology rule organization with improved scope-based grouping and composite key-based duplicate detection for better release management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->