### PR TITLE
fix(shared): normalize null participant businessName to undefined on parse

### DIFF
--- a/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
+++ b/libs/shared/methodologies/bold/io-helpers/src/document.helpers.spec.ts
@@ -114,5 +114,38 @@ describe('Document Helpers', () => {
         });
       }
     });
+
+    it('should accept a null participant businessName and normalize it to undefined', async () => {
+      const key = faker.string.uuid();
+      const baseDocument = stubDocument();
+      const documentWithNulls = {
+        ...baseDocument,
+        externalEvents: baseDocument.externalEvents?.map((event) => ({
+          ...event,
+          participant: {
+            ...event.participant,
+            businessName: null,
+          },
+        })),
+        primaryParticipant: {
+          ...baseDocument.primaryParticipant,
+          businessName: null,
+        },
+      } as unknown as BoldDocument;
+
+      vi.spyOn(loaderService, 'load').mockResolvedValueOnce(
+        stubDocumentEntity({ document: documentWithNulls }),
+      );
+
+      const result = await loadDocument(loaderService, key);
+
+      expect(result).toBeDefined();
+      expect(result?.primaryParticipant).toMatchObject({
+        businessName: undefined,
+      });
+      for (const event of result?.externalEvents ?? []) {
+        expect(event.participant).toMatchObject({ businessName: undefined });
+      }
+    });
   });
 });

--- a/libs/shared/types/src/document/document-participant.types.ts
+++ b/libs/shared/types/src/document/document-participant.types.ts
@@ -3,7 +3,9 @@ import { z } from 'zod';
 import { NonEmptyStringSchema } from '../string.types';
 
 export const DocumentParticipantSchema = z.object({
-  businessName: NonEmptyStringSchema.optional(),
+  businessName: NonEmptyStringSchema.nullish().transform(
+    (value) => value ?? undefined,
+  ),
   countryCode: NonEmptyStringSchema,
   id: NonEmptyStringSchema,
   name: NonEmptyStringSchema,

--- a/libs/shared/types/src/document/document-participant.types.ts
+++ b/libs/shared/types/src/document/document-participant.types.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import { NonEmptyStringSchema } from '../string.types';
 
 export const DocumentParticipantSchema = z.object({
-  businessName: NonEmptyStringSchema.nullish().transform(
-    (value) => value ?? undefined,
-  ),
+  businessName: NonEmptyStringSchema.nullish()
+    .transform((value) => value ?? undefined)
+    .optional(),
   countryCode: NonEmptyStringSchema,
   id: NonEmptyStringSchema,
   name: NonEmptyStringSchema,


### PR DESCRIPTION
## Problem

Every rule on a fresh MassID audit fails with the generic `Could not load the document with id <massId>` / `MassID document not found`, breaking smaug's scheduled `E2E Tests` (`e2e-methodology` → `mass-audit.e2e.spec.ts`) every day since 2026-07-15.

Root cause: smaug writes `participant.businessName` as `null` in the methodology-execution S3 documents. `DocumentParticipantSchema` declared it as `NonEmptyStringSchema.optional()`, which accepts `undefined` but **rejects `null`**, so `BoldDocumentSchema.safeParse` fails for the whole document. `loadDocument` swallows the ZodError into `undefined`, and every processor then reports the generic "not found" result.

## Evidence

- The document **is** present in S3 (`s3://smaug-development-methodology-executions/ad975243-8320-4c59-b250-9d431d5c5501/documents/9b9895c5-02da-4af1-8a3e-0458c71e8c37.json`) — this is not a propagation race.
- The dev `methodology-execution` record for audit `03e6a337-c783-4ece-9dde-edf18ba434bd` shows **all** rules FAILED with `Could not load the document`, not just `waste-mass-is-unique` (the e2e only reports the first because of `--bail 1`).
- Running `validateDocument` against that exact S3 document yields only `externalEvents[N].participant.businessName: expected string, received null` issues.

## Fix

```ts
businessName: NonEmptyStringSchema.nullish().transform(
  (value) => value ?? undefined,
),
```

Same pattern as the nullable address fields (#401): the input contract accepts `null` (matching what Smaug stores), while the output type stays `string | undefined` so downstream consumers are unaffected.

## Verification

- New regression test in `document.helpers.spec.ts` — red before the schema change, green after.
- The real failing S3 document now parses as valid.
- `nx affected --target test` green (96 projects), `nx affected --target lint` green (99 projects).

## Note

Smaug already shipped a producer-side fix (`59c0a887a`, 2026-07-16, `fix(methodology): omit null participant business names`) that strips the null before the S3 write, but it has not reached dev — smaug's `Check and Deploy` workflow has failed on every run since 2026-07-15. This consumer-side widening is the defense-in-depth half and unblocks the suite independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Le3xofCszFPKFVtXkvMrhV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document participant data handling by accepting empty business name values.
  * Empty business names are now consistently normalized, preventing inconsistent values in loaded documents.
* **Tests**
  * Added coverage verifying normalization for primary participants and external event participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->