### PR TITLE
Lower regional waste classification description similarity threshold to 0.85

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.processor.ts
@@ -29,7 +29,7 @@ import { RESULT_COMMENTS } from './regional-waste-classification.constants';
 import { RegionalWasteClassificationProcessorErrors } from './regional-waste-classification.errors';
 import { getCdmCodeFromSubtype } from './regional-waste-classification.helpers';
 
-const DESCRIPTION_SIMILARITY_THRESHOLD = 0.9;
+const DESCRIPTION_SIMILARITY_THRESHOLD = 0.85;
 
 const {
   LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,

--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -239,6 +239,33 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
     },
     {
       events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '20 01 25'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              'Óleos e gorduras vegetais alimentares',
+            ],
+          ],
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: 'Óleos e gorduras vegetais alimentares',
+        id: '20 01 25',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.FOOD_FOOD_WASTE_AND_BEVERAGES,
+      },
+      resultStatus: 'PASSED',
+      scenario:
+        'The local waste classification description is a SINIR-MTR variant of the CONAMA entry (Dice 0.857 >= 0.85 threshold)',
+    },
+    {
+      events: {
         [`${ACTOR}-${RECYCLER}`]: americanRecyclerEvent,
         [PICK_UP]: stubBoldMassIDPickUpEvent({
           metadataAttributes: [


### PR DESCRIPTION
### 🧾 Summary

Lowers `DESCRIPTION_SIMILARITY_THRESHOLD` in the Regional Waste Classification rule processor from **0.9 → 0.85** so that SINIR/MTR variants of canonical CONAMA descriptions stop failing audit.

### 🧩 Context

The rule compares the declared `Local Waste Classification Description` (from the Pick-up event) against the canonical CONAMA description in `WASTE_CLASSIFICATION_CODES.BR` using Sorensen-Dice over aggressively-normalized strings (`isNameMatch` in `libs/shared/helpers`).

In production we observe integrators copying the literal MTR/SINIR text (which adds small qualifier tokens like `"vegetais"`, `"comum"`, etc.) instead of the CONAMA dictionary text. These near-misses fail by a narrow margin against the 0.9 threshold.

**Real-world failing case (CONAMA `20 01 25` — oils and fats):**

| Field | Value |
|---|---|
| Declared description (MTR/SINIR) | `Óleos e gorduras vegetais alimentares` |
| Canonical dict description | `Óleos e gorduras alimentares` |
| Dice score (after aggressive normalization) | **0.857** |
| Old threshold (0.9) | ❌ FAIL (gap ≈ 0.043) |
| New threshold (0.85) | ✅ PASS |

0.85 keeps the comparison conservative — random sentences score near 0 against the dict, and the existing negative tests still fail as expected.

### 🧱 Scope of this PR

**In scope:**
- Threshold constant change in `regional-waste-classification.processor.ts` (0.9 → 0.85).
- New test case asserting the `20 01 25` SINIR/CONAMA variant now passes.

**Out of scope:**
- No changes to `isNameMatch` helper, normalization, or the `WASTE_CLASSIFICATION_CODES` dictionary.
- No changes to any other rule processor.

### 🧪 How to test

```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-regional-waste-classification
pnpm nx lint methodologies-bold-rule-processors-mass-id-regional-waste-classification
pnpm nx ts   methodologies-bold-rule-processors-mass-id-regional-waste-classification
```

All targets pass locally (16/16 tests, 100% coverage on `processor.ts` + `helpers.ts`).

### 🧠 Considerations for Review

- **Why 0.85 and not lower?** The largest observed real-world gap is ~0.043 below 0.9. 0.85 covers it with margin without opening the door to spurious matches — at 0.85, two strings still need substantial bigram overlap after accent stripping, lowercasing, and punctuation removal.
- **Audit impact**: ~21 production MassIDs (4 with this exact `"Óleos e gorduras vegetais alimentares"` description, plus other similar near-miss variants) become auditable. No previously-passing case flips to FAIL.
- **No boundary tests to adjust**: existing PASS cases use the exact dict text (Dice 1.0) or punctuation-padded variants that normalize to identical strings. Existing FAIL cases use `faker.lorem.sentence()` (Dice ≈ 0). Neither crosses the 0.85–0.9 band.

### 🔗 Related Links

_n/a_

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined waste classification matching to better accommodate variations in regional waste descriptions.

* **Tests**
  * Added test case for regional waste classification validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/carrot-foundation/methodology-rules/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->