### PR TITLE
fix(rule): select MassID sorting prior value event by timestamp not array index

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.spec.ts
@@ -1,4 +1,8 @@
-import { stubBoldMassIDSortingEvent } from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  stubBoldMassIDSortingEvent,
+  stubBoldMassIDTransportManifestEvent,
+  stubBoldMassIDWeighingEvent,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
   BoldAttributeName,
   BoldDocumentEvent,
@@ -114,13 +118,39 @@ describe('mass-id-sorting helpers', () => {
   describe('findSortingEvents', () => {
     it('should pick the last prior event with value as priorEventWithValue', () => {
       const events = [
-        { name: 'ANY', value: undefined } as unknown as BoldDocumentEvent,
-        { name: 'ANY', value: 5 } as unknown as BoldDocumentEvent,
-        { name: 'ANY' } as unknown as BoldDocumentEvent,
-        { name: 'ANY', value: 7 } as unknown as BoldDocumentEvent,
-        { name: 'ANY' } as unknown as BoldDocumentEvent,
-        { name: 'ANY' } as unknown as BoldDocumentEvent,
-        stubBoldMassIDSortingEvent({ partialDocumentEvent: { value: 9 } }),
+        {
+          externalCreatedAt: '2026-01-01T03:00:00.000Z',
+          name: 'ANY',
+          value: undefined,
+        } as unknown as BoldDocumentEvent,
+        {
+          externalCreatedAt: '2026-01-01T03:00:01.000Z',
+          name: 'ANY',
+          value: 5,
+        } as unknown as BoldDocumentEvent,
+        {
+          externalCreatedAt: '2026-01-01T03:00:02.000Z',
+          name: 'ANY',
+        } as unknown as BoldDocumentEvent,
+        {
+          externalCreatedAt: '2026-01-01T03:00:03.000Z',
+          name: 'ANY',
+          value: 7,
+        } as unknown as BoldDocumentEvent,
+        {
+          externalCreatedAt: '2026-01-01T03:00:04.000Z',
+          name: 'ANY',
+        } as unknown as BoldDocumentEvent,
+        {
+          externalCreatedAt: '2026-01-01T03:00:05.000Z',
+          name: 'ANY',
+        } as unknown as BoldDocumentEvent,
+        stubBoldMassIDSortingEvent({
+          partialDocumentEvent: {
+            externalCreatedAt: '2026-01-01T03:00:06.000Z',
+            value: 9,
+          },
+        }),
       ];
 
       const result = findSortingEvents(
@@ -132,6 +162,68 @@ describe('mass-id-sorting helpers', () => {
       }
 
       expect(result.priorEventWithValue?.value).toBe(7);
+    });
+
+    it('should select the prior value event by timestamp even when Sorting precedes it in array order', () => {
+      const sortingEvent = stubBoldMassIDSortingEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: '2026-01-01T03:00:09.000Z',
+          value: 112.404,
+        },
+      });
+      const transportManifestEvent = stubBoldMassIDTransportManifestEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: '2026-01-01T03:00:01.000Z',
+          value: 114,
+        },
+      });
+      const weighingEvent = stubBoldMassIDWeighingEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: '2026-01-01T03:00:03.000Z',
+          value: 120,
+        },
+      });
+      const actorEvent = {
+        externalCreatedAt: '2026-01-01T03:00:00.000Z',
+        name: 'ACTOR',
+        value: undefined,
+      } as unknown as BoldDocumentEvent;
+
+      const result = findSortingEvents([
+        actorEvent,
+        sortingEvent,
+        transportManifestEvent,
+        weighingEvent,
+      ]);
+
+      if ('isError' in result) {
+        throw new Error('Expected SortingEvents, got ValidationError');
+      }
+
+      expect(result.priorEventWithValue?.value).toBe(120);
+    });
+
+    it('should leave priorEventWithValue undefined when no value event precedes Sorting in time', () => {
+      const sortingEvent = stubBoldMassIDSortingEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: '2026-01-01T03:00:01.000Z',
+          value: 100,
+        },
+      });
+      const laterWeighingEvent = stubBoldMassIDWeighingEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: '2026-01-01T03:00:05.000Z',
+          value: 120,
+        },
+      });
+
+      const result = findSortingEvents([laterWeighingEvent, sortingEvent]);
+
+      if ('isError' in result) {
+        throw new Error('Expected SortingEvents, got ValidationError');
+      }
+
+      expect(result.priorEventWithValue).toBeUndefined();
     });
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.ts
@@ -102,10 +102,21 @@ export const findSortingEvents = (
     sortingEventIndex,
   ) as BoldDocumentEvent;
 
+  const sortingCreatedAt = new Date(sortingEvent.externalCreatedAt).getTime();
+
   const priorEventWithValue = externalEvents
-    .slice(0, sortingEventIndex)
-    .reverse()
-    .find((event) => event.value !== undefined);
+    .filter(
+      (event) =>
+        event !== sortingEvent &&
+        event.value !== undefined &&
+        new Date(event.externalCreatedAt).getTime() < sortingCreatedAt,
+    )
+    .sort(
+      (a, b) =>
+        new Date(a.externalCreatedAt).getTime() -
+        new Date(b.externalCreatedAt).getTime(),
+    )
+    .at(-1);
 
   return { priorEventWithValue, sortingEvent };
 };

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.test-cases.ts
@@ -94,7 +94,10 @@ const createMassIDEvents = (
   includeDescription = true,
 ) => ({
   [DROP_OFF]: stubBoldMassIDDropOffEvent({
-    partialDocumentEvent: { value: valueBeforeSorting },
+    partialDocumentEvent: {
+      externalCreatedAt: DROP_OFF_EXTERNAL_CREATED_AT,
+      value: valueBeforeSorting,
+    },
   }),
   [SORTING]: stubBoldMassIDSortingEvent({
     metadataAttributes: [
@@ -103,9 +106,10 @@ const createMassIDEvents = (
         ? []
         : [[DESCRIPTION, undefined] as [BoldAttributeName, undefined]]),
     ],
-    ...(sortingValue !== undefined && {
-      partialDocumentEvent: { value: sortingValue },
-    }),
+    partialDocumentEvent: {
+      externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+      ...(sortingValue !== undefined && { value: sortingValue }),
+    },
   }),
 });
 
@@ -159,6 +163,9 @@ const MANIFEST_DEDUCTED_WEIGHT =
   MANIFEST_GROSS_WEIGHT * MANIFEST_SORTING_FACTOR;
 const MANIFEST_SORTING_VALUE = MANIFEST_GROSS_WEIGHT - MANIFEST_DEDUCTED_WEIGHT;
 
+const DROP_OFF_EXTERNAL_CREATED_AT = '2099-01-01T00:00:00.000Z';
+const SORTING_EXTERNAL_CREATED_AT = '2099-01-01T01:00:00.000Z';
+
 const sortingFactor = faker.number.float({ max: 1, min: 0 });
 const valueBeforeSorting = faker.number.float({ min: 1 });
 const grossWeight = valueBeforeSorting;
@@ -188,6 +195,7 @@ const {
     externalEventsMap: {
       [DROP_OFF]: stubBoldMassIDDropOffEvent({
         partialDocumentEvent: {
+          externalCreatedAt: DROP_OFF_EXTERNAL_CREATED_AT,
           value: 0,
         },
       }),
@@ -207,6 +215,9 @@ const {
             }),
           },
         ],
+        partialDocumentEvent: {
+          externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+        },
       }),
     },
     partialDocument: {
@@ -239,6 +250,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     partialDocument: {
       ...massIDDocument,
       currentValue: calculatedSortingValue,
+      externalEvents: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.MISSING_SORTING_DESCRIPTION,
     resultStatus: 'FAILED',
@@ -260,6 +272,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     partialDocument: {
       ...massIDDocument,
       currentValue: MANIFEST_SORTING_VALUE,
+      externalEvents: undefined,
     },
     resultComment: RESULT_COMMENTS.passed.SORTING_VALUE_WITHIN_TOLERANCE(0),
     resultStatus: 'PASSED',
@@ -279,6 +292,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     partialDocument: {
       ...massIDDocument,
       currentValue: calculatedSortingValue + 1,
+      externalEvents: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.DOCUMENT_VALUE_MISMATCH(
       calculatedSortingValue + 1,
@@ -298,7 +312,11 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
       deductedWeight,
       wrongSortingValue,
     ),
-    partialDocument: { ...massIDDocument, currentValue: wrongSortingValue },
+    partialDocument: {
+      ...massIDDocument,
+      currentValue: wrongSortingValue,
+      externalEvents: undefined,
+    },
     resultComment: RESULT_COMMENTS.failed.SORTING_VALUE_EXCEEDS_TOLERANCE(
       Math.abs(calculatedSortingValue - wrongSortingValue),
     ),
@@ -318,6 +336,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     partialDocument: {
       ...massIDDocument,
       currentValue: calculatedSortingValue,
+      externalEvents: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.DEDUCTED_WEIGHT_MISMATCH(
       mismatchedDeductedWeight,
@@ -339,6 +358,7 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
     partialDocument: {
       ...massIDDocument,
       currentValue: calculatedSortingValue,
+      externalEvents: undefined,
     },
     resultComment: RESULT_COMMENTS.failed.GROSS_WEIGHT_MISMATCH(
       grossWeight + 0.2,
@@ -352,6 +372,11 @@ export const massIDSortingTestCases: MassIDSortingTestCase[] = [
 const invalidSortingValue = new BoldStubsBuilder()
   .createMassIDDocuments({
     externalEventsMap: {
+      [DROP_OFF]: stubBoldMassIDDropOffEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: DROP_OFF_EXTERNAL_CREATED_AT,
+        },
+      }),
       [SORTING]: stubBoldMassIDSortingEvent({
         metadataAttributes: [
           {
@@ -366,6 +391,7 @@ const invalidSortingValue = new BoldStubsBuilder()
           },
         ],
         partialDocumentEvent: {
+          externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
           value: 0,
         },
       }),
@@ -474,7 +500,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
             CUBIC_METER,
             KILOGRAM,
           ),
-          partialDocumentEvent: { value: calculatedSortingValue },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: calculatedSortingValue,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),
@@ -498,7 +527,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
             KILOGRAM,
             CUBIC_METER,
           ),
-          partialDocumentEvent: { value: calculatedSortingValue },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: calculatedSortingValue,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),
@@ -517,7 +549,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
         },
         [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(0, deductedWeight),
-          partialDocumentEvent: { value: calculatedSortingValue },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: calculatedSortingValue,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),
@@ -536,7 +571,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
         },
         [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(valueBeforeSorting, 0),
-          partialDocumentEvent: { value: calculatedSortingValue },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: calculatedSortingValue,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),
@@ -560,7 +598,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
             CUBIC_METER,
             KILOGRAM,
           ),
-          partialDocumentEvent: { value: 7 },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: 7,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),
@@ -584,7 +625,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
             KILOGRAM,
             CUBIC_METER,
           ),
-          partialDocumentEvent: { value: 7 },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: 7,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),
@@ -603,7 +647,10 @@ export const massIDSortingErrorTestCases: MassIDSortingErrorTestCase[] = [
         },
         [String(SORTING)]: stubBoldMassIDSortingEvent({
           metadataAttributes: createWeightAttributes(5, 10),
-          partialDocumentEvent: { value: calculatedSortingValue },
+          partialDocumentEvent: {
+            externalCreatedAt: SORTING_EXTERNAL_CREATED_AT,
+            value: calculatedSortingValue,
+          },
         }),
       }),
       ...participantsAccreditationDocuments.values(),


### PR DESCRIPTION
## Problem

The MassID Sorting rule fails on a large set of MassIDs with:

> The value before the "Sorting" must be greater than 0, but "undefined" was provided.

This is a **false failure caused by rule logic**, not bad data.

## Root cause

`findSortingEvents` (`mass-id-sorting.helpers.ts`) selected "the value before Sorting" by **array position**:

```ts
const sortingEventIndex = externalEvents.findIndex(eventNameIsAnyOf([SORTING]));
const priorEventWithValue = externalEvents
  .slice(0, sortingEventIndex)   // events before Sorting BY ARRAY INDEX
  .reverse()
  .find((event) => event.value !== undefined);
```

This assumes `externalEvents` is in chronological order. **It is not.** Production documents store events in a non-chronological array order. Verified example (real MassID document, array order as the rule reads it):

```
idx 3  Sorting             externalCreatedAt=...T03:00:09Z  value=<masked>
idx 5  Transport Manifest  externalCreatedAt=...T03:00:01Z  value=<masked>
idx 7  Weighing            externalCreatedAt=...T03:00:03Z  value=<masked>
(indices 0-2 are ACTOR events with value=undefined)
```

Sorting sits at index 3, but the value-bearing events that are chronologically **earlier** sit at indices 5 and 7 — **after** Sorting in the array. So `slice(0, 3)` only sees value-less ACTOR events → `find` returns nothing → `priorEventWithValue` is `undefined` → `EVENT_BEFORE_SORTING_UNDEFINED` → the rendered error above.

## Fix

Select the prior value event by **timestamp**, not array index: the latest value-bearing event whose `externalCreatedAt` is **strictly before** the Sorting event's `externalCreatedAt`.

- Strict `<` correctly excludes the Sorting event itself and anything at/after it (stored timestamps are distinct/sequential).
- Handles multiple value-bearing events before Sorting (e.g. more than one Weighing): takes the chronologically last one.
- Does not hardcode the event name — any prior event that sets `value` qualifies.
- Preserves the function signature/return shape, the `MISSING_SORTING_EVENT` path, and the downstream `EVENT_BEFORE_SORTING_UNDEFINED` behavior when there is genuinely no prior value-bearing event.

## Tests (TDD)

- **Updated** the existing `findSortingEvents` helper test to carry `externalCreatedAt` consistent with array order.
- **Added** a regression test reproducing the production bug — Sorting at a lower array index than the value events, but with earlier timestamps — asserting the chronologically-latest prior value is chosen. Fails on the old array-index implementation, passes after the fix.
- **Added** a no-prior-event-in-time test (prior stays `undefined`).
- **Processor fixtures:** the processor spec relied on stub array order, but `BoldStubsBuilder` assigns **random `externalCreatedAt`** to every event, so timestamp-based selection was non-deterministic over them (verified flaky: 3/3/4 failures across identical runs). The fixtures now stamp DROP_OFF/SORTING with explicit chronological timestamps and stop the `partialDocument` spread from duplicating events. Suite is green and deterministic (28/28 across 5 consecutive runs).

## Follow-up (out of scope)

Other rule processors likely share the same array-order assumption about `externalEvents`. Worth an audit in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected Mass ID sorting event selection to identify preceding events based on actual timestamps rather than array position, ensuring accurate event ordering.

* **Tests**
  * Expanded test coverage for sorting event scenarios with timestamp-based event ordering verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->