### PR TITLE
ci(nx): add dedicated test-e2e runner for lambda e2e specs

### DIFF
--- a/.eslint/eslint.config.js
+++ b/.eslint/eslint.config.js
@@ -7,7 +7,14 @@ function getBaseEslintConfig({ projectPath, overrides = [] }) {
   return [
     ...baseConfig,
     // '!**/*' pattern is required to run ESLint on all files using Nx to compensate the lint-staged config pattern '**/*' on the root config
-    { ignores: ['!**/*', '**/*.config.js', '**/vitest.config.ts'] },
+    {
+      ignores: [
+        '!**/*',
+        '**/*.config.js',
+        '**/vitest.config.ts',
+        '**/vitest.e2e.config.ts',
+      ],
+    },
     {
       files: ['*.ts', '*.js'],
       rules: {

--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -245,3 +245,28 @@ jobs:
         run: pnpm nx affected --target=build-lambda --configuration=production
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  backend-tests-e2e:
+    name: Tests (E2E)
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.inputs.skip }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0 # required for Nx affected
+      - uses: ./.github/actions/prepare-to-run-nx
+        with:
+          environment: development
+          aws_account_id_production: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
+          aws_account_id_development: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
+          nx_key: ${{ secrets.NX_KEY }}
+
+      - run: pnpm nx affected --target=test-e2e --parallel=1
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      - uses: ./.github/actions/send-slack-message
+        if: ${{ failure() && github.ref_name == 'main' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: 'Backend E2E Tests job failed :suffering_cat:'

--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -269,3 +269,28 @@ jobs:
         run: pnpm nx affected --target=build-lambda --configuration=production
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  backend-tests-e2e:
+    name: Tests (E2E)
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.inputs.skip }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0 # required for Nx affected
+      - uses: ./.github/actions/prepare-to-run-nx
+        with:
+          environment: development
+          aws_account_id_production: ${{ secrets.AWS_ACCOUNT_ID_PRODUCTION }}
+          aws_account_id_development: ${{ secrets.AWS_ACCOUNT_ID_DEVELOPMENT }}
+          nx_key: ${{ secrets.NX_KEY }}
+
+      - run: pnpm nx affected --target=test-e2e --parallel=1
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      - uses: ./.github/actions/send-slack-message
+        if: ${{ failure() && github.ref_name == 'main' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: 'Backend E2E Tests job failed :suffering_cat:'

--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -278,6 +278,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0 # required for Nx affected
+          persist-credentials: false # job runs pnpm install; don't leave GITHUB_TOKEN in .git/config
       - uses: ./.github/actions/prepare-to-run-nx
         with:
           environment: development

--- a/.vitest/config/vitest.e2e.base.config.ts
+++ b/.vitest/config/vitest.e2e.base.config.ts
@@ -1,0 +1,31 @@
+import { getVitestBaseConfig } from './vitest.base.config';
+
+export const getVitestE2EBaseConfig = (dirname: string) => {
+  const base = getVitestBaseConfig(dirname);
+
+  return {
+    ...base,
+    test: {
+      ...base.test,
+
+      // Only pick up files that opted into the e2e category via the
+      // `.e2e.spec.*` / `.e2e.test.*` suffix. The unit target excludes these;
+      // the e2e target is the one place they run.
+      include: ['**/*.e2e.{test,spec}.{ts,js}'],
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/coverage/**',
+        '**/.git/**',
+      ],
+
+      // Coverage is enforced by the unit target; e2e specs exercise the full
+      // lambda path through the real document-query walker and would blow up
+      // the coverage model if counted again.
+      coverage: {
+        ...base.test.coverage,
+        enabled: false,
+      },
+    },
+  };
+};

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/project.json
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/project.json
@@ -14,6 +14,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/credit-order/rewards-distribution/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/project.json
@@ -14,6 +14,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/composting-cycle-timeframe/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/document-manifest-data/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/driver-identification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/driver-identification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/geolocation-and-address-precision/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/hauler-identification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-qualifications/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/participant-accreditations-and-verifications-requirements/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/processor-identification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/processor-identification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/project-period-limit/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/recycler-identification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/vehicle-identification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-mass-is-unique/vitest.e2e.config.ts
@@ -1,0 +1,20 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+const base = getVitestE2EBaseConfig(import.meta.dirname);
+
+export default {
+  ...base,
+  plugins: getVitestBasePlugins(),
+  test: {
+    ...base.test,
+    // `waste-mass-is-unique.helpers.e2e.spec.ts` hits the real audit-api
+    // (`smaug.carrot.eco/documents`) during `beforeAll` via `seedDocument`
+    // and requires live AWS credentials. It can't run under the standard
+    // test-e2e target; leave it for a future live-AWS runner.
+    exclude: [
+      ...base.test.exclude,
+      '**/waste-mass-is-unique.helpers.e2e.spec.ts',
+    ],
+  },
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/waste-origin-identification/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/project.json
@@ -13,6 +13,7 @@
   "targets": {
     "lint": {},
     "test": {},
+    "test-e2e": {},
     "ts": {}
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
   },
   "include": ["**/*.ts"],
-  "exclude": ["vitest.config.ts"]
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/weighing/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/weighing/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/nx.json
+++ b/nx.json
@@ -8,6 +8,7 @@
         "cacheableOperations": [
           "build-lambda",
           "test",
+          "test-e2e",
           "lint",
           "ts",
           "package-lambda"
@@ -94,6 +95,15 @@
         "resourceName": "{projectName}",
         "zipPath": "{workspaceRoot}/dist/.zip/{projectName}.zip"
       }
+    },
+    "test-e2e": {
+      "executor": "nx:run-commands",
+      "inputs": ["test-e2e", "^production"],
+      "outputs": ["{workspaceRoot}/coverage/{projectName}/junit.xml"],
+      "options": {
+        "command": "vitest run --config vitest.e2e.config.ts",
+        "cwd": "{projectRoot}"
+      }
     }
   },
   "pluginsConfig": {
@@ -150,6 +160,17 @@
       "{workspaceRoot}/.vitest/**/*.ts",
       "{workspaceRoot}/vitest.workspace.ts",
       "{projectRoot}/vitest.config.ts",
+      "{projectRoot}/tsconfig.spec.json"
+    ],
+    "test-e2e": [
+      "node",
+      "src",
+      "{workspaceRoot}/tsconfig.base.json",
+      "{workspaceRoot}/.env-files/.env.test",
+      "{workspaceRoot}/.tsconfig/tsconfig.spec.json",
+      "{workspaceRoot}/.vitest/**/*.ts",
+      "{workspaceRoot}/vitest.workspace.ts",
+      "{projectRoot}/vitest.e2e.config.ts",
       "{projectRoot}/tsconfig.spec.json"
     ]
   },


### PR DESCRIPTION
## Summary

PR #358 (Jest → Vitest migration) excluded `**/*.e2e.spec.{ts,js}` from the default test target via commit `8f0b1419` ("fix: resolve vitest full test suite failures"). The motivation was pragmatic: e2e specs had mock-isolation and live-AWS problems during the migration, and the plan was to run them via a separate mechanism later. That separate mechanism was never added, so every `.e2e.spec.ts` file in the repo has been dormant for a month — not running locally, not running in CI, not producing coverage.

This PR wires up the deferred runner as a dedicated `test-e2e` nx target.

## Changes

### Shared config

- **`.vitest/config/vitest.e2e.base.config.ts`** (new) — extends the unit base but flips `include` to match only `*.e2e.{test,spec}.{ts,js}` and narrows `exclude` to the usual `node_modules`/`dist`/`coverage`/`.git` set. Coverage is disabled because it's enforced at the unit-test level and double-counting e2e specs would break the model.

### nx.json

- New `test-e2e` entry in `targetDefaults` using `nx:run-commands` to invoke `vitest run --config vitest.e2e.config.ts` in each project root.
- New `test-e2e` named input mirroring the `test` one but pointing at `vitest.e2e.config.ts`.
- `test-e2e` added to `cacheableOperations`.

### Per-project

- **21 new `vitest.e2e.config.ts` files**, one per rule processor that has a `.e2e.spec.ts` file — each is a thin wrapper around the shared base.
- **21 `project.json` files** updated to opt in via `"test-e2e": {}` in the `targets` block (target defaults only apply to projects that list the target explicitly, so each project that wants the runner has to opt in).
- **`waste-mass-is-unique/vitest.e2e.config.ts`** has a per-project override that excludes `waste-mass-is-unique.helpers.e2e.spec.ts`. That spec's `beforeAll` hook calls `seedDocument()` against `smaug.carrot.eco/documents` and requires live AWS credentials. The adjacent `lambda.e2e.spec.ts` in the same project is in-memory and runs normally.
- **`audit-api`** is intentionally not opted in. Its only e2e spec (`audit-api.service.e2e.spec.ts`) is a true live-AWS test with the same constraint as `waste-mass-is-unique.helpers`. Leaving it dormant until a future live-AWS runner is set up.

### CI

- **`backend-check.yaml`**: new `backend-tests-e2e` job running `pnpm nx affected --target=test-e2e --parallel=1` alongside the existing `backend-tests` job. Same `prepare-to-run-nx` setup and Slack failure notification pattern. Separate job so unit failures don't block e2e feedback and vice versa.

## Why a new nx target instead of removing the exclude

The `@nx/vitest` plugin's config-file glob is hardcoded to `{vite,vitest}.config.{js,ts,mjs,mts,cjs,cts}` — there's no way to have a second plugin instance discover `vitest.e2e.config.ts` under a different target name. Options were:

1. **Remove the exclude from `vitest.base.config.ts`** and run e2e specs under the existing `test` target — conflates unit and e2e, triggers the coverage model against specs that aren't meant to be coverage-graded.
2. **Add a new `test-e2e` target via `nx:run-commands`** (this PR) — keeps unit and e2e cleanly separated, per-project opt-in, uses nx caching.

Option 2 respects PR #358's original intent (unit vs e2e as separate categories) while actually implementing the separate runner.

## Test plan

- [x] `pnpm nx run-many --target=test-e2e --parallel=1` — 21/21 projects pass (120+ e2e tests across lambda processors + shared io-helpers).
- [x] `pnpm nx run-many --target=test` — existing unit tests still pass, coverage thresholds still enforced at 100%.
- [x] `pnpm nx test-e2e <project>` works for individual projects.
- [x] `pnpm nx affected --target=test-e2e` correctly detects affected projects.
- [x] Neither target picks up files from the other target's category.
- [ ] CI green on this branch.

## Follow-up (not blocking this PR)

- `audit-api.service.e2e.spec.ts` and `waste-mass-is-unique.helpers.e2e.spec.ts` stay dormant until a separate live-AWS runner is wired up (new `test-e2e-live` target with AWS credentials). Track as a separate ticket.

Refs: #358

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Nx target and CI job that will start running previously-excluded `.e2e.*` specs, which may increase CI runtime and surface new failures/flakiness. Low production impact since changes are limited to test configuration and workflows.
> 
> **Overview**
> Re-enables dormant Vitest E2E specs by adding a dedicated Nx `test-e2e` target that runs `vitest` with per-project `vitest.e2e.config.ts` files and a shared `.vitest/config/vitest.e2e.base.config.ts` (E2E-only include pattern, coverage disabled).
> 
> Updates `nx.json` to cache `test-e2e`, define its target defaults and named inputs, and opts multiple rule-processor libraries into the new target via `project.json` (with one project-specific exclude for a live-AWS spec). CI now runs these via a separate `backend-tests-e2e` job in `backend-check.yaml`, with Slack notification on main-branch failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366b85594bf71de33aa8c0d0772a1474cf1816c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end (E2E) test targets for multiple rule modules, each with its own Vitest E2E configuration.
* **Tests**
  * Standardized E2E test discovery and execution, including dedicated E2E runner behavior with E2E coverage disabled.
* **Chores**
  * Updated CI to run E2E checks on main for affected changes and notify on failures.
  * Improved linting/TypeScript tooling to ignore E2E Vitest configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->