### PR TITLE
fix(shared): accept null geo and zip fields on document address

### DIFF
--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
@@ -68,10 +68,10 @@ describe('Document Helpers', () => {
       expect(result).toBe(undefined);
     });
 
-    it('should return the document when address fields are null', async () => {
+    it('should accept null address fields and normalize them to undefined', async () => {
       const key = faker.string.uuid();
       const baseDocument = stubDocument();
-      const document = {
+      const documentWithNulls = {
         ...baseDocument,
         externalEvents: baseDocument.externalEvents?.map((event) => ({
           ...event,
@@ -93,12 +93,26 @@ describe('Document Helpers', () => {
       } as unknown as BoldDocument;
 
       vi.spyOn(loaderService, 'load').mockResolvedValueOnce(
-        stubDocumentEntity({ document }),
+        stubDocumentEntity({ document: documentWithNulls }),
       );
 
       const result = await loadDocument(loaderService, key);
 
-      expect(result).toEqual(document);
+      expect(result).toBeDefined();
+      expect(result?.primaryAddress).toMatchObject({
+        latitude: undefined,
+        longitude: undefined,
+        neighborhood: undefined,
+        zipCode: undefined,
+      });
+      for (const event of result?.externalEvents ?? []) {
+        expect(event.address).toMatchObject({
+          latitude: undefined,
+          longitude: undefined,
+          neighborhood: undefined,
+          zipCode: undefined,
+        });
+      }
     });
   });
 });

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
@@ -67,5 +67,38 @@ describe('Document Helpers', () => {
 
       expect(result).toBe(undefined);
     });
+
+    it('should return the document when address fields are null', async () => {
+      const key = faker.string.uuid();
+      const baseDocument = stubDocument();
+      const document = {
+        ...baseDocument,
+        externalEvents: baseDocument.externalEvents?.map((event) => ({
+          ...event,
+          address: {
+            ...event.address,
+            latitude: null,
+            longitude: null,
+            neighborhood: null,
+            zipCode: null,
+          },
+        })),
+        primaryAddress: {
+          ...baseDocument.primaryAddress,
+          latitude: null,
+          longitude: null,
+          neighborhood: null,
+          zipCode: null,
+        },
+      } as unknown as BoldDocument;
+
+      vi.spyOn(loaderService, 'load').mockResolvedValueOnce(
+        stubDocumentEntity({ document }),
+      );
+
+      const result = await loadDocument(loaderService, key);
+
+      expect(result).toEqual(document);
+    });
   });
 });

--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.ts
@@ -23,7 +23,12 @@ export const loadDocument = async (
 
     if (!validation.success) {
       logger.error(
-        { documentKey: key, err: validation.error, operation: 'loadDocument' },
+        {
+          documentKey: key,
+          err: validation.error,
+          operation: 'loadDocument',
+          validationIssues: validation.error.issues,
+        },
         '[loadDocument] Invalid document',
       );
 

--- a/libs/shared/types/src/document/document-address.types.ts
+++ b/libs/shared/types/src/document/document-address.types.ts
@@ -8,14 +8,14 @@ export const DocumentAddressSchema = z.object({
   countryCode: NonEmptyStringSchema,
   countryState: NonEmptyStringSchema,
   id: NonEmptyStringSchema,
-  latitude: LatitudeSchema.optional(),
-  longitude: LongitudeSchema.optional(),
-  neighborhood: NonEmptyStringSchema.optional(),
+  latitude: LatitudeSchema.nullish(),
+  longitude: LongitudeSchema.nullish(),
+  neighborhood: NonEmptyStringSchema.nullish(),
   number: NonEmptyStringSchema,
   participantId: NonEmptyStringSchema,
   piiSnapshotId: NonEmptyStringSchema,
   street: NonEmptyStringSchema,
-  zipCode: NonEmptyStringSchema.optional(),
+  zipCode: NonEmptyStringSchema.nullish(),
 });
 export type DocumentAddress = z.infer<typeof DocumentAddressSchema>;
 

--- a/libs/shared/types/src/document/document-address.types.ts
+++ b/libs/shared/types/src/document/document-address.types.ts
@@ -8,14 +8,18 @@ export const DocumentAddressSchema = z.object({
   countryCode: NonEmptyStringSchema,
   countryState: NonEmptyStringSchema,
   id: NonEmptyStringSchema,
-  latitude: LatitudeSchema.nullish(),
-  longitude: LongitudeSchema.nullish(),
-  neighborhood: NonEmptyStringSchema.nullish(),
+  latitude: LatitudeSchema.nullish().transform((value) => value ?? undefined),
+  longitude: LongitudeSchema.nullish().transform((value) => value ?? undefined),
+  neighborhood: NonEmptyStringSchema.nullish().transform(
+    (value) => value ?? undefined,
+  ),
   number: NonEmptyStringSchema,
   participantId: NonEmptyStringSchema,
   piiSnapshotId: NonEmptyStringSchema,
   street: NonEmptyStringSchema,
-  zipCode: NonEmptyStringSchema.nullish(),
+  zipCode: NonEmptyStringSchema.nullish().transform(
+    (value) => value ?? undefined,
+  ),
 });
 export type DocumentAddress = z.infer<typeof DocumentAddressSchema>;
 


### PR DESCRIPTION
### 🧾 Summary

`DocumentAddressSchema` declared `latitude`, `longitude`, `neighborhood`, and `zipCode` with `.optional()`, which in Zod 4.x accepts **`undefined` only**. Smaug actually writes **`null`** for unknown values on those fields, so `loadDocument` rejected every recently produced document and every rule reported `"Could not load the document with id <id>"` with no further detail.

This PR:

1. Switches the four fields to `.nullish()` so both `null` and absent values are accepted.
2. Adds a regression test that loads a document with `null` values across `primaryAddress` and per-event `address`.
3. Logs `validation.error.issues` on `loadDocument` failure so future schema drift surfaces in CloudWatch with the failing field path, not just a generic "Invalid document" line.

### 🧩 Context

Discovered while running BOLD Carbon TEST audits for Eloverde on 2026-04-27 — all 38 audits failed at the document-load stage. Pulled one of the failing S3 documents and ran the rule via `pnpm run-rule` with `--debug`, which surfaced this `ZodError`:

```
- primaryAddress.latitude: expected number, received null
- primaryAddress.longitude: expected number, received null
- primaryAddress.zipCode: expected string, received null
- externalEvents[N].address.latitude/longitude/zipCode: same
```

The drift was introduced on March 30, 2026 (`7cbd6401` "feat(shared): add layered document schema namespace with enum foundation"), which migrated from a permissive `MethodologyDocumentSchema = z.looseObject` to strict `z.object` schemas. The `.optional()` choice carried over from the typia era (`?: T | null | undefined`) but Zod 4 treats `.optional()` as undefined-only.

### 🧱 Scope of this PR

**Included:**

- Schema change: `latitude`, `longitude`, `neighborhood`, `zipCode` → `.nullish()`.
- New unit test covering null address fields end-to-end through `loadDocument`.
- Logging improvement: structured `validationIssues` field.

**Not included:**

- Audit of every other schema field for the same `.optional()` vs `.nullish()` pattern. If other null-valued fields appear in production docs, they will surface via the new log field — to be addressed in follow-up PRs.
- Re-running the 38 stuck audits — that will happen against `main` after this PR ships.

### 🧪 How to test

```bash
pnpm nx test shared-methodologies-bold-io-helpers
pnpm nx test shared-types
```

The new `should return the document when address fields are null` test fails on current `main` (reproduces production error) and passes with this PR.

End-to-end verification against a real failing document:

```bash
aws-vault exec smaug-prod -- pnpm run-rule \
  libs/methodologies/bold/rule-processors/mass-id/driver-identification \
  --methodology-execution-id e85311bf-e841-410e-9905-866c636e1a3a \
  --audit-document-id ea3d1fce-ddaf-407e-ac10-1dad1ed5e3b5 \
  --audited-document-id f3105a2d-d42d-4405-8ce5-ca804d2f5429
```

Returns `Status: ✓ PASSED` with this PR; returns `Status: ✗ FAILED — Could not load the document` without it.

### 🧠 Considerations for Review

- `.nullish()` is `.nullable().optional()`, so it widens the contract on the input side only. Downstream rule processors already coerce/skip these fields where needed.
- The added log field uses the existing pino logger. `validation.error.issues` is JSON-serializable and will land as a structured array in CloudWatch.
- I considered fixing this on the Smaug side (stripping `null`s before write), but that would couple writers to reader-specific quirks and silently lose information. Accepting `null` at the schema boundary is the right contract.

### 🔗 Related Links

- Production audit run: 38 BOLD Carbon TEST audits on 2026-04-27 for Eloverde, all failed at document-load (now ready to re-run once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging to include detailed validation diagnostics when document validation fails.
  * Better handling and normalization of null or missing address fields (latitude, longitude, neighborhood, zip code).

* **Tests**
  * Added test coverage for loading documents with null address field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->