### PR TITLE
feat(shared): add ENABLE_REVIEW_REQUIRED flag for geodesic distance

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.constants.ts
@@ -30,6 +30,12 @@ export const RESULT_COMMENTS = {
   passed: {
     OPTIONAL_VALIDATION_SKIPPED: (actorType: string): string =>
       `Optional validation skipped for ${actorType} (verification document not found).`,
+    PASSED_WITH_ADDRESS_SIMILARITY: (
+      actorType: string,
+      addressDistance: number,
+      similarityPercent: number,
+    ): string =>
+      `Compliant ${actorType} address: the geodesic distance between the event address coordinates and the accredited facility coordinates is ${addressDistance} m, but the address data matches with ${similarityPercent}% similarity.`,
     PASSED_WITH_GPS: (
       actorType: string,
       addressDistance: number,

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.spec.ts
@@ -15,6 +15,7 @@ import { GeolocationAndAddressPrecisionProcessor } from './geolocation-and-addre
 import {
   geolocationAndAddressPrecisionErrorTestCases,
   geolocationAndAddressPrecisionTestCases,
+  reviewRequiredTestCase,
 } from './geolocation-and-address-precision.test-cases';
 
 describe('GeolocationAndAddressPrecisionProcessor', () => {
@@ -88,6 +89,80 @@ describe('GeolocationAndAddressPrecisionProcessor', () => {
       });
     },
   );
+
+  describe('when ENABLE_REVIEW_REQUIRED is enabled', () => {
+    beforeEach(() => {
+      vi.stubEnv('ENABLE_REVIEW_REQUIRED', 'true');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should return REVIEW_REQUIRED when address similarity matches', async () => {
+      const {
+        accreditationDocuments,
+        actorParticipants,
+        massIDDocumentParameters,
+        resultComment,
+        resultStatus,
+      } = reviewRequiredTestCase;
+
+      const {
+        massIDAuditDocument,
+        massIDDocument,
+        participantsAccreditationDocuments,
+      } = new BoldStubsBuilder({
+        massIDActorParticipants: actorParticipants,
+      })
+        .createMassIDDocuments(massIDDocumentParameters)
+        .createMassIDAuditDocuments()
+        .createMethodologyDocument()
+        .createParticipantAccreditationDocuments(accreditationDocuments)
+        .build();
+
+      const auditActorEvents = [...actorParticipants.values()].map(
+        (participant) =>
+          stubDocumentEvent({
+            label: participant.type,
+            name: BoldDocumentEventName.ACTOR,
+            participant,
+            relatedDocument: {
+              documentId: participantsAccreditationDocuments.get(
+                participant.type,
+              )!.id,
+            },
+          }),
+      );
+
+      massIDAuditDocument.externalEvents = [
+        ...(massIDAuditDocument.externalEvents ?? []),
+        ...auditActorEvents,
+      ];
+
+      const allDocuments = [
+        massIDDocument,
+        massIDAuditDocument,
+        ...participantsAccreditationDocuments.values(),
+      ];
+
+      spyOnLoadDocument(massIDAuditDocument);
+      spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);
+
+      const ruleInput = stubRuleInput({
+        documentId: massIDAuditDocument.id,
+      });
+
+      const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+      expectRuleOutput({
+        resultComment,
+        resultStatus,
+        ruleInput,
+        ruleOutput,
+      });
+    });
+  });
 
   describe('GeolocationAndAddressPrecisionProcessorErrors', () => {
     it.each(geolocationAndAddressPrecisionErrorTestCases)(

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.processor.ts
@@ -3,6 +3,7 @@ import type { DocumentAddress, Geolocation } from '@carrot-fndn/shared/types';
 
 import { RuleDataProcessor } from '@carrot-fndn/shared/app/types';
 import { provideDocumentLoaderService } from '@carrot-fndn/shared/document/loader';
+import { getEnableReviewRequired } from '@carrot-fndn/shared/env';
 import {
   calculateDistance,
   getOrUndefined,
@@ -347,15 +348,28 @@ export class GeolocationAndAddressPrecisionProcessor extends RuleDataProcessor {
     const similarityPercent = Math.floor(score * 100);
 
     if (isMatch && score >= ADDRESS_SIMILARITY_THRESHOLD) {
+      if (getEnableReviewRequired()) {
+        return [
+          {
+            resultComment:
+              RESULT_COMMENTS.reviewRequired.REVIEW_REQUIRED_WITH_ADDRESS_SIMILARITY(
+                actorType,
+                addressDistance,
+                similarityPercent,
+              ),
+            resultStatus: 'REVIEW_REQUIRED',
+          },
+        ];
+      }
+
       return [
         {
-          resultComment:
-            RESULT_COMMENTS.reviewRequired.REVIEW_REQUIRED_WITH_ADDRESS_SIMILARITY(
-              actorType,
-              addressDistance,
-              similarityPercent,
-            ),
-          resultStatus: 'REVIEW_REQUIRED',
+          resultComment: RESULT_COMMENTS.passed.PASSED_WITH_ADDRESS_SIMILARITY(
+            actorType,
+            addressDistance,
+            similarityPercent,
+          ),
+          resultStatus: 'PASSED',
         },
       ];
     }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -836,9 +836,9 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
       },
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       resultComment: expect.stringContaining('similarity'),
-      resultStatus: 'REVIEW_REQUIRED',
+      resultStatus: 'PASSED',
       scenario:
-        'Recycler address is 2-30km away but textual address matches by similarity (REVIEW_REQUIRED)',
+        'Recycler address is 2-30km away but textual address matches by similarity (PASSED when ENABLE_REVIEW_REQUIRED is disabled)',
     },
     {
       accreditationDocuments: new Map([
@@ -1004,6 +1004,61 @@ export const geolocationAndAddressPrecisionTestCases: GeolocationAndAddressPreci
       scenario: 'Recycler address is beyond 30km (FAILED)',
     },
   ];
+
+export const reviewRequiredTestCase: GeolocationAndAddressPrecisionTestCase = {
+  accreditationDocuments: new Map([
+    [
+      RECYCLER,
+      createAccreditationDocumentWithAddress(
+        similarRecyclerAccreditedAddress,
+        similarRecyclerParticipant,
+      ),
+    ],
+    [
+      WASTE_GENERATOR,
+      createAccreditationDocumentWithAddress(
+        similarWasteGeneratorAddress,
+        similarWasteGeneratorParticipant,
+      ),
+    ],
+  ]),
+  actorParticipants: new Map([
+    ...actorParticipants,
+    [RECYCLER, similarRecyclerParticipant],
+    [WASTE_GENERATOR, similarWasteGeneratorParticipant],
+  ]),
+  massIDDocumentParameters: {
+    externalEventsMap: {
+      [`${ACTOR}-${RECYCLER}`]: stubDocumentEvent({
+        address: similarRecyclerEventAddress,
+        label: RECYCLER,
+        name: ACTOR,
+        participant: similarRecyclerParticipant,
+      }),
+      [`${ACTOR}-${WASTE_GENERATOR}`]: stubDocumentEvent({
+        address: similarWasteGeneratorAddress,
+        label: WASTE_GENERATOR,
+        name: ACTOR,
+        participant: similarWasteGeneratorParticipant,
+      }),
+      [DROP_OFF]: createMassIDEvent(
+        DROP_OFF,
+        similarRecyclerEventAddress,
+        similarRecyclerParticipant,
+      ),
+      [PICK_UP]: createMassIDEvent(
+        PICK_UP,
+        similarWasteGeneratorAddress,
+        similarWasteGeneratorParticipant,
+      ),
+    },
+  },
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  resultComment: expect.stringContaining('requires review'),
+  resultStatus: 'REVIEW_REQUIRED',
+  scenario:
+    'Recycler address is 2-30km away but textual address matches by similarity (REVIEW_REQUIRED when ENABLE_REVIEW_REQUIRED is enabled)',
+};
 
 const errorMessage = new GeolocationAndAddressPrecisionProcessorErrors();
 

--- a/libs/shared/env/src/env.helpers.spec.ts
+++ b/libs/shared/env/src/env.helpers.spec.ts
@@ -9,6 +9,7 @@ import {
   getDocumentAttachmentBucketName,
   getDocumentBucketName,
   getEnableCloudwatchMetrics,
+  getEnableReviewRequired,
   getEnvironment,
   getNodeEnv as getNodeEnvironment,
   getOptionalEnv as getOptionalEnvironment,
@@ -283,6 +284,18 @@ describe('specific env helpers', () => {
       delete process.env['ENABLE_CLOUDWATCH_METRICS'];
 
       expect(getEnableCloudwatchMetrics()).toBe(false);
+    });
+
+    it('getEnableReviewRequired should return true when set to "true"', () => {
+      process.env['ENABLE_REVIEW_REQUIRED'] = 'true';
+
+      expect(getEnableReviewRequired()).toBe(true);
+    });
+
+    it('getEnableReviewRequired should return false when not set', () => {
+      delete process.env['ENABLE_REVIEW_REQUIRED'];
+
+      expect(getEnableReviewRequired()).toBe(false);
     });
   });
 });

--- a/libs/shared/env/src/env.helpers.ts
+++ b/libs/shared/env/src/env.helpers.ts
@@ -52,5 +52,7 @@ export const getDocumentAttachmentBucketName = (): string | undefined =>
   getOptionalEnv('DOCUMENT_ATTACHMENT_BUCKET_NAME');
 export const getEnableCloudwatchMetrics = (): boolean =>
   getBooleanEnv('ENABLE_CLOUDWATCH_METRICS');
+export const getEnableReviewRequired = (): boolean =>
+  getBooleanEnv('ENABLE_REVIEW_REQUIRED');
 export const getSentryDsn = (): string | undefined =>
   getOptionalEnv('SENTRY_DSN');

--- a/libs/shared/env/src/index.ts
+++ b/libs/shared/env/src/index.ts
@@ -7,6 +7,7 @@ export {
   getDocumentAttachmentBucketName,
   getDocumentBucketName,
   getEnableCloudwatchMetrics,
+  getEnableReviewRequired,
   getEnvironment,
   getNodeEnv,
   getOptionalEnv,


### PR DESCRIPTION
## Summary
- When address similarity matches (>= 75%) but geodesic distance is 2-30km, the geolocation rule now returns **PASSED** by default instead of `REVIEW_REQUIRED`
- Added `ENABLE_REVIEW_REQUIRED` env var (defaults to `false`) — set to `true` to restore the previous `REVIEW_REQUIRED` behavior
- Added `PASSED_WITH_ADDRESS_SIMILARITY` result comment for the new pass case
- Full test coverage for both flag states

## Test plan
- [x] All 40 geolocation-and-address-precision tests pass with 100% coverage
- [x] Lint passes
- [ ] Deploy with `ENABLE_REVIEW_REQUIRED` unset and verify the recycler geodesic distance case returns PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggleable behavior for address-similarity results: when disabled matches return "Compliant" with distance (m) and similarity (%) in the comment; when enabled matches produce "Review Required".
  * Exposed a new environment helper to control this feature.

* **Tests**
  * Added and updated tests covering both feature-flagged and non-flagged behaviors, including the new "Review Required" test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->