### PR TITLE
fix(nx): rename type-check target to ts in mass-id rule processors

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/src/document-manifest-data.test-cases.ts
@@ -74,22 +74,24 @@ export const documentManifestDataTestCases: DocumentManifestDataTestCase[] = [
     resultStatus: 'FAILED',
     scenario: `The MassID document does not have a ${documentManifestType} event`,
   },
-  ...[ISSUE_DATE, DOCUMENT_NUMBER, DOCUMENT_TYPE].map((attribute) => ({
-    documentManifestType,
-    events: {
-      [documentManifestType]: documentManifestTypeStub[documentManifestType]({
-        metadataAttributes: [[attribute, undefined]],
-        partialDocumentEvent: {
-          address: sameAddress,
-        },
-      }),
-      ...defaultEvents,
-    },
-    manifestExample: true,
-    resultComment: attributeErrorMessages[attribute]!,
-    resultStatus: 'FAILED',
-    scenario: `The MassID document has a ${documentManifestType} event without a ${attribute}`,
-  })),
+  ...[ISSUE_DATE, DOCUMENT_NUMBER, DOCUMENT_TYPE].map(
+    (attribute): DocumentManifestDataTestCase => ({
+      documentManifestType,
+      events: {
+        [documentManifestType]: documentManifestTypeStub[documentManifestType]({
+          metadataAttributes: [[attribute, undefined]],
+          partialDocumentEvent: {
+            address: sameAddress,
+          },
+        }),
+        ...defaultEvents,
+      },
+      manifestExample: true,
+      resultComment: attributeErrorMessages[attribute]!,
+      resultStatus: 'FAILED',
+      scenario: `The MassID document has a ${documentManifestType} event without a ${attribute}`,
+    }),
+  ),
   {
     documentManifestType,
     events: {

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/src/geolocation-and-address-precision.test-cases.ts
@@ -22,7 +22,10 @@ import {
   BoldDocumentEventName,
   MassIDActorType,
 } from '@carrot-fndn/shared/methodologies/bold/types';
-import { type DocumentParticipant } from '@carrot-fndn/shared/types';
+import {
+  type DocumentAddress,
+  type DocumentParticipant,
+} from '@carrot-fndn/shared/types';
 import { faker } from '@faker-js/faker';
 import { expect } from 'vitest';
 
@@ -69,6 +72,12 @@ const actorsCoordinates = new Map(
   ]),
 );
 
+const distanceBetweenAddresses = (a: DocumentAddress, b: DocumentAddress) =>
+  calculateDistance(
+    { latitude: a.latitude!, longitude: a.longitude! },
+    { latitude: b.latitude!, longitude: b.longitude! },
+  );
+
 const recyclerParticipant = actorParticipants.get(
   RECYCLER,
 ) as DocumentParticipant;
@@ -94,15 +103,15 @@ const nearbyRecyclerAddress = stubAddress({
   ...actorsCoordinates.get(RECYCLER)!.nearby,
 });
 
-const invalidRecyclerAddressDistance = calculateDistance(
+const invalidRecyclerAddressDistance = distanceBetweenAddresses(
   recyclerAddress,
   invalidRecyclerAddress,
 );
-const invalidWasteGeneratorAddressDistance = calculateDistance(
+const invalidWasteGeneratorAddressDistance = distanceBetweenAddresses(
   wasteGeneratorAddress,
   invalidWasteGeneratorAddress,
 );
-const nearbyRecyclerAddressDistance = calculateDistance(
+const nearbyRecyclerAddressDistance = distanceBetweenAddresses(
   recyclerAddress,
   nearbyRecyclerAddress,
 );
@@ -149,19 +158,19 @@ const manifestInvalidWasteGeneratorAddress = stubAddress({
   longitude: -118.2437,
 });
 
-const manifestNearbyRecyclerAddressDistance = calculateDistance(
+const manifestNearbyRecyclerAddressDistance = distanceBetweenAddresses(
   manifestRecyclerAddress,
   manifestNearbyRecyclerAddress,
 );
-const manifestNearbyWasteGeneratorAddressDistance = calculateDistance(
+const manifestNearbyWasteGeneratorAddressDistance = distanceBetweenAddresses(
   manifestWasteGeneratorAddress,
   manifestNearbyWasteGeneratorAddress,
 );
-const manifestInvalidRecyclerAddressDistance = calculateDistance(
+const manifestInvalidRecyclerAddressDistance = distanceBetweenAddresses(
   manifestRecyclerAddress,
   manifestInvalidRecyclerAddress,
 );
-const manifestInvalidWasteGeneratorAddressDistance = calculateDistance(
+const manifestInvalidWasteGeneratorAddressDistance = distanceBetweenAddresses(
   manifestWasteGeneratorAddress,
   manifestInvalidWasteGeneratorAddress,
 );

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -125,7 +125,7 @@ const createErrorTestCase = (
   scenario: string,
   documents: BoldDocument[],
   resultComment: string,
-) => ({
+): MassIDSortingErrorTestCase => ({
   documents,
   massIDAuditDocument,
   resultComment,
@@ -136,8 +136,8 @@ const createErrorTestCase = (
 const createWeightAttributesWithFormat = (
   grossWeight: number,
   deductedWeight: number,
-  grossFormat = KILOGRAM,
-  deductedFormat = KILOGRAM,
+  grossFormat: DocumentEventAttributeFormat = KILOGRAM,
+  deductedFormat: DocumentEventAttributeFormat = KILOGRAM,
 ) => [
   {
     format: grossFormat,

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.lambda.e2e.spec.ts
@@ -12,7 +12,6 @@ import { faker } from '@faker-js/faker';
 import { preventedEmissionsLambda } from './prevented-emissions.lambda';
 import {
   preventedEmissionsErrorTestCases,
-  type PreventedEmissionsTestCase,
   preventedEmissionsTestCases,
 } from './prevented-emissions.test-cases';
 
@@ -23,7 +22,7 @@ describe('PreventedEmissionsProcessor E2E', () => {
 
   const documentKeyPrefix = faker.string.uuid();
 
-  it.each<PreventedEmissionsTestCase>(preventedEmissionsTestCases)(
+  it.each(preventedEmissionsTestCases)(
     'should return $resultStatus when $scenario',
     async ({
       accreditationDocuments,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.processor.spec.ts
@@ -8,7 +8,6 @@ import { stubRuleInput } from '@carrot-fndn/shared/testing';
 import { PreventedEmissionsProcessor } from './prevented-emissions.processor';
 import {
   preventedEmissionsErrorTestCases,
-  type PreventedEmissionsTestCase,
   preventedEmissionsTestCases,
 } from './prevented-emissions.test-cases';
 
@@ -20,7 +19,7 @@ describe('PreventedEmissionsProcessor', () => {
   });
 
   describe('PreventedEmissionsProcessor', () => {
-    it.each<PreventedEmissionsTestCase>(preventedEmissionsTestCases)(
+    it.each(preventedEmissionsTestCases)(
       'should return $resultStatus when $scenario',
       async ({
         accreditationDocuments,

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/prevented-emissions.test-cases.ts
@@ -137,7 +137,7 @@ const {
   .createParticipantAccreditationDocuments()
   .build();
 
-export const preventedEmissionsTestCases = [
+export const preventedEmissionsTestCases: PreventedEmissionsTestCase[] = [
   {
     accreditationDocuments: makeAccreditationDocuments([
       [EXCEEDING_EMISSION_COEFFICIENT, undefined],
@@ -249,7 +249,7 @@ export const preventedEmissionsTestCases = [
     BoldBaseline.LANDFILLS_WITHOUT_FLARING_OF_METHANE_GAS,
     BoldBaseline.OPEN_AIR_DUMP,
     BoldBaseline.LANDFILLS_WITH_FLARING_OF_METHANE_GAS,
-  ].map((othersBaseline) => {
+  ].map((othersBaseline): PreventedEmissionsTestCase => {
     const othersFactor = computeOthersIfOrganicFactor(othersBaseline);
     const expectedOthersPreventedEmissions =
       massIDDocumentValue * othersFactor -

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/src/vehicle-identification.test-cases.ts
@@ -89,22 +89,24 @@ export const vehicleIdentificationTestCases: VehicleIdentificationTestCase[] = [
     resultStatus: 'FAILED',
     scenario: `The "${PICK_UP}" event is not present`,
   },
-  ...[...VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES].map((vehicleType) => ({
-    events: new Map([
-      [
-        PICK_UP,
-        stubBoldMassIDPickUpEvent({
-          metadataAttributes: [[VEHICLE_TYPE, vehicleType]],
-        }),
-      ],
-    ]),
-    resultComment:
-      RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITHOUT_LICENSE_PLATE(
-        vehicleType,
-      ),
-    resultStatus: 'PASSED',
-    scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${vehicleType} and no license plate is needed`,
-  })),
+  ...[...VEHICLE_TYPE_NON_LICENSE_PLATE_VALUES].map(
+    (vehicleType): VehicleIdentificationTestCase => ({
+      events: new Map([
+        [
+          PICK_UP,
+          stubBoldMassIDPickUpEvent({
+            metadataAttributes: [[VEHICLE_TYPE, vehicleType]],
+          }),
+        ],
+      ]),
+      resultComment:
+        RESULT_COMMENTS.passed.VEHICLE_IDENTIFIED_WITHOUT_LICENSE_PLATE(
+          vehicleType,
+        ),
+      resultStatus: 'PASSED',
+      scenario: `The "${VEHICLE_TYPE}" attribute is declared as ${vehicleType} and no license plate is needed`,
+    }),
+  ),
   {
     events: new Map([
       [

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.e2e.spec.ts
@@ -140,28 +140,33 @@ describe('Waste Mass Is Unique Helpers E2E', () => {
               ...eventsData.pickUpEvent,
               name: 'OPEN',
             },
-            [['vehicle-license-plate', vehicleLicensePlate]],
+            [
+              [
+                'vehicle-license-plate' as BoldAttributeName,
+                vehicleLicensePlate,
+              ],
+            ],
           ),
           stubDocumentEventWithMetadataAttributes(
             {
               ...eventsData.dropOffEvent,
               name: MOVE,
             },
-            [['move-type', 'Drop-off']],
+            [['move-type' as BoldAttributeName, 'Drop-off']],
           ),
           stubDocumentEventWithMetadataAttributes(
             {
               ...eventsData.recyclerEvent,
               name: ACTOR,
             },
-            [['actor-type', 'RECYCLER']],
+            [['actor-type' as BoldAttributeName, 'RECYCLER']],
           ),
           stubDocumentEventWithMetadataAttributes(
             {
               ...eventsData.wasteGeneratorEvent,
               name: ACTOR,
             },
-            [['actor-type', 'SOURCE']],
+            [['actor-type' as BoldAttributeName, 'SOURCE']],
           ),
         ],
         subtype: v2DocumentStub.subtype,

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/src/waste-mass-is-unique.helpers.spec.ts
@@ -117,9 +117,9 @@ describe('waste-mass-is-unique.helpers', () => {
 
       expect(calls.length).toBeGreaterThanOrEqual(2);
 
-      expect(calls[0][0].match.category).toBe(MASS_ID);
+      expect(calls[0]![0].match.category).toBe(MASS_ID);
 
-      expect(calls[1][0].match.category).toBe('Mass');
+      expect(calls[1]![0].match.category).toBe('Mass');
     });
   });
 

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/project.json
@@ -13,6 +13,6 @@
   "targets": {
     "lint": {},
     "test": {},
-    "type-check": {}
+    "ts": {}
   }
 }


### PR DESCRIPTION
## Summary

- 19 `mass-id` rule processor `project.json` files declared a `type-check` target, but `nx.json` only configures `ts` as a `targetDefault`. `pnpm nx type-check <project>` silently failed with *"Cannot find configuration for task"* — these projects had **never been typechecked via Nx**.
- Renamed `"type-check": {}` → `"ts": {}` in all 19 files so they inherit the working executor (`pnpm tsc -p {projectRoot}/tsconfig.eslint.json --noEmit`).
- Fixed latent type errors that surfaced in 6 projects once `ts` actually ran.

## Latent fixes

- **`document-manifest-data`, `vehicle-identification`, `prevented-emissions`** — `.map()` callbacks spreading into typed arrays lost contextual narrowing on `resultStatus` literals. Annotated the callback return type.
- **`mass-id-sorting`** — `createWeightAttributesWithFormat` default params were inferred as `typeof KILOGRAM`, rejecting `CUBIC_METER`. Widened to `DocumentEventAttributeFormat`. `createErrorTestCase` return type annotated.
- **`geolocation-and-address-precision`** — `calculateDistance` was receiving full `Address` objects, which no longer structurally match `GeolibInputCoordinates` now that `lat/lng` are optional on `Address`. Added a local `distanceBetweenAddresses` helper that extracts coordinates explicitly.
- **`waste-mass-is-unique`** — legacy v1 attribute names (`vehicle-license-plate`, `move-type`, `actor-type`, used intentionally in the v1↔v2 duplicate-detection e2e test) cast to `BoldAttributeName`. Tightened non-null asserts on mock call indexing.
- **`prevented-emissions`** — annotated `preventedEmissionsTestCases` as `PreventedEmissionsTestCase[]`; removed incorrect `it.each<PreventedEmissionsTestCase>(...)` generics that forced tuple interpretation of the row type.

## Test plan

- [x] `pnpm nx run-many --target=ts --projects='methodologies-bold-rule-processors-mass-id-*'` — 20/20 projects pass
- [x] `pnpm nx run-many --target=lint --projects='methodologies-bold-rule-processors-mass-id-*' --fix` — clean (pre-existing warnings only)
- [x] `pnpm nx run-many --target=test --projects='methodologies-bold-rule-processors-mass-id-*'` — all tests pass
- [x] `grep -rn "type-check" libs apps tools scripts package.json nx.json .github` — no remaining target-name references (only descriptive prose in `.ai/` and `README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build target configurations across multiple libraries for improved tooling consistency
  
* **Tests**
  * Enhanced TypeScript type safety in test case definitions and helper utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->