### PR TITLE
fix(rule): walk cert parent audit to reach waste generator accreditation

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.constants.ts
@@ -100,6 +100,10 @@ export const REWARDS_DISTRIBUTION_BY_WASTE_TYPE: Record<
 };
 
 export const REWARDS_DISTRIBUTION_CRITERIA: DocumentCriteria = {
+  parentDocument: {
+    omit: true,
+    relatedDocuments: [PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.match],
+  },
   relatedDocuments: [
     METHODOLOGY_DEFINITION.match,
     MASS_ID.match,

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.lambda.e2e.spec.ts
@@ -1,7 +1,15 @@
 import type { BoldDocument } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
-import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  BoldStubsBuilder,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  BoldAttributeName,
+  BoldDocumentEventName,
+  BoldDocumentSubtype,
+} from '@carrot-fndn/shared/methodologies/bold/types';
 import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
 import {
   prepareEnvironmentTestE2E,
@@ -17,6 +25,17 @@ import {
   rewardsDistributionProcessorTestCases,
 } from './rewards-distribution.test-cases';
 
+const { ONBOARDING_DECLARATION } = BoldDocumentEventName;
+const { BUSINESS_SIZE_DECLARATION } = BoldAttributeName;
+const { WASTE_GENERATOR } = BoldDocumentSubtype;
+
+interface MassIDRewardsResultContent {
+  massIDRewards: Array<{
+    actorType: string;
+    massIDPercentage: string;
+  }>;
+}
+
 describe('RewardsDistributionProcessor E2E', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -26,29 +45,59 @@ describe('RewardsDistributionProcessor E2E', () => {
 
   it.each(rewardsDistributionProcessorTestCases)(
     'should return $resultStatus when $scenario',
-    async ({ massIDDocumentEvents, massIDPartialDocument, resultStatus }) => {
-      const {
-        massIDAuditDocument,
-        massIDCertificateDocument,
-        massIDDocument,
-        methodologyDocument,
-      } = new BoldStubsBuilder()
+    async ({
+      accreditationBusinessSize,
+      expectedRewards,
+      massIDDocumentEvents,
+      massIDPartialDocument,
+      resultStatus,
+    }) => {
+      const builder = new BoldStubsBuilder()
         .createMassIDDocuments({
           externalEventsMap: massIDDocumentEvents,
           partialDocument: massIDPartialDocument,
         })
         .createMassIDAuditDocuments()
-        .createMassIDCertificateDocuments()
         .createMethodologyDocument()
-        .build();
+        .createMassIDCertificateDocuments();
+
+      if (accreditationBusinessSize !== undefined) {
+        builder.createParticipantAccreditationDocuments(
+          new Map([
+            [
+              WASTE_GENERATOR,
+              {
+                externalEventsMap: {
+                  [ONBOARDING_DECLARATION]:
+                    stubDocumentEventWithMetadataAttributes(
+                      { name: ONBOARDING_DECLARATION },
+                      [[BUSINESS_SIZE_DECLARATION, accreditationBusinessSize]],
+                    ),
+                },
+              },
+            ],
+          ]),
+        );
+      }
+
+      const {
+        massIDAuditDocument,
+        massIDCertificateDocument,
+        massIDDocument,
+        methodologyDocument,
+        participantsAccreditationDocuments,
+      } = builder.build();
+
+      const documents: BoldDocument[] = [
+        massIDDocument,
+        massIDAuditDocument,
+        massIDCertificateDocument,
+        methodologyDocument as BoldDocument,
+        ...participantsAccreditationDocuments.values(),
+      ];
 
       prepareEnvironmentTestE2E(
-        [
-          massIDDocument,
-          massIDAuditDocument,
-          massIDCertificateDocument,
-          methodologyDocument as BoldDocument,
-        ].map((document) => ({
+        documents.map((document) => ({
           document,
           documentKey: toDocumentKey({
             documentId: document.id,
@@ -59,36 +108,51 @@ describe('RewardsDistributionProcessor E2E', () => {
 
       const response = (await rewardsDistributionLambda(
         stubRuleInput({
-          documentId: massIDAuditDocument.id,
+          documentId: massIDCertificateDocument.id,
           documentKeyPrefix,
         }),
         stubContext(),
         () => stubRuleResponse(),
       )) as RuleOutput;
 
-      expect(response).toMatchObject({
-        resultStatus,
-      });
+      const rewardsByActor = Object.fromEntries(
+        (
+          response.resultContent as MassIDRewardsResultContent
+        ).massIDRewards.map(({ actorType, massIDPercentage }) => [
+          actorType,
+          massIDPercentage,
+        ]),
+      );
+
+      expect(response.resultStatus).toBe(resultStatus);
+      expect(rewardsByActor).toEqual(expectedRewards);
     },
   );
 
   describe('RewardsDistributionProcessorErrors', () => {
     it.each(rewardsDistributionProcessorErrors)(
       'should return $resultStatus when $scenario',
-      async ({ documents, massIDAuditDocument, resultStatus }) => {
+      async ({
+        documents,
+        massIDAuditDocument,
+        massIDCertificateDocument,
+        resultStatus,
+      }) => {
         prepareEnvironmentTestE2E(
-          [...documents, massIDAuditDocument].map((document) => ({
-            document,
-            documentKey: toDocumentKey({
-              documentId: document.id,
-              documentKeyPrefix,
+          [...documents, massIDAuditDocument, massIDCertificateDocument].map(
+            (document) => ({
+              document,
+              documentKey: toDocumentKey({
+                documentId: document.id,
+                documentKeyPrefix,
+              }),
             }),
-          })),
+          ),
         );
 
         const response = (await rewardsDistributionLambda(
           stubRuleInput({
-            documentId: massIDAuditDocument.id,
+            documentId: massIDCertificateDocument.id,
             documentKeyPrefix,
           }),
           stubContext(),

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -1,8 +1,14 @@
 import { sumBigNumbers } from '@carrot-fndn/shared/helpers';
 import { spyOnDocumentQueryServiceLoad } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  BoldStubsBuilder,
+  stubDocumentEventWithMetadataAttributes,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  BoldAttributeName,
   type BoldDocument,
+  BoldDocumentEventName,
+  BoldDocumentSubtype,
   BoldMethodologyName,
   type RewardsDistributionResultContent,
 } from '@carrot-fndn/shared/methodologies/bold/types';
@@ -15,6 +21,10 @@ import {
   rewardsDistributionProcessorTestCases,
 } from './rewards-distribution.test-cases';
 
+const { ONBOARDING_DECLARATION } = BoldDocumentEventName;
+const { BUSINESS_SIZE_DECLARATION } = BoldAttributeName;
+const { WASTE_GENERATOR } = BoldDocumentSubtype;
+
 describe('RewardsDistributionProcessor', () => {
   const ruleDataProcessor = new RewardsDistributionProcessor();
 
@@ -26,17 +36,12 @@ describe('RewardsDistributionProcessor', () => {
     it.each(rewardsDistributionProcessorTestCases)(
       'should return $resultStatus when $scenario',
       async ({
+        accreditationBusinessSize,
         expectedRewards,
         massIDDocumentEvents,
         massIDPartialDocument,
-        wasteGeneratorVerificationDocument,
       }) => {
-        const {
-          massIDAuditDocument,
-          massIDCertificateDocument,
-          massIDDocument,
-          methodologyDocument,
-        } = new BoldStubsBuilder({
+        const builder = new BoldStubsBuilder({
           methodologyName: BoldMethodologyName.RECYCLING,
         })
           .createMassIDDocuments({
@@ -44,18 +49,47 @@ describe('RewardsDistributionProcessor', () => {
             partialDocument: massIDPartialDocument,
           })
           .createMassIDAuditDocuments()
-          .createMassIDCertificateDocuments()
           .createMethodologyDocument()
-          .build();
+          .createMassIDCertificateDocuments();
+
+        if (accreditationBusinessSize !== undefined) {
+          builder.createParticipantAccreditationDocuments(
+            new Map([
+              [
+                WASTE_GENERATOR,
+                {
+                  externalEventsMap: {
+                    [ONBOARDING_DECLARATION]:
+                      stubDocumentEventWithMetadataAttributes(
+                        { name: ONBOARDING_DECLARATION },
+                        [
+                          [
+                            BUSINESS_SIZE_DECLARATION,
+                            accreditationBusinessSize,
+                          ],
+                        ],
+                      ),
+                  },
+                },
+              ],
+            ]),
+          );
+        }
+
+        const {
+          massIDAuditDocument,
+          massIDCertificateDocument,
+          massIDDocument,
+          methodologyDocument,
+          participantsAccreditationDocuments,
+        } = builder.build();
 
         const allDocuments = [
           massIDAuditDocument,
           massIDDocument,
           massIDCertificateDocument,
           methodologyDocument as BoldDocument,
-          ...(wasteGeneratorVerificationDocument
-            ? [wasteGeneratorVerificationDocument]
-            : []),
+          ...participantsAccreditationDocuments.values(),
         ];
 
         spyOnDocumentQueryServiceLoad(massIDAuditDocument, allDocuments);

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -6,7 +6,6 @@ import {
   BoldStubsBuilder,
   stubBoldMassIDPickUpEvent,
   stubDocumentEvent,
-  stubDocumentEventWithMetadataAttributes,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   BoldAttributeName,
@@ -14,7 +13,6 @@ import {
   type BoldDocument,
   BoldDocumentCategory,
   BoldDocumentEventName,
-  BoldDocumentSubtype,
   BoldUnidentifiedAttributeValue,
   MassIDOrganicSubtype,
   RewardsDistributionActorType,
@@ -25,11 +23,10 @@ import { REWARDS_DISTRIBUTION_BY_WASTE_TYPE } from './rewards-distribution.const
 import { ERROR_MESSAGES } from './rewards-distribution.errors';
 
 const { MASS_ID, METHODOLOGY } = BoldDocumentCategory;
-const { ACTOR, ONBOARDING_DECLARATION, PICK_UP } = BoldDocumentEventName;
-const { BUSINESS_SIZE_DECLARATION, WASTE_ORIGIN } = BoldAttributeName;
+const { ACTOR, PICK_UP } = BoldDocumentEventName;
+const { WASTE_ORIGIN } = BoldAttributeName;
 const { LARGE_BUSINESS, SMALL_BUSINESS } = BoldBusinessSizeDeclarationValue;
 const { UNIDENTIFIED } = BoldUnidentifiedAttributeValue;
-const { WASTE_GENERATOR: WASTE_GENERATOR_SUBTYPE } = BoldDocumentSubtype;
 const {
   COMMUNITY_IMPACT_POOL,
   HAULER,
@@ -41,36 +38,6 @@ const {
   RECYCLER,
   WASTE_GENERATOR,
 } = RewardsDistributionActorType;
-
-const createWasteGeneratorVerificationDocument = (
-  businessSize: BoldBusinessSizeDeclarationValue,
-): BoldDocument =>
-  ({
-    ...new BoldStubsBuilder()
-      .createMassIDDocuments()
-      .createMassIDAuditDocuments()
-      .createMethodologyDocument()
-      .createParticipantAccreditationDocuments(
-        new Map([
-          [
-            WASTE_GENERATOR_SUBTYPE,
-            {
-              externalEventsMap: {
-                [ONBOARDING_DECLARATION]:
-                  stubDocumentEventWithMetadataAttributes(
-                    {
-                      name: ONBOARDING_DECLARATION,
-                    },
-                    [[BUSINESS_SIZE_DECLARATION, businessSize]],
-                  ),
-              },
-            },
-          ],
-        ]),
-      )
-      .build()
-      .participantsAccreditationDocuments.get(WASTE_GENERATOR_SUBTYPE)!,
-  }) as BoldDocument;
 
 const DEFAULT_REWARDS = {
   [COMMUNITY_IMPACT_POOL]: '0',
@@ -157,11 +124,11 @@ interface RewardsDistributionTestCase extends Omit<
   RuleTestCase,
   'resultComment'
 > {
+  accreditationBusinessSize?: BoldBusinessSizeDeclarationValue | undefined;
   expectedRewards: Record<string, string>;
   massIDDocumentEvents?: BoldExternalEventsObject | undefined;
   massIDPartialDocument: PartialDeep<BoldDocument>;
   resultComment?: string;
-  wasteGeneratorVerificationDocument?: BoldDocument | undefined;
 }
 
 export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[] =
@@ -227,6 +194,7 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       scenario: `Large Business discount is applied when Waste Generator Verification Document is missing (defaults to Large Business)`,
     },
     {
+      accreditationBusinessSize: LARGE_BUSINESS,
       expectedRewards: EXPECTED_REWARDS['Mixed Organic Waste'],
       massIDDocumentEvents: {},
       massIDPartialDocument: {
@@ -234,10 +202,9 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       },
       resultStatus: 'PASSED' as const,
       scenario: `Large Business discount is applied when Waste Generator Verification Document indicates Large Business`,
-      wasteGeneratorVerificationDocument:
-        createWasteGeneratorVerificationDocument(LARGE_BUSINESS),
     },
     {
+      accreditationBusinessSize: SMALL_BUSINESS,
       expectedRewards:
         EXPECTED_REWARDS.SMALL_BUSINESS[
           RewardsDistributionWasteType.MIXED_ORGANIC_WASTE
@@ -248,8 +215,19 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
       },
       resultStatus: 'PASSED' as const,
       scenario: `no discount is applied when Waste Generator Verification Document indicates Small Business`,
-      wasteGeneratorVerificationDocument:
-        createWasteGeneratorVerificationDocument(SMALL_BUSINESS),
+    },
+    {
+      accreditationBusinessSize: SMALL_BUSINESS,
+      expectedRewards:
+        EXPECTED_REWARDS.SMALL_BUSINESS[
+          RewardsDistributionWasteType.MIXED_ORGANIC_WASTE
+        ],
+      massIDDocumentEvents: {},
+      massIDPartialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: 'PASSED' as const,
+      scenario: `regression: a small-business waste generator on a Food/Food Waste and Beverages MassID receives the full generator share and the Community Impact Pool does not receive any redirected share`,
     },
     {
       expectedRewards:
@@ -269,16 +247,22 @@ export const rewardsDistributionProcessorTestCases: RewardsDistributionTestCase[
     },
   ];
 
-const { massIDAuditDocument, massIDDocument, methodologyDocument } =
-  new BoldStubsBuilder()
-    .createMassIDDocuments()
-    .createMassIDAuditDocuments()
-    .createMethodologyDocument()
-    .build();
+const {
+  massIDAuditDocument,
+  massIDCertificateDocument,
+  massIDDocument,
+  methodologyDocument,
+} = new BoldStubsBuilder()
+  .createMassIDDocuments()
+  .createMassIDAuditDocuments()
+  .createMethodologyDocument()
+  .createMassIDCertificateDocuments()
+  .build();
 
 interface RewardsDistributionErrorTestCase extends RuleTestCase {
   documents: BoldDocument[];
   massIDAuditDocument: BoldDocument;
+  massIDCertificateDocument: BoldDocument;
 }
 
 export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCase[] =
@@ -286,6 +270,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
     {
       documents: [],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.MASS_ID_DOCUMENT_NOT_FOUND,
       resultStatus: 'FAILED' as const,
       scenario: `${MASS_ID} document is not found`,
@@ -293,6 +278,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
     {
       documents: [massIDDocument],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.METHODOLOGY_DOCUMENT_NOT_FOUND,
       resultStatus: 'FAILED' as const,
       scenario: `${METHODOLOGY} document is not found`,
@@ -308,6 +294,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
         methodologyDocument as BoldDocument,
       ],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.MISSING_REQUIRED_ACTORS(massIDDocument.id, [
         RewardsDistributionActorType.INTEGRATOR,
       ]),
@@ -323,6 +310,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
         massIDDocument,
       ],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
       resultStatus: 'FAILED' as const,
       scenario: `the ${METHODOLOGY} document does not have the required actors`,
@@ -336,6 +324,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
         methodologyDocument as BoldDocument,
       ],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.EXTERNAL_EVENTS_NOT_FOUND(
         massIDDocument.id,
       ),
@@ -351,6 +340,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
         methodologyDocument as BoldDocument,
       ],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.UNEXPECTED_DOCUMENT_SUBTYPE('unknown'),
       resultStatus: 'FAILED' as const,
       scenario: `the ${MASS_ID} document has an unexpected subtype`,
@@ -368,6 +358,7 @@ export const rewardsDistributionProcessorErrors: RewardsDistributionErrorTestCas
         } as BoldDocument,
       ],
       massIDAuditDocument,
+      massIDCertificateDocument,
       resultComment: ERROR_MESSAGES.FAILED_BY_ERROR,
       resultStatus: 'FAILED' as const,
       scenario: `the ${METHODOLOGY} document does not have the required address in actors`,


### PR DESCRIPTION
## Summary

Investigation of a production credit surfaced a systemic bug in rewards-distribution: Community Impact Pool was receiving 15% (or 12.5% for sludge/tobacco) of the waste generator's share even when the generator was registered as Small Business. Every rewards-distribution event ever stamped in production had the large-business discount applied — zero certs have ever skipped it.

## Root cause

The `rewards-distribution` rule runs on `GasID` / `RecycledID` certificates. `REWARDS_DISTRIBUTION_CRITERIA` was a flat `relatedDocuments: [METHODOLOGY_DEFINITION.match, MASS_ID.match, PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.match]`, which makes the walker enumerate the starting document's own `externalEvents[].relatedDocument` once and match against each criterion. The cert's forward edges only reach:

- The methodology definition (via `Methodology` event)
- The MassID (via `MassID` event)
- The credit order (via `Issued: Credit Order` event)

**Not the Participant Accreditation.** So the walker returns methodology + MassID + no accreditation, and `shouldApplyLargeBusinessDiscount` falls through its documented fail-closed default (treat as Large Business, so CP gets the generator's 50%).

The fail-closed default was introduced intentionally in the large-business-verification feature and is explicitly pinned as expected behavior in `rewards-distribution.helpers.spec.ts`. It's load-bearing: if the accreditation is *genuinely* missing (generator has not onboarded yet), the rule must still produce a valid distribution and must default to Large per product rule. This PR does not touch it.

But the fix had never been exercised for the case where the accreditation **does** exist — because the walker was structurally unable to reach it from the cert's forward-edge graph. For every cert ever stamped, `wasteGeneratorVerificationDocument` resolved to `undefined`, the default fired, and Community Pool silently received its share of the generator's allocation.

## The fix

The graph already has every edge the rule needs on the **MassID Audit** document. Each audit carries ACTOR events with `relatedDocument` pointing at the respective `Participant Accreditation` doc for every role (Waste Generator, Hauler, Processor, Recycler, Integrator, Recycler Verifier), plus a `MassID` event relating to the MassID and a `Network` ACTOR event relating to the methodology definition. The cert's `parentDocumentId` is the audit.

One `parentDocument` climb bridges the gap:

```ts
export const REWARDS_DISTRIBUTION_CRITERIA: DocumentCriteria = {
  parentDocument: {
    omit: true,
    relatedDocuments: [PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.match],
  },
  relatedDocuments: [
    METHODOLOGY_DEFINITION.match,
    MASS_ID.match,
    PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.match,
  ],
};
```

- Top-level `relatedDocuments` keeps the existing direct walk (cert → methodology + cert → MassID via cert forward edges, defensive).
- `parentDocument.omit: true` with nested `relatedDocuments: [PARTICIPANT_ACCREDITATION_PARTIAL_MATCH.match]` climbs cert → audit, *does not* emit the audit itself, and walks audit's forward edges looking for any `Participant Accreditation` document. The processor then filters by `subtype === BoldDocumentSubtype.WASTE_GENERATOR` as before.

Zero changes to `shouldApplyLargeBusinessDiscount`. The default-to-large path is preserved exactly as-is. The fix is purely in the traversal shape so the rule can actually *find* accreditations that already exist.

## Regression test

`rewards-distribution.lambda.e2e.spec.ts` now covers the small-business shape: `FOOD_FOOD_WASTE_AND_BEVERAGES` subtype, Small Business declaration on the Waste Generator accreditation, asserts `Waste Generator: "30"` and `Community Impact Pool: "0"` in the actual `resultContent.massIDRewards` output.

The previous version of this spec is worth calling out: its `it.each` destructure silently dropped `expectedRewards` and `wasteGeneratorVerificationDocument` from the test case, only asserted `resultStatus`, and never called `createParticipantAccreditationDocuments`. That's how this bug went unnoticed despite a test file with "Small Business" in its scenario name. The new version:

- Destructures `accreditationBusinessSize` (replacing the dead `wasteGeneratorVerificationDocument` field).
- Conditionally calls `createParticipantAccreditationDocuments` when a business size is specified.
- Seeds all participant accreditation docs into `prepareEnvironmentTestE2E`.
- Invokes the lambda with `massIDCertificateDocument.id` (matches production — the event is stamped on the cert).
- Asserts the full `rewardsByActor` output, not just `resultStatus`.

`rewards-distribution.test-cases.ts` replaces `wasteGeneratorVerificationDocument?: BoldDocument` with `accreditationBusinessSize?: BoldBusinessSizeDeclarationValue` and drops the stale `createWasteGeneratorVerificationDocument` helper. `rewards-distribution.processor.spec.ts` gets the matching destructure update.

Both specs also reorder `createMethodologyDocument()` before `createMassIDCertificateDocuments()` in the builder chain. That's a stubs-builder ordering quirk workaround: `createMassIDCertificateDocuments` reads `this.methodologyRelation` at cert-build time, but that field is only populated in `createMethodologyDocument`, so with the old order the cert's methodology event ends up with `relatedDocument: undefined`. Reordering in the test keeps the stubs builder untouched.

## Negative control

I verified the test is actually load-bearing. With the criteria change reverted (flat `relatedDocuments` only), the e2e spec fails exactly **2** test cases — the "Small Business" case and the regression case — both with the exact production bug shape:

```
- "Community Impact Pool": "0",
+ "Community Impact Pool": "15",
- "Waste Generator": "30",
+ "Waste Generator": "15",
```

The other 52 test cases pass independently of the criteria fix. That keeps the test focused on exactly the bug it's guarding against.

## Out of scope

- **Smaug-side ingestion change**. Not required. The graph already has every edge on the audit; smaug does not need to emit anything new.
- **Remediation for already-stamped certs**. Separate work — needs to re-run the rewards-distribution rule on each affected cert after this fix lands, then re-run the credit-order aggregator on every credit that references one of those certs. Financial reconciliation for credits that have already been sold is a legal/finance call, not engineering.
- **Flipping the fail-closed default to Small Business**. Considered and rejected earlier in this investigation: the rule must still produce a valid distribution when the generator has not onboarded yet, and in that case the business rule says treat as Large (default-to-large is correct for the "no accreditation" case).

## Test plan

- [x] `pnpm nx test methodologies-bold-rule-processors-mass-id-certificate-rewards-distribution` — all tests pass, 100% coverage on helpers and processor.
- [x] `pnpm nx test-e2e methodologies-bold-rule-processors-mass-id-certificate-rewards-distribution` — all tests pass (depends on #396 being in place for the test-e2e target to exist).
- [x] Negative control: revert the criteria change → exactly 2 tests fail with the production bug shape.
- [x] Negative control: restore the criteria change → all tests pass.
- [x] Affected unit tests for rules that use the shared stubs builder still pass.
- [ ] CI green on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced rewards distribution configuration to better scope participant accreditation relationships.

* **Tests**
  * Expanded unit and end-to-end coverage for varied accreditation scenarios, including a new small-business regression case.
  * Improved test fixtures and tightened assertions for more precise verification of reward outcomes.
  * Updated end-to-end flows to exercise certificate-level processing for reward calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Affects rewards distribution calculation inputs by changing document traversal to locate participant accreditations; mistakes could change payout percentages (especially small vs large business handling) across issued certificates.
> 
> **Overview**
> Fixes `rewards-distribution` document loading so a MassID certificate can reach `Participant Accreditation` docs by walking through its **parent audit** (`REWARDS_DISTRIBUTION_CRITERIA.parentDocument` with `omit: true`). This enables the rule to correctly apply small-business vs large-business reward splits instead of always falling back to the default large-business behavior.
> 
> Strengthens tests to match production behavior: E2E now runs the lambda against the **certificate** document, seeds participant accreditation stubs (via `accreditationBusinessSize`), and asserts the full `resultContent.massIDRewards` map; unit tests and shared test cases are updated accordingly, including a regression case for small-business generator share/Community Impact Pool share.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70a1fd24a3993c1f157a1cd95db3dd9e071ada8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->