### PR TITLE
fix(rule): omit zero Community Impact Pool from rewards distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ docs/superpowers/
 
 # Claude
 .claude/projects
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .claude/todos
 .claude.local.md
 

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.spec.ts
@@ -1,3 +1,4 @@
+import { logger } from '@carrot-fndn/shared/helpers';
 import {
   BoldStubsBuilder,
   stubDocumentEventWithMetadataAttributes,
@@ -5,6 +6,7 @@ import {
 import {
   BoldAttributeName,
   BoldBusinessSizeDeclarationValue,
+  type BoldDocument,
   BoldDocumentEventName,
   BoldDocumentSubtype,
   RewardsDistributionActorType,
@@ -12,6 +14,7 @@ import {
 import BigNumber from 'bignumber.js';
 
 import type {
+  ActorReward,
   RewardsDistributionActor,
   RewardsDistributionActorTypePercentage,
 } from './rewards-distribution.types';
@@ -19,6 +22,7 @@ import type {
 import {
   calculateNetworkPercentageForUnidentifiedWasteOrigin,
   getWasteGeneratorAdditionalPercentage,
+  mapMassIDRewards,
   shouldApplyLargeBusinessDiscount,
 } from './rewards-distribution.helpers';
 
@@ -178,5 +182,125 @@ describe('getWasteGeneratorAdditionalPercentage', () => {
     );
 
     expect(result).toEqual(new BigNumber(0));
+  });
+});
+
+describe('mapMassIDRewards', () => {
+  let massIDDocument: BoldDocument;
+  let warnSpy: vi.MockInstance<typeof logger.warn>;
+
+  beforeAll(() => {
+    massIDDocument = new BoldStubsBuilder()
+      .createMassIDDocuments()
+      .createMassIDAuditDocuments()
+      .createMethodologyDocument()
+      .build().massIDDocument;
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+  });
+
+  const buildActorReward = (
+    overrides: Partial<ActorReward> = {},
+  ): ActorReward => ({
+    actorType: RewardsDistributionActorType.RECYCLER,
+    address: { id: 'address-recycler' },
+    massIDDocument,
+    massIDPercentage: new BigNumber('0.2'),
+    participant: { id: 'participant-recycler', name: 'Recycler Co' },
+    preserveSensitiveData: false,
+    ...overrides,
+  });
+
+  it('returns an empty array for an empty input and does not warn', () => {
+    expect(mapMassIDRewards([])).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits non-zero entries with formatted percentage and unchanged fields', () => {
+    const result = mapMassIDRewards([
+      buildActorReward({ massIDPercentage: new BigNumber('0.3') }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        actorType: RewardsDistributionActorType.RECYCLER,
+        address: { id: 'address-recycler' },
+        massIDPercentage: '30',
+        participant: { id: 'participant-recycler', name: 'Recycler Co' },
+        preserveSensitiveData: false,
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits a Community Impact Pool entry when its percentage is non-zero', () => {
+    const result = mapMassIDRewards([
+      buildActorReward({
+        actorType: RewardsDistributionActorType.COMMUNITY_IMPACT_POOL,
+        address: { id: 'address-cip' },
+        massIDPercentage: new BigNumber('0.15'),
+        participant: { id: 'participant-cip', name: 'Community Impact Pool' },
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        actorType: RewardsDistributionActorType.COMMUNITY_IMPACT_POOL,
+        address: { id: 'address-cip' },
+        massIDPercentage: '15',
+        participant: { id: 'participant-cip', name: 'Community Impact Pool' },
+        preserveSensitiveData: false,
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops a zero-percentage Community Impact Pool entry and does not log a warning', () => {
+    const result = mapMassIDRewards([
+      buildActorReward({
+        actorType: RewardsDistributionActorType.COMMUNITY_IMPACT_POOL,
+        address: { id: 'address-cip' },
+        massIDPercentage: new BigNumber(0),
+        participant: { id: 'participant-cip', name: 'Community Impact Pool' },
+      }),
+      buildActorReward({ massIDPercentage: new BigNumber('0.2') }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.actorType).toBe(RewardsDistributionActorType.RECYCLER);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits a zero-percentage non-CIP entry and logs a warning with diagnostic context', () => {
+    const result = mapMassIDRewards([
+      buildActorReward({
+        actorType: RewardsDistributionActorType.NETWORK,
+        address: { id: 'address-network' },
+        massIDPercentage: new BigNumber(0),
+        participant: { id: 'participant-network', name: 'Network' },
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        actorType: RewardsDistributionActorType.NETWORK,
+        address: { id: 'address-network' },
+        massIDPercentage: '0',
+        participant: { id: 'participant-network', name: 'Network' },
+        preserveSensitiveData: false,
+      },
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      {
+        actorType: RewardsDistributionActorType.NETWORK,
+        massIDDocumentId: massIDDocument.id,
+        participantId: 'participant-network',
+      },
+      'Rewards distribution actor received zero percentage',
+    );
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.helpers.ts
@@ -2,6 +2,7 @@ import {
   getOrDefault,
   isNil,
   isNonEmptyArray,
+  logger,
 } from '@carrot-fndn/shared/helpers';
 import { getEventAttributeValue } from '@carrot-fndn/shared/methodologies/bold/getters';
 import {
@@ -48,24 +49,42 @@ export const isHaulerActorDefined = (
 export const formatPercentage = (percentage: BigNumber): string =>
   percentage.multipliedBy(100).toString();
 
+const formatMassIDReward = ({
+  actorType,
+  address,
+  massIDPercentage,
+  participant,
+  preserveSensitiveData,
+}: ActorReward): RewardsDistributionMassIDReward => ({
+  actorType,
+  address,
+  massIDPercentage: formatPercentage(massIDPercentage),
+  participant,
+  preserveSensitiveData,
+});
+
 export const mapMassIDRewards = (
   participants: ActorReward[],
 ): RewardsDistributionMassIDReward[] =>
-  participants.map(
-    ({
-      actorType,
-      address,
-      massIDPercentage,
-      participant,
-      preserveSensitiveData,
-    }) => ({
-      actorType,
-      address,
-      massIDPercentage: formatPercentage(massIDPercentage),
-      participant,
-      preserveSensitiveData,
-    }),
-  );
+  participants.flatMap((reward) => {
+    if (reward.massIDPercentage.isZero()) {
+      if (
+        reward.actorType === RewardsDistributionActorType.COMMUNITY_IMPACT_POOL
+      ) {
+        return [];
+      }
+      logger.warn(
+        {
+          actorType: reward.actorType,
+          massIDDocumentId: reward.massIDDocument.id,
+          participantId: reward.participant.id,
+        },
+        'Rewards distribution actor received zero percentage',
+      );
+    }
+
+    return [formatMassIDReward(reward)];
+  });
 
 export const mapActorReward = ({
   actorType,

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.processor.spec.ts
@@ -113,6 +113,8 @@ describe('RewardsDistributionProcessor', () => {
           massIDDocumentId: massIDDocument.id,
         });
 
+        expect(massIDRewards).toHaveLength(Object.keys(expectedRewards).length);
+
         for (const actorType of Object.keys(expectedRewards)) {
           const reward = massIDRewards.find(
             (massIDReward) => massIDReward.actorType === actorType,

--- a/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id-certificate/rewards-distribution/src/rewards-distribution.test-cases.ts
@@ -40,7 +40,6 @@ const {
 } = RewardsDistributionActorType;
 
 const DEFAULT_REWARDS = {
-  [COMMUNITY_IMPACT_POOL]: '0',
   [INTEGRATOR]: '8',
   [METHODOLOGY_AUTHOR]: '1',
   [METHODOLOGY_DEVELOPER]: '1',
@@ -82,7 +81,6 @@ const EXPECTED_REWARDS = {
       [RECYCLER]: '20',
       [WASTE_GENERATOR]: '30',
       ...DEFAULT_REWARDS,
-      [COMMUNITY_IMPACT_POOL]: '0',
     },
     [RewardsDistributionWasteType.SLUDGE_FROM_WASTE_TREATMENT]: {
       [HAULER]: '5',
@@ -91,7 +89,6 @@ const EXPECTED_REWARDS = {
       [RECYCLER]: '30',
       [WASTE_GENERATOR]: '25',
       ...DEFAULT_REWARDS,
-      [COMMUNITY_IMPACT_POOL]: '0',
     },
     [RewardsDistributionWasteType.TOBACCO_INDUSTRY_RESIDUES]: {
       [HAULER]: '5',
@@ -100,7 +97,6 @@ const EXPECTED_REWARDS = {
       [RECYCLER]: '30',
       [WASTE_GENERATOR]: '25',
       ...DEFAULT_REWARDS,
-      [COMMUNITY_IMPACT_POOL]: '0',
     },
   },
   WITHOUT_WASTE_GENERATOR: {


### PR DESCRIPTION
## Summary

Smaug validates each rewards-distribution reward entry as `> 0` and rejects the whole event when Community Impact Pool arrives at zero percentage. After PR #397 fixed the document-traversal bug, CIP legitimately resolves to `0` for small-business generators (and already did for unidentified-waste-origin cases). Omit those zero-CIP entries at the serialization boundary so the Smaug contract is respected.

## Implementation

- Refactor `mapMassIDRewards` (`rewards-distribution.helpers.ts`) from `.map` to `.flatMap`. Drop CIP entries when `massIDPercentage.isZero()`; for any other actor type at zero, `logger.warn` with `{ actorType, massIDDocumentId, participantId }` and emit the entry as-is (Smaug's 4xx stays authoritative).
- Extract `formatMassIDReward` as a small private helper so `mapMassIDRewards` reads as "which rewards to drop/warn vs emit" and the new helper reads as "how to serialize one reward."
- DRY the test fixtures in `rewards-distribution.test-cases.ts`: remove `CIP: '0'` from `DEFAULT_REWARDS` and the redundant overrides in the three `SMALL_BUSINESS` fixtures. `WITHOUT_WASTE_GENERATOR` cases lose their inherited zero automatically.
- Add a `toHaveLength` assertion in `rewards-distribution.processor.spec.ts` so the unit test matches the e2e spec's strict shape and catches future regressions where extra keys leak into the output.

Zero changes to: the cert → parent-audit traversal, `shouldApplyLargeBusinessDiscount`, `calculateCommunityImpactPoolShare`, actor assembly, or the output schema. `credit-order/rewards-distribution` has no source or fixture edits — its aggregator absorbs the change transparently because absent keys already mean "no contribution."

## Test plan

- [x] `pnpm nx test methodologies-bold-rule-processors-mass-id-certificate-rewards-distribution` — all green, including three new `mapMassIDRewards` direct tests (happy path, CIP drop, non-CIP warn).
- [x] `pnpm nx test methodologies-bold-rule-processors-credit-order-rewards-distribution` — all green (no changes; safety net).
- [x] `pnpm nx lint` and `pnpm nx ts` on both projects — clean.
- [x] `pnpm test:affected` — all affected projects green.
- [x] Negative control: temporarily reverted the filter → helper-spec, processor.spec `toHaveLength`, and e2e `toEqual` all failed as expected; restored and re-verified green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exclude community impact pool entries with zero percentage from Mass ID rewards output; emit warnings for other zero-percentage entries.

* **Tests**
  * Added unit tests to validate filtering, formatting, logging behavior, and exact result cardinality; updated expected test cases to remove community impact pool defaults.

* **Chores**
  * Ignore local Claude lock/settings files in repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->