### PR TITLE
chore(ci): bump codecov-action to v5.5.5 for GPG key migration

### DIFF
--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload overall coverage to Codecov
         if: ${{ !cancelled() && steps.coverage-exists.outputs.has_coverage == 'true' }}
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           directory: ./coverage
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -252,7 +252,7 @@ jobs:
         # step outcome so the follow-up warning step can detect upload failures.
         if: ${{ !cancelled() && steps.run-tests.outcome != 'skipped' && steps.codecov-check.outputs.available == 'true' }}
         continue-on-error: true
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           directory: ./coverage
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

The `Backend Check / Tests` job fails on the **Upload overall coverage to Codecov** and **Upload test results to Codecov** steps with:

```
gpg: Signature made Tue Apr 21 2026 using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

**Root cause:** Codecov migrated its GPG signing key from the `codecovsecurity` to the `codecovsecops` Keybase account in June 2026 (codecov/codecov-action#1956). The CLI's `codecov.SHA256SUM.sig` is now signed with the new key, which the pinned `codecov-action@v5.5.3` (released 2026-03-18, pre-migration) does not trust. With `fail_ci_if_error: true`, the step reds the whole job. This affects `main` and every branch that produces coverage.

This is independent of #411 (which fixed the separate hand-rolled `Download Codecov CLI` step — that step does not use GPG and passes fine).

## What changed

`.github/workflows/backend-check.yaml` — bump both `codecov/codecov-action` pins from `v5.5.3` → `v5.5.5`:

- Line 130 — `Upload overall coverage to Codecov`
- Line 255 — `Upload test results to Codecov`

v5.5.5's only change is the keybase key migration (per its release notes), so this is a patch bump on the same major with no input changes. Chose v5.5.5 over v7.0.0 (latest) to keep it minimal — same major, zero input-compatibility risk.

## How to test

- This PR's own `Backend Check / Tests` run exercises both upload steps; the GPG signature verification should now pass and coverage/test-results upload.

## Declaration

- [x] Verified the failing run's GPG error matches the documented `codecovsecurity` → `codecovsecops` key migration, and that v5.5.5's sole change is that migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin bump with no application or workflow input changes; v5.5.5 is a patch release for the documented GPG key update.
> 
> **Overview**
> Restores **Backend Check / Tests** Codecov uploads that were failing GPG signature verification after Codecov’s signing-key migration.
> 
> In `.github/workflows/backend-check.yaml`, both `codecov/codecov-action` pins move from **v5.5.3** to **v5.5.5** (commit `0fb71748…`): the **Upload overall coverage to Codecov** step and the **Upload test results to Codecov** step. Step inputs (`directory`, `token`, `fail_ci_if_error`, `report_type`, `files`) are unchanged; only the action version pin updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da75e58a71d4f5e656876ded6f229c0b42c9a4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the coverage reporting integration to a newer version, keeping CI tooling current without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->