### PR TITLE
fix(shared): treat Weighbridge variants as equivalent in accreditation comparison

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.helpers.ts
@@ -433,7 +433,15 @@ const validators: Record<string, Validator> = {
       return { errors: [NOT_FOUND_RESULT_COMMENTS.ACCREDITATION_EVENT] };
     }
 
-    if (String(values.scaleType) !== String(values.accreditationScaleType)) {
+    const normalizeScaleType = (value: unknown): string =>
+      String(value) === BoldScaleType.WEIGHBRIDGE
+        ? BoldScaleType.WEIGHBRIDGE_SHORT
+        : String(value);
+
+    if (
+      normalizeScaleType(values.scaleType) !==
+      normalizeScaleType(values.accreditationScaleType)
+    ) {
       errors.push(
         INVALID_RESULT_COMMENTS.SCALE_TYPE_MISMATCH(
           values.scaleType,

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/src/weighing.test-cases.ts
@@ -447,6 +447,21 @@ export const weighingTestCases: WeighingTestCase[] = [
     scenario: `The "${SCALE_TYPE}" attribute is not equal to the "${SCALE_TYPE}" attribute in the Recycler Accreditation document and is not supported by the methodology`,
   },
   {
+    accreditationDocuments: stubBaseAccreditationDocuments({
+      scaleTypeValue: BoldScaleType.WEIGHBRIDGE,
+    }),
+    massIDDocumentEvents: {
+      [WEIGHING]: createWeighingEvent(
+        mergeAttributes(validWeighingAttributes, [
+          [SCALE_TYPE, BoldScaleType.WEIGHBRIDGE_SHORT],
+        ]),
+      ),
+    },
+    resultComment: PASSED_RESULT_COMMENTS.SINGLE_STEP,
+    resultStatus: 'PASSED',
+    scenario: `The "${SCALE_TYPE}" "${BoldScaleType.WEIGHBRIDGE_SHORT}" matches accreditation "${BoldScaleType.WEIGHBRIDGE}" as equivalent`,
+  },
+  {
     accreditationDocuments: stubBaseAccreditationDocuments(),
     massIDDocumentEvents: {
       [WEIGHING]: createWeighingEvent(


### PR DESCRIPTION
## Summary
- The scale type comparison between event and accreditation was a strict string equality, causing `"Weighbridge"` to mismatch `"Weighbridge (Truck Scale)"`
- Added normalization so both weighbridge variants are treated as equivalent during the accreditation scale type check
- Follows up on PR #386 which added `WEIGHBRIDGE_SHORT` to the enum but missed the accreditation comparison path

## Test plan
- [x] All 67 weighing tests pass with 100% coverage
- [x] Lint passes
- [ ] Re-run `run-rule` for the affected MassID to confirm PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scale type comparison to correctly handle equivalent weighbridge scale type representations during accreditation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->