### PR TITLE
feat(shared): make address neighborhood optional

### DIFF
--- a/libs/shared/types/src/document/document-address.types.spec.ts
+++ b/libs/shared/types/src/document/document-address.types.spec.ts
@@ -44,6 +44,11 @@ describe('DocumentAddressSchema', () => {
       value: without('zipCode'),
     },
     {
+      expected: true,
+      scenario: 'an address without neighborhood',
+      value: without('neighborhood'),
+    },
+    {
       expected: false,
       scenario: 'an address without city',
       value: without('city'),

--- a/libs/shared/types/src/document/document-address.types.ts
+++ b/libs/shared/types/src/document/document-address.types.ts
@@ -10,7 +10,7 @@ export const DocumentAddressSchema = z.object({
   id: NonEmptyStringSchema,
   latitude: LatitudeSchema.optional(),
   longitude: LongitudeSchema.optional(),
-  neighborhood: NonEmptyStringSchema,
+  neighborhood: NonEmptyStringSchema.optional(),
   number: NonEmptyStringSchema,
   participantId: NonEmptyStringSchema,
   piiSnapshotId: NonEmptyStringSchema,


### PR DESCRIPTION
## Summary
- Widens `DocumentAddressSchema.neighborhood` to `.optional()`, mirroring the prior `latitude`/`longitude`/`zipCode` change (#391).
- Adds a schema spec case asserting an address without a neighborhood is accepted.

## Impact review
No rule processor or helper reads `address.neighborhood`. The only consumer of address fields beyond pass-through is `buildAddressString` in `document-manifest-data` cross-validation, which already composes `street, number, city, countryState` and ignores neighborhood. `DocumentAddressWithCoordinatesSchema` only extends lat/long, so no follow-up there. Existing test fixtures that populate `neighborhood` continue to validate.

## Test plan
- [x] `pnpm nx lint shared-types --fix`
- [x] `pnpm nx ts shared-types`
- [x] `pnpm nx test shared-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made the neighborhood field optional in address validation, allowing addresses without neighborhood information to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->