### PR TITLE
fix(shared): map CONAMA 19 08 12 to CDM 8.7B for Industrial Sludge

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/regional-waste-classification/src/regional-waste-classification.test-cases.ts
@@ -86,6 +86,33 @@ export const regionalWasteClassificationTestCases: RegionalWasteClassificationTe
         [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
         [PICK_UP]: stubBoldMassIDPickUpEvent({
           metadataAttributes: [
+            [LOCAL_WASTE_CLASSIFICATION_ID, '19 08 12'],
+            [
+              LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+              WASTE_CLASSIFICATION_CODES.BR['19 08 12'].description,
+            ],
+          ],
+        }),
+      },
+      partialDocument: {
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultComment: RESULT_COMMENTS.passed.VALID_CLASSIFICATION,
+      resultContent: {
+        description: WASTE_CLASSIFICATION_CODES.BR['19 08 12'].description,
+        id: '19 08 12',
+        recyclerCountryCode: 'BR',
+        subtype: MassIDOrganicSubtype.INDUSTRIAL_SLUDGE,
+      },
+      resultStatus: 'PASSED',
+      scenario:
+        'The Industrial Sludge subtype matches the 19 08 12 classification code (CDM 8.7B)',
+    },
+    {
+      events: {
+        [`${ACTOR}-${RECYCLER}`]: brazilianRecyclerEvent,
+        [PICK_UP]: stubBoldMassIDPickUpEvent({
+          metadataAttributes: [
             [LOCAL_WASTE_CLASSIFICATION_ID, '020101'],
             [
               LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,

--- a/libs/shared/methodologies/bold/utils/src/waste-classification.constants.ts
+++ b/libs/shared/methodologies/bold/utils/src/waste-classification.constants.ts
@@ -722,7 +722,7 @@ export const WASTE_CLASSIFICATION_CODES = {
         'Misturas de gorduras e óleos, da separação óleo/água, contendo apenas óleos e gorduras alimentares',
     },
     '19 08 12': {
-      CDM_CODE: '8.7D',
+      CDM_CODE: '8.7B',
       description:
         'Lodos do tratamento biológico de efluentes industriais não abrangidas em 19 08 11',
     },


### PR DESCRIPTION
## What

Maps CONAMA waste code \`19 08 12\` ("Lodos do tratamento biológico de efluentes industriais") to CDM code **\`8.7B\`** (was \`8.7D\`).

## Why

\`19 08 12\` is operationally classified as **Industrial Sludge**. The \`MassIDOrganicSubtype.INDUSTRIAL_SLUDGE\` subtype maps to CDM \`8.7B\` via \`SUBTYPE_TO_CDM_CODE_MAP\`, but the classification table had it as the sibling \`8.7D\` ("outros"). The Regional Waste Classification rule compares \`classificationEntry.CDM_CODE\` against \`getCdmCodeFromSubtype(subtype)\`, so the mismatch produced \`INVALID_SUBTYPE_CDM_CODE_MISMATCH\` for 29 Industrial Sludge MassIDs carrying this classification ID.

Only \`CDM_CODE\` changes — the \`description\` is unchanged, so the description match (\`isNameMatch\`, threshold 0.85) is unaffected.

## Changes

- \`waste-classification.constants.ts\` — \`'19 08 12'\` CDM_CODE \`8.7D\` → \`8.7B\`
- \`regional-waste-classification.test-cases.ts\` — added PASSED case: \`INDUSTRIAL_SLUDGE\` + \`19 08 12\` → \`VALID_CLASSIFICATION\`

## Scope

Sibling code \`19 08 14\` left as \`8.7D\` — the operations decision covers only \`19 08 12\`.

## Verification

- \`nx test methodologies-bold-rule-processors-mass-id-regional-waste-classification\` — 17 pass, 100% coverage
- lint + ts green on both \`shared-methodologies-bold-utils\` and the rule processor

## Post-merge (manual, ops)

Deploy \`regional-waste-classification\` lambdas, then delete + re-audit the 29 affected MassIDs (re-audit only reflects after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated waste classification mapping for Brazilian waste code 19 08 12, changing the CDM code from 8.7D to 8.7B.

* **Tests**
  * Added test coverage for industrial sludge waste classification validation in Brazilian recycler events with corresponding waste classification code mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/carrot-foundation/methodology-rules/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->