### PR TITLE
Capture transport-manifest waste row when item marker is a separate block

### DIFF
--- a/libs/shared/document-extractor-transport-manifest/src/mtr-sinfat.parser.spec.ts
+++ b/libs/shared/document-extractor-transport-manifest/src/mtr-sinfat.parser.spec.ts
@@ -644,6 +644,121 @@ Tecnologia: Compostagem`;
         { code: '020299', description: 'Outros resíduos' },
       ]);
     });
+
+    it('should capture waste row when item marker is emitted as a separate block within the description column', () => {
+      const headerY = 0.7;
+      const dataY = 0.72;
+
+      const result = parser.parse(
+        stubTextExtractionResultWithBlocks(validSinfatText, [
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.04,
+              top: headerY,
+              width: 0.18,
+            },
+            text: 'Item. Código IBAMA e Denominação',
+          },
+          {
+            boundingBox: { height: 0.02, left: 0.4, top: headerY, width: 0.07 },
+            text: 'Estado Físico',
+          },
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.49,
+              top: headerY,
+              width: 0.03,
+            },
+            text: 'Classe',
+          },
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.54,
+              top: headerY,
+              width: 0.09,
+            },
+            text: 'Acondicionamento',
+          },
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.65,
+              top: headerY,
+              width: 0.02,
+            },
+            text: 'Qtde',
+          },
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.72,
+              top: headerY,
+              width: 0.04,
+            },
+            text: 'Unidade',
+          },
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.84,
+              top: headerY,
+              width: 0.05,
+            },
+            text: 'Tecnologia',
+          },
+          // CONAMA-code+description block emitted first (slightly lower top).
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.057,
+              top: dataY - 0.001,
+              width: 0.22,
+            },
+            text: '999900 Fictional waste description',
+          },
+          // Item-marker block emitted later in y order but within the same cluster
+          // and inside the description column's x range.
+          {
+            boundingBox: {
+              height: 0.02,
+              left: 0.04,
+              top: dataY + 0.0005,
+              width: 0.01,
+            },
+            text: '1.',
+          },
+          {
+            boundingBox: { height: 0.02, left: 0.4, top: dataY, width: 0.07 },
+            text: 'Semi-solido',
+          },
+          {
+            boundingBox: { height: 0.02, left: 0.49, top: dataY, width: 0.03 },
+            text: 'IIA',
+          },
+          {
+            boundingBox: { height: 0.02, left: 0.65, top: dataY, width: 0.05 },
+            text: '8.400,00000',
+          },
+          {
+            boundingBox: { height: 0.02, left: 0.72, top: dataY, width: 0.04 },
+            text: 'Quilograma',
+          },
+        ]),
+      );
+
+      expect(result.data.wasteTypes?.map(toWasteTypeEntryData)).toEqual([
+        {
+          classification: 'IIA',
+          code: '999900',
+          description: 'Fictional waste description',
+          quantity: 8400,
+          unit: 'Quilograma',
+        },
+      ]);
+    });
   });
 
   describe('getMatchScore', () => {

--- a/libs/shared/document-extractor-transport-manifest/src/mtr-sinfat.parser.ts
+++ b/libs/shared/document-extractor-transport-manifest/src/mtr-sinfat.parser.ts
@@ -80,10 +80,13 @@ const SINFAT_HEADER_DEFS: [
 
 const SINFAT_ANCHOR_COLUMN: SinfatWasteColumn = 'description';
 
-const SINFAT_WASTE_CODE_PATTERN = /^\d+\.\s+(\d{6})\s+(.+)/;
+const SINFAT_WASTE_CODE_PATTERN = /\b(\d{6})\b[\s.,\-–]*([\s\S]+)/;
 
 // eslint-disable-next-line sonarjs/slow-regex
 const SINFAT_WASTE_ITEM_PATTERN = /\d+\.\s+(\d{6})\s+(.+)/g;
+
+// eslint-disable-next-line sonarjs/slow-regex
+const TRAILING_ITEM_MARKER_PATTERN = /\s*\b\d+\.\s*$/;
 
 const parseSinfatWasteRow = (
   rawDescription: string,
@@ -93,7 +96,9 @@ const parseSinfatWasteRow = (
 
   const entry: WasteTypeEntryData = {
     code: codeMatch[1] as string,
-    description: (codeMatch[2] as string).trim(),
+    description: (codeMatch[2] as string)
+      .replace(TRAILING_ITEM_MARKER_PATTERN, '')
+      .trim(),
   };
 
   if (row['classification']) {


### PR DESCRIPTION
### 🧾 Summary

Stop the SINFAT Transport Manifest parser from silently dropping a clearly-formed waste row when Textract emits the row's item indicator (for example "1.") as a separate LINE block inside the same description column. The row is now captured regardless of the order in which the item-marker block and CONAMA-code block appear within the description cluster.

### 🧩 Context

For SEMAD/FEAM (SINFAT) manifests, Textract sometimes returns the per-row item indicator on its own LINE block. When this block sorts after the code+description block in Y order, the table extractor concatenates them as `"<code> <description> <item>."` instead of `"<item>. <code> <description>"`. The previous filter required the description to begin with `"N. CODE "`, so the well-formed row was discarded. The downstream Transport Manifest Data rule then saw no waste type or quantity at all.

This is purely a parser quirk on the SINFAT path — the OCR output is fine.

### 🧱 Scope of this PR

Included
- `mtr-sinfat.parser.ts`: replace the anchored `^N. CODE description` pattern with a lenient match that locates the CONAMA code anywhere in the description text. After matching, a trailing item marker (such as `" 1."`) is stripped before producing the entry.
- New regression test in `mtr-sinfat.parser.spec.ts` reproducing the exact block layout (item-marker block emitted at a slightly later Y inside the description column) and asserting the row is captured with code, description, quantity, classification, and unit.

Not included
- No changes to the SIGOR or SINIR parser variants.
- No changes to the text-fallback path or to `isOcrPlausiblePlateMatch`, `OCR_CONFUSABLE_PAIRS`, `normalizeVehiclePlate`, or any cross-validation comparison logic in `document-manifest-data`.

### 🧪 How to test

```
pnpm nx test shared-document-extractor-transport-manifest
pnpm nx lint shared-document-extractor-transport-manifest
pnpm nx ts shared-document-extractor-transport-manifest
```

All three pass locally with 100% coverage on the affected file.

Fictional before/after for the single-row table:

```
Header: Item. Código IBAMA e Denominação | Estado Físico | ... | Qtde       | Unidade
Row:    999900 Fictional waste description  / Semi-solido / ... / 8.400,00000 / Quilograma
        (item marker "1." emitted as a separate block in the same column)
```

Before this PR: row dropped silently, `wasteTypes` undefined.

After this PR:
```json
[
  {
    "code": "999900",
    "description": "Fictional waste description",
    "quantity": 8400,
    "unit": "Quilograma",
    "classification": "IIA"
  }
]
```

The fix was also verified end-to-end against a real SEMAD/FEAM manifest PDF locally; no data from that document is checked in.

### 🧠 Considerations for Review

- The lenient pattern intentionally accepts CONAMA codes whose value is unknown to the methodology — the rule layer is the right place to validate codes, not the extractor.
- The trailing-item-marker strip is anchored to the end of the description and looks for `N.` only, so codes embedded inside the description text are not affected.
- Behavior of SIGOR and SINIR variants is unchanged.

### 🔗 Related Links

_n/a_

---

- [x] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test verifying waste-row extraction when item markers are emitted as separate blocks within description columns.

* **Bug Fixes**
  * Enhanced waste code and description parsing to support new formats and properly handle trailing item-number markers in waste descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/carrot-foundation/methodology-rules/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->