### PR TITLE
fix(shared): carry over data columns from CDF waste continuation rows

### DIFF
--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.ts
@@ -269,6 +269,12 @@ const mergeWasteContinuationRows = (
       previous[anchorColumn] = anchorText
         ? `${previousAnchor} ${anchorText}`
         : previousAnchor;
+
+      for (const [key, value] of Object.entries(row)) {
+        if (key !== anchorColumn && value !== undefined && !previous[key]) {
+          previous[key] = value;
+        }
+      }
     }
   }
 

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.ts
@@ -262,18 +262,11 @@ const mergeWasteContinuationRows = (
       merged.push({ ...row });
     } else {
       const previous = merged.at(-1)!;
-      // v8 ignore next -- anchor-based extraction guarantees non-empty text
-      const previousAnchor = previous[anchorColumn]?.trim() ?? '';
-
-      // v8 ignore next -- anchor-based extraction guarantees non-empty anchor text
-      previous[anchorColumn] = anchorText
-        ? `${previousAnchor} ${anchorText}`
-        : previousAnchor;
 
       for (const [key, value] of Object.entries(row)) {
-        if (key !== anchorColumn && value !== undefined && !previous[key]) {
-          previous[key] = value;
-        }
+        const existing = previous[key];
+
+        previous[key] = existing ? `${existing} ${value}` : value;
       }
     }
   }

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-shared.helpers.ts
@@ -183,6 +183,7 @@ const parseCdfWasteRow = (
 
   const codeMatch = config.codePattern.exec(wasteText);
 
+  // v8 ignore next -- isNewRow predicate in table extraction guarantees code-matching anchor text
   if (!codeMatch?.[1]) {
     return undefined;
   }
@@ -241,39 +242,6 @@ const findTableEndY = (
   return undefined;
 };
 
-/**
- * Merges continuation rows (where the anchor column text does not match the
- * waste code pattern) into the preceding row.  This handles multi-line waste
- * descriptions that Textract splits across separate LINE blocks.
- */
-const mergeWasteContinuationRows = (
-  rows: Array<Record<string, string | undefined>>,
-  anchorColumn: string,
-  codePattern: RegExp,
-): Array<Record<string, string | undefined>> => {
-  const merged: Array<Record<string, string | undefined>> = [];
-
-  for (const row of rows) {
-    // v8 ignore next -- anchor-based extraction guarantees non-empty anchor text
-    const anchorText = row[anchorColumn]?.trim() ?? '';
-    const isCodeRow = codePattern.test(anchorText);
-
-    if (isCodeRow || merged.length === 0) {
-      merged.push({ ...row });
-    } else {
-      const previous = merged.at(-1)!;
-
-      for (const [key, value] of Object.entries(row)) {
-        const existing = previous[key];
-
-        previous[key] = existing ? `${existing} ${value}` : value;
-      }
-    }
-  }
-
-  return merged;
-};
-
 export const extractCdfWasteEntries = (
   extractionResult: TextExtractionResult,
   config: CdfWasteTableConfig,
@@ -296,6 +264,7 @@ export const extractCdfWasteEntries = (
       TableColumnConfig,
       ...Array<TableColumnConfig>,
     ],
+    isNewRow: (anchorValue) => config.codePattern.test(anchorValue.trim()),
     maxRowGap: 0.03,
     xTolerance: 0.2,
     yRange: {
@@ -304,13 +273,7 @@ export const extractCdfWasteEntries = (
     },
   });
 
-  const mergedRows = mergeWasteContinuationRows(
-    rows,
-    config.anchorColumn,
-    config.codePattern,
-  );
-
-  const entries = mergedRows
+  const entries = rows
     .map((row) => parseCdfWasteRow(row, config))
     .filter((r): r is WasteEntry => r !== undefined);
 

--- a/libs/shared/document-extractor-recycling-manifest/src/cdf-sinfat.parser.spec.ts
+++ b/libs/shared/document-extractor-recycling-manifest/src/cdf-sinfat.parser.spec.ts
@@ -487,6 +487,83 @@ describe('CdfSinfatParser', () => {
       expect(entry?.quantity).toBe(420);
     });
 
+    it('should carry over data columns from continuation rows when data is Y-aligned with the continuation line', () => {
+      const rawText = [
+        'Certificado de Destinacao Final CDF nº 9900002/2025',
+        'VERDE ORGANICOS LTDA, CPF/CNPJ 44.555.666/0001-88 certifica que recebeu',
+        'Identificacao dos Residuos',
+        'Residuo Classe Quantidade Unidade Tecnologia',
+        '1. 020106 - Fezes, urina e estrume de animais (incluindo palha suja),',
+        'efluentes recolhidos separadamente e tratados noutro local Classe II A 420,00000 Tonelada Compostagem',
+        'Observacoes',
+        'Declaracao.',
+        'MTRs incluidos',
+        '9900000001, 9900000002',
+      ].join('\n');
+
+      const result = parser.parse(
+        stubTextExtractionResultWithBlocks(rawText, [
+          ...sinfatWasteHeaderBlocks,
+          {
+            boundingBox: { height: 0.01, left: 0.05, top: 0.31, width: 0.4 },
+            text: '1. 020106 - Fezes, urina e estrume de animais (incluindo palha suja),',
+          },
+          {
+            boundingBox: { height: 0.01, left: 0.05, top: 0.33, width: 0.4 },
+            text: 'efluentes recolhidos separadamente e tratados noutro local',
+          },
+          {
+            boundingBox: { height: 0.008, left: 0.46, top: 0.325, width: 0.08 },
+            text: 'Classe II A',
+          },
+          {
+            boundingBox: {
+              height: 0.009,
+              left: 0.578,
+              top: 0.325,
+              width: 0.04,
+            },
+            text: '420,00000',
+          },
+          {
+            boundingBox: {
+              height: 0.008,
+              left: 0.652,
+              top: 0.325,
+              width: 0.06,
+            },
+            text: 'Tonelada',
+          },
+          {
+            boundingBox: {
+              height: 0.009,
+              left: 0.749,
+              top: 0.325,
+              width: 0.09,
+            },
+            text: 'Compostagem',
+          },
+          {
+            boundingBox: { height: 0.02, left: 0.05, top: 0.38, width: 0.1 },
+            text: 'Observacoes',
+          },
+        ]),
+      );
+
+      expect(result.data.wasteEntries?.parsed).toHaveLength(1);
+
+      const entry = result.data.wasteEntries?.parsed[0];
+
+      expect(entry?.code).toBe('020106');
+      expect(entry?.description).toBe(
+        'Fezes, urina e estrume de animais (incluindo palha suja), efluentes recolhidos separadamente e tratados noutro local',
+      );
+      expect(entry?.classification).toBe('Classe II A');
+      expect(entry?.quantity).toBe(420);
+      expect(entry?.unit).toBe('Tonelada');
+      expect(entry?.technology).toBe('Compostagem');
+    });
+
     it('should exclude MTR numbers below the Observacoes table boundary', () => {
       const rawText = [
         'Certificado de Destinacao Final CDF nº 100/2025',

--- a/libs/shared/text-extractor/src/table-extraction.helpers.ts
+++ b/libs/shared/text-extractor/src/table-extraction.helpers.ts
@@ -13,6 +13,13 @@ export interface TableColumnConfig<TColumn extends string = string> {
 export interface TableExtractionConfig<TColumn extends string = string> {
   anchorColumn: TColumn;
   columns: [TableColumnConfig<TColumn>, ...Array<TableColumnConfig<TColumn>>];
+  /**
+   * Optional predicate to determine if an anchor value starts a new row.
+   * When omitted, any non-empty anchor value starts a new row.
+   * When provided, rows whose anchor value does not satisfy the predicate
+   * are merged into the previous row (all columns carried over).
+   */
+  isNewRow?: (anchorValue: string) => boolean;
   maxRowGap?: number;
   xTolerance?: number;
   yRange?: { max: number; min: number };
@@ -143,13 +150,18 @@ const mergeRowsByAnchor = (
   partialRows: readonly PartialRowWithTop[],
   anchorColumn: string,
   maxRowGap?: number,
+  isNewRowPredicate?: (anchorValue: string) => boolean,
 ): TableRow[] => {
   const merged: TableRow[] = [];
   let lastAnchorTop: number | undefined;
 
   for (const { row, top } of partialRows) {
     const anchorValue = row[anchorColumn];
-    const isNewRow = anchorValue !== undefined && anchorValue.trim().length > 0;
+    const hasAnchor =
+      anchorValue !== undefined && anchorValue.trim().length > 0;
+    const isNewRow = hasAnchor
+      ? (isNewRowPredicate?.(anchorValue) ?? true)
+      : false;
     const exceedsMaxGap =
       maxRowGap !== undefined &&
       lastAnchorTop !== undefined &&
@@ -254,6 +266,7 @@ export const extractTableFromBlocks = <TColumn extends string>(
     partialRows,
     config.anchorColumn,
     config.maxRowGap,
+    config.isNewRow,
   ) as Array<TableRow<TColumn>>;
 
   return { rows };


### PR DESCRIPTION
## Summary
- Fixed a bug where CDF waste entry data columns (quantity, unit, classification, technology) were lost when Textract placed them on a different Y cluster than the waste description
- Root cause: when a multi-line waste description splits across Y clusters, data columns (quantity, unit, etc.) end up in the continuation cluster and were silently dropped during row merging
- Added `isNewRow` predicate to `extractTableFromBlocks` config, allowing `mergeRowsByAnchor` to handle continuation rows natively via `appendToRow` — this makes the fix available to all document types using table extraction
- Removed the CDF-specific `mergeWasteContinuationRows` function (DRY)

## Test plan
- [x] All recycling manifest extractor tests pass with 100% coverage (83 tests)
- [x] All text-extractor tests pass with 100% coverage (76 tests)
- [x] All transport manifest extractor tests pass with 100% coverage (no regressions)
- [x] Verified fix against real CDF PDF using `document-extractor-cli` — quantity, unit, classification, and technology now extracted correctly
- [ ] Re-run audit for affected MassID to confirm cross-validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of continuation rows so description text and all associated columns from continuation lines are correctly merged into the corresponding waste entry.

* **Tests**
  * Added test coverage for parsing waste entries where descriptions span continuation lines and for carrying over classification, quantity, unit, and technology columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->