### PR TITLE
chore(ci): harden Codecov CLI download and bump to v11.2.8

### DIFF
--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -137,9 +137,15 @@ jobs:
         id: download-cli
         if: ${{ !cancelled() && steps.coverage-exists.outputs.has_coverage == 'true' }}
         run: |
-          # Pinned for reproducibility; bump manually after verifying CLI compatibility
+          # Pinned for reproducibility; bump CODECOV_CLI_VERSION and CODECOV_CLI_SHA256
+          # together after verifying CLI compatibility.
           # Releases: https://github.com/codecov/codecov-cli/releases
           CODECOV_CLI_VERSION="v11.2.8"
+          # Repo-owned expected SHA-256 of the linux codecov binary. This is the source
+          # of trust: the binary and its codecov.SHA256SUM are served from the same
+          # origin, so a same-origin checksum alone cannot prove the binary was not
+          # tampered with at the origin/CDN. Pinning the hash here catches such a swap.
+          CODECOV_CLI_SHA256="8930c4bb30254a42f3d8c340706b1be340885e20c0df5160a24efa2e030e662b"
           CODECOV_CLI_BASE_URL="https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux"
 
           # cli.codecov.io redirects to a CDN that can occasionally serve a corrupt or
@@ -148,12 +154,7 @@ jobs:
           # bad transfer instead of failing the build.
           download_and_verify_codecov_cli() {
             curl -fsSL --retry 3 --retry-connrefused "${CODECOV_CLI_BASE_URL}/codecov" -o ./codecov || return 1
-            curl -fsSL --retry 3 --retry-connrefused "${CODECOV_CLI_BASE_URL}/codecov.SHA256SUM" -o ./codecov.SHA256SUM || return 1
-            # Reconstruct the canonical "<hash>  codecov" line so verification is robust
-            # to filename-field formatting (single vs double space, a path prefix).
-            expected_hash="$(awk 'NR==1 {print $1}' ./codecov.SHA256SUM)"
-            [ -n "${expected_hash}" ] || return 1
-            echo "${expected_hash}  codecov" | sha256sum --check -
+            echo "${CODECOV_CLI_SHA256}  codecov" | sha256sum --check -
           }
 
           verified=false
@@ -166,7 +167,7 @@ jobs:
             sleep 2
           done
           if [ "${verified}" != "true" ]; then
-            echo "::error::Codecov CLI checksum verification failed for ${CODECOV_CLI_VERSION} after 3 attempts. The download may be corrupted or tampered with. Try bumping CODECOV_CLI_VERSION."
+            echo "::error::Codecov CLI checksum verification failed for ${CODECOV_CLI_VERSION} after 3 attempts. Expected SHA-256 ${CODECOV_CLI_SHA256}. The download may be corrupted or tampered with, or the pinned hash is stale after a version bump."
             exit 1
           fi
           chmod +x ./codecov

--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -139,11 +139,34 @@ jobs:
         run: |
           # Pinned for reproducibility; bump manually after verifying CLI compatibility
           # Releases: https://github.com/codecov/codecov-cli/releases
-          CODECOV_CLI_VERSION="v10.4.0"
-          curl -fsSL --retry 3 --retry-connrefused "https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux/codecov" -o ./codecov
-          curl -fsSL --retry 3 --retry-connrefused "https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux/codecov.SHA256SUM" -o ./codecov.SHA256SUM
-          if ! grep ' codecov$' ./codecov.SHA256SUM | sha256sum --check -; then
-            echo "::error::Codecov CLI checksum verification failed for ${CODECOV_CLI_VERSION}. The download may be corrupted or tampered with. Try bumping CODECOV_CLI_VERSION."
+          CODECOV_CLI_VERSION="v11.2.8"
+          CODECOV_CLI_BASE_URL="https://cli.codecov.io/${CODECOV_CLI_VERSION}/linux"
+
+          # cli.codecov.io redirects to a CDN that can occasionally serve a corrupt or
+          # partial body with HTTP 200; curl --retry only retries connection-level
+          # failures, so re-download and re-verify a few times to self-heal a transient
+          # bad transfer instead of failing the build.
+          download_and_verify_codecov_cli() {
+            curl -fsSL --retry 3 --retry-connrefused "${CODECOV_CLI_BASE_URL}/codecov" -o ./codecov || return 1
+            curl -fsSL --retry 3 --retry-connrefused "${CODECOV_CLI_BASE_URL}/codecov.SHA256SUM" -o ./codecov.SHA256SUM || return 1
+            # Reconstruct the canonical "<hash>  codecov" line so verification is robust
+            # to filename-field formatting (single vs double space, a path prefix).
+            expected_hash="$(awk 'NR==1 {print $1}' ./codecov.SHA256SUM)"
+            [ -n "${expected_hash}" ] || return 1
+            echo "${expected_hash}  codecov" | sha256sum --check -
+          }
+
+          verified=false
+          for attempt in 1 2 3; do
+            if download_and_verify_codecov_cli; then
+              verified=true
+              break
+            fi
+            echo "::warning::Codecov CLI download/verification failed for ${CODECOV_CLI_VERSION} (attempt ${attempt}/3); retrying."
+            sleep 2
+          done
+          if [ "${verified}" != "true" ]; then
+            echo "::error::Codecov CLI checksum verification failed for ${CODECOV_CLI_VERSION} after 3 attempts. The download may be corrupted or tampered with. Try bumping CODECOV_CLI_VERSION."
             exit 1
           fi
           chmod +x ./codecov


### PR DESCRIPTION
## Summary

The `Backend Check / Tests` job intermittently failed on the **Download Codecov CLI** step (not on the tests — all unit tests pass), painting a red ✖ on PRs (e.g. #410). This is an infra/CI fix, independent of any feature.

**Root cause:** `cli.codecov.io` redirects to a CDN that can occasionally serve a corrupt or partial body with HTTP 200. `curl --retry` only retries connection-level failures, so a single bad transfer slipped through and failed checksum verification, taking down the whole job. The pinned `v10.4.0` artifacts verify cleanly on demand — the failure was a transient bad download, not a format change or a tampered binary.

## What changed

`.github/workflows/backend-check.yaml`, `Download Codecov CLI` step:

- **Retry the download + checksum verification up to 3 times** so a transient bad transfer self-heals instead of failing the build. A genuine mismatch still fails hard after 3 attempts — the integrity check is preserved.
- **Robust checksum extraction**: reconstruct the canonical `<hash>  codecov` line via `awk` so verification tolerates SHA256SUM filename-field formatting changes (single vs double space, a path prefix).
- **Bump pinned version `v10.4.0` → `v11.2.8`** (latest). Binary + SHA256SUM verified locally (`8930c4bb…`, ELF x86-64). `upload-process` and its flags (`-t -f -F -n --disable-search`) are unchanged across the bump; this PR's own CI run exercises the full upload path on a real runner.

Pinned-version + integrity-check intent is kept intact.

## Notes

- `v11.0.0` is the rebrand boundary (codecov-cli → `getsentry/prevent-cli`), but its changes are build-internal only (`uv`, pure-Python, tree-sitter removal) — no documented CLI-surface change. If the upload step regresses on a real runner, it's a one-line revert to `v10.4.0` while keeping the hardening.

## Declaration

- [x] I have verified the download + checksum logic against the chosen version locally (real download verifies; a forced-corrupt body retries then fails as expected).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to download/verify logic for the Codecov CLI; no application runtime, auth, or data paths are affected.
> 
> **Overview**
> **Backend Check / Tests** hardens how the workflow fetches the Codecov CLI so flaky CDN responses are less likely to fail the job, and bumps the pinned CLI from **v10.4.0** to **v11.2.8**.
> 
> Integrity checking no longer downloads `codecov.SHA256SUM` from the same origin as the binary. It verifies the linux `codecov` artifact against a **repo-pinned SHA-256** (`CODECOV_CLI_SHA256`), with comments that version and hash must be bumped together. A **`download_and_verify_codecov_cli`** helper wraps curl plus `sha256sum --check`, and the step **retries up to three times** (with warnings and a short sleep) before failing with a clearer error that mentions stale pins or tampering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a7ee957a8ac24640829b424b78ac3e97c02dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability for the backend checks by adding retry logic around downloading the Codecov CLI.
  * Strengthened the integrity verification by pinning the expected SHA-256 and validating the downloaded binary with a deterministic checksum check.
  * Updated the Codecov CLI version used in the workflow and improved failure reporting with clearer error messages after all retry attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->