### PR TITLE
feat(rule): add mass-id privacy-flags rule

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -92,6 +92,11 @@ flags:
       - libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/
     carryforward: true
 
+  mass-id--privacy-flags:
+    paths:
+      - libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/
+    carryforward: true
+
   mass-id--processor-identification:
     paths:
       - libs/methodologies/bold/rule-processors/mass-id/processor-identification/src/

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/CHANGELOG.md
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 (2026-08-05)
+
+- Initial versioned release
+

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/eslint.config.js
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/eslint.config.js
@@ -1,0 +1,7 @@
+const {
+  getBaseEslintConfig,
+} = require('../../../../../../.eslint/eslint.config');
+
+module.exports = getBaseEslintConfig({
+  projectPath: __dirname,
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/package.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@carrot-fndn/methodologies/bold/rule-processors/mass-id/privacy-flags",
+  "version": "0.0.0"
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/project.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "methodologies-bold-rule-processors-mass-id-privacy-flags",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "tags": [
+    "app:any",
+    "methodology:bold",
+    "scope:mass-id",
+    "stack:any",
+    "type:library"
+  ],
+  "sourceRoot": "libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {},
+    "test": {},
+    "test-e2e": {},
+    "ts": {}
+  }
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts
@@ -1,1 +1,2 @@
-export * from './privacy-flags.processor';
+export * from './privacy-flags.lambda';
+export * from './privacy-flags.rule-definition';

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts
@@ -1,0 +1,1 @@
+export * from './privacy-flags.processor';

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.spec.ts
@@ -1,0 +1,75 @@
+import {
+  BoldAttributeName,
+  BoldDocumentEventName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import {
+  EVENT_PRIVACY_SPEC,
+  OPEN_ACTOR_LABELS,
+  SKIPPED_ACTOR_LABELS,
+  SKIPPED_EVENT_NAMES,
+} from './privacy-flags.constants';
+
+const { PICK_UP, WEIGHING } = BoldDocumentEventName;
+const { DRIVER_IDENTIFIER, VEHICLE_LICENSE_PLATE } = BoldAttributeName;
+
+const sortAlphabetically = (a: string, b: string): number => a.localeCompare(b);
+
+describe('privacy-flags constants', () => {
+  it('should specify exactly the seven methodology events', () => {
+    expect([...EVENT_PRIVACY_SPEC.keys()].sort(sortAlphabetically)).toEqual([
+      'Drop-off',
+      'Pick-up',
+      'Recycled',
+      'Recycling Manifest',
+      'Sorting',
+      'Transport Manifest',
+      'Weighing',
+    ]);
+  });
+
+  it('should expect every specified event and attribute to be public', () => {
+    for (const eventSpec of EVENT_PRIVACY_SPEC.values()) {
+      expect(eventSpec.isPublic).toBe(true);
+
+      for (const attributeSpec of eventSpec.attributes.values()) {
+        expect(attributeSpec.isPublic).toBe(true);
+      }
+    }
+  });
+
+  it('should mark the vehicle license plate as sensitive on Pick-up and Weighing', () => {
+    expect(
+      EVENT_PRIVACY_SPEC.get(PICK_UP)?.attributes.get(VEHICLE_LICENSE_PLATE),
+    ).toEqual({ isPublic: true, sensitive: true });
+    expect(
+      EVENT_PRIVACY_SPEC.get(WEIGHING)?.attributes.get(VEHICLE_LICENSE_PLATE),
+    ).toEqual({ isPublic: true, sensitive: true });
+  });
+
+  it('should mark the driver identifier as sensitive on Pick-up', () => {
+    expect(
+      EVENT_PRIVACY_SPEC.get(PICK_UP)?.attributes.get(DRIVER_IDENTIFIER),
+    ).toEqual({ isPublic: true, sensitive: true });
+  });
+
+  it('should treat only Processor and Recycler as open actors', () => {
+    expect([...OPEN_ACTOR_LABELS].sort(sortAlphabetically)).toEqual([
+      'Processor',
+      'Recycler',
+    ]);
+  });
+
+  it('should skip the internal actors and the rule-execution outputs', () => {
+    expect([...SKIPPED_ACTOR_LABELS].sort(sortAlphabetically)).toEqual([
+      'Integrator',
+      'METHODOLOGY PLATFORM',
+    ]);
+    expect([...SKIPPED_EVENT_NAMES].sort(sortAlphabetically)).toEqual([
+      'GasID',
+      'MassID Audit (BOLD Carbon)',
+      'MassID Audit (BOLD Recycling)',
+      'RecycledID',
+    ]);
+  });
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.spec.ts
@@ -1,56 +1,100 @@
 import {
-  BoldAttributeName,
-  BoldDocumentEventName,
-} from '@carrot-fndn/shared/methodologies/bold/types';
-
-import {
+  ASSERTABLE_ACTOR_LABELS,
   EVENT_PRIVACY_SPEC,
   OPEN_ACTOR_LABELS,
-  SKIPPED_ACTOR_LABELS,
   SKIPPED_EVENT_NAMES,
 } from './privacy-flags.constants';
-
-const { PICK_UP, WEIGHING } = BoldDocumentEventName;
-const { DRIVER_IDENTIFIER, VEHICLE_LICENSE_PLATE } = BoldAttributeName;
 
 const sortAlphabetically = (a: string, b: string): number => a.localeCompare(b);
 
 describe('privacy-flags constants', () => {
-  it('should specify exactly the seven methodology events', () => {
-    expect([...EVENT_PRIVACY_SPEC.keys()].sort(sortAlphabetically)).toEqual([
-      'Drop-off',
-      'Pick-up',
-      'Recycled',
-      'Recycling Manifest',
-      'Sorting',
-      'Transport Manifest',
-      'Weighing',
-    ]);
-  });
-
-  it('should expect every specified event and attribute to be public', () => {
-    for (const eventSpec of EVENT_PRIVACY_SPEC.values()) {
-      expect(eventSpec.isPublic).toBe(true);
-
-      for (const attributeSpec of eventSpec.attributes.values()) {
-        expect(attributeSpec.isPublic).toBe(true);
-      }
-    }
-  });
-
-  it('should mark the vehicle license plate as sensitive on Pick-up and Weighing', () => {
+  it('should specify the exact privacy spec for every methodology event and attribute', () => {
     expect(
-      EVENT_PRIVACY_SPEC.get(PICK_UP)?.attributes.get(VEHICLE_LICENSE_PLATE),
-    ).toEqual({ isPublic: true, sensitive: true });
-    expect(
-      EVENT_PRIVACY_SPEC.get(WEIGHING)?.attributes.get(VEHICLE_LICENSE_PLATE),
-    ).toEqual({ isPublic: true, sensitive: true });
-  });
-
-  it('should mark the driver identifier as sensitive on Pick-up', () => {
-    expect(
-      EVENT_PRIVACY_SPEC.get(PICK_UP)?.attributes.get(DRIVER_IDENTIFIER),
-    ).toEqual({ isPublic: true, sensitive: true });
+      Object.fromEntries(
+        [...EVENT_PRIVACY_SPEC].map(([eventName, eventSpec]) => [
+          eventName,
+          {
+            attributes: Object.fromEntries(eventSpec.attributes),
+            isPublic: eventSpec.isPublic,
+          },
+        ]),
+      ),
+    ).toEqual({
+      'Drop-off': {
+        attributes: {
+          Description: { isPublic: true, sensitive: false },
+          'Receiving Operator Identifier': {
+            isPublic: true,
+            sensitive: false,
+          },
+        },
+        isPublic: true,
+      },
+      'Pick-up': {
+        attributes: {
+          Description: { isPublic: true, sensitive: false },
+          'Driver Identifier': { isPublic: true, sensitive: true },
+          'Driver Identifier Exemption Justification': {
+            isPublic: true,
+            sensitive: false,
+          },
+          'Local Waste Classification Description': {
+            isPublic: true,
+            sensitive: false,
+          },
+          'Local Waste Classification ID': {
+            isPublic: true,
+            sensitive: false,
+          },
+          'Vehicle License Plate': { isPublic: true, sensitive: true },
+          'Vehicle Type': { isPublic: true, sensitive: false },
+        },
+        isPublic: true,
+      },
+      Recycled: {
+        attributes: {
+          Description: { isPublic: true, sensitive: false },
+        },
+        isPublic: true,
+      },
+      'Recycling Manifest': {
+        attributes: {
+          'Document Number': { isPublic: true, sensitive: false },
+          'Document Type': { isPublic: true, sensitive: false },
+          'Issue Date': { isPublic: true, sensitive: false },
+        },
+        isPublic: true,
+      },
+      Sorting: {
+        attributes: {
+          'Deducted Weight': { isPublic: true, sensitive: false },
+          Description: { isPublic: true, sensitive: false },
+          'Gross Weight': { isPublic: true, sensitive: false },
+        },
+        isPublic: true,
+      },
+      'Transport Manifest': {
+        attributes: {
+          'Document Number': { isPublic: true, sensitive: false },
+          'Document Type': { isPublic: true, sensitive: false },
+          'Exemption Justification': { isPublic: true, sensitive: false },
+          'Issue Date': { isPublic: true, sensitive: false },
+        },
+        isPublic: true,
+      },
+      Weighing: {
+        attributes: {
+          'Container Type': { isPublic: true, sensitive: false },
+          Description: { isPublic: true, sensitive: false },
+          'Gross Weight': { isPublic: true, sensitive: false },
+          'Scale Type': { isPublic: true, sensitive: false },
+          Tare: { isPublic: true, sensitive: false },
+          'Vehicle License Plate': { isPublic: true, sensitive: true },
+          'Weighing Capture Method': { isPublic: true, sensitive: false },
+        },
+        isPublic: true,
+      },
+    });
   });
 
   it('should treat only Processor and Recycler as open actors', () => {
@@ -60,11 +104,16 @@ describe('privacy-flags constants', () => {
     ]);
   });
 
-  it('should skip the internal actors and the rule-execution outputs', () => {
-    expect([...SKIPPED_ACTOR_LABELS].sort(sortAlphabetically)).toEqual([
-      'Integrator',
-      'METHODOLOGY PLATFORM',
+  it('should assert privacy flags only for the Hauler, Processor, Recycler, and Waste Generator actors', () => {
+    expect([...ASSERTABLE_ACTOR_LABELS].sort(sortAlphabetically)).toEqual([
+      'Hauler',
+      'Processor',
+      'Recycler',
+      'Waste Generator',
     ]);
+  });
+
+  it('should skip the rule-execution outputs', () => {
     expect([...SKIPPED_EVENT_NAMES].sort(sortAlphabetically)).toEqual([
       'GasID',
       'MassID Audit (BOLD Carbon)',

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.ts
@@ -36,9 +36,7 @@ const {
   WEIGHING,
 } = BoldDocumentEventName;
 
-const { INTEGRATOR, PROCESSOR, RECYCLER } = BoldActorType;
-
-const METHODOLOGY_PLATFORM_LABEL = 'METHODOLOGY PLATFORM';
+const { HAULER, PROCESSOR, RECYCLER, WASTE_GENERATOR } = BoldActorType;
 
 export interface AttributePrivacySpec {
   isPublic: boolean;
@@ -123,9 +121,11 @@ export const OPEN_ACTOR_LABELS: ReadonlySet<string> = new Set([
   RECYCLER,
 ]);
 
-export const SKIPPED_ACTOR_LABELS: ReadonlySet<string> = new Set([
-  INTEGRATOR,
-  METHODOLOGY_PLATFORM_LABEL,
+export const ASSERTABLE_ACTOR_LABELS: ReadonlySet<string> = new Set([
+  HAULER,
+  PROCESSOR,
+  RECYCLER,
+  WASTE_GENERATOR,
 ]);
 
 export const SKIPPED_EVENT_NAMES: ReadonlySet<string> = new Set([

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.constants.ts
@@ -1,0 +1,170 @@
+import {
+  BoldActorType,
+  BoldAttributeName,
+  BoldDocumentEventName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+const {
+  CONTAINER_TYPE,
+  DEDUCTED_WEIGHT,
+  DESCRIPTION,
+  DOCUMENT_NUMBER,
+  DOCUMENT_TYPE,
+  DRIVER_IDENTIFIER,
+  DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION,
+  EXEMPTION_JUSTIFICATION,
+  GROSS_WEIGHT,
+  ISSUE_DATE,
+  LOCAL_WASTE_CLASSIFICATION_DESCRIPTION,
+  LOCAL_WASTE_CLASSIFICATION_ID,
+  RECEIVING_OPERATOR_IDENTIFIER,
+  SCALE_TYPE,
+  TARE,
+  VEHICLE_LICENSE_PLATE,
+  VEHICLE_TYPE,
+  WEIGHING_CAPTURE_METHOD,
+} = BoldAttributeName;
+
+const {
+  ACTOR,
+  DROP_OFF,
+  PICK_UP,
+  RECYCLED,
+  RECYCLING_MANIFEST,
+  SORTING,
+  TRANSPORT_MANIFEST,
+  WEIGHING,
+} = BoldDocumentEventName;
+
+const { INTEGRATOR, PROCESSOR, RECYCLER } = BoldActorType;
+
+const METHODOLOGY_PLATFORM_LABEL = 'METHODOLOGY PLATFORM';
+
+export interface AttributePrivacySpec {
+  isPublic: boolean;
+  sensitive: boolean;
+}
+
+export interface EventPrivacySpec {
+  attributes: ReadonlyMap<string, AttributePrivacySpec>;
+  isPublic: boolean;
+}
+
+const PUBLIC: AttributePrivacySpec = { isPublic: true, sensitive: false };
+const PUBLIC_MASKED: AttributePrivacySpec = { isPublic: true, sensitive: true };
+
+const publicEvent = (
+  attributes: ReadonlyArray<readonly [BoldAttributeName, AttributePrivacySpec]>,
+): EventPrivacySpec => ({ attributes: new Map(attributes), isPublic: true });
+
+export const EVENT_PRIVACY_SPEC: ReadonlyMap<string, EventPrivacySpec> =
+  new Map<BoldDocumentEventName, EventPrivacySpec>([
+    [
+      DROP_OFF,
+      publicEvent([
+        [DESCRIPTION, PUBLIC],
+        [RECEIVING_OPERATOR_IDENTIFIER, PUBLIC],
+      ]),
+    ],
+    [
+      PICK_UP,
+      publicEvent([
+        [DESCRIPTION, PUBLIC],
+        [DRIVER_IDENTIFIER, PUBLIC_MASKED],
+        [DRIVER_IDENTIFIER_EXEMPTION_JUSTIFICATION, PUBLIC],
+        [LOCAL_WASTE_CLASSIFICATION_DESCRIPTION, PUBLIC],
+        [LOCAL_WASTE_CLASSIFICATION_ID, PUBLIC],
+        [VEHICLE_LICENSE_PLATE, PUBLIC_MASKED],
+        [VEHICLE_TYPE, PUBLIC],
+      ]),
+    ],
+    [RECYCLED, publicEvent([[DESCRIPTION, PUBLIC]])],
+    [
+      RECYCLING_MANIFEST,
+      publicEvent([
+        [DOCUMENT_NUMBER, PUBLIC],
+        [DOCUMENT_TYPE, PUBLIC],
+        [ISSUE_DATE, PUBLIC],
+      ]),
+    ],
+    [
+      SORTING,
+      publicEvent([
+        [DEDUCTED_WEIGHT, PUBLIC],
+        [DESCRIPTION, PUBLIC],
+        [GROSS_WEIGHT, PUBLIC],
+      ]),
+    ],
+    [
+      TRANSPORT_MANIFEST,
+      publicEvent([
+        [DOCUMENT_NUMBER, PUBLIC],
+        [DOCUMENT_TYPE, PUBLIC],
+        [EXEMPTION_JUSTIFICATION, PUBLIC],
+        [ISSUE_DATE, PUBLIC],
+      ]),
+    ],
+    [
+      WEIGHING,
+      publicEvent([
+        [CONTAINER_TYPE, PUBLIC],
+        [DESCRIPTION, PUBLIC],
+        [GROSS_WEIGHT, PUBLIC],
+        [SCALE_TYPE, PUBLIC],
+        [TARE, PUBLIC],
+        [VEHICLE_LICENSE_PLATE, PUBLIC_MASKED],
+        [WEIGHING_CAPTURE_METHOD, PUBLIC],
+      ]),
+    ],
+  ]);
+
+export const OPEN_ACTOR_LABELS: ReadonlySet<string> = new Set([
+  PROCESSOR,
+  RECYCLER,
+]);
+
+export const SKIPPED_ACTOR_LABELS: ReadonlySet<string> = new Set([
+  INTEGRATOR,
+  METHODOLOGY_PLATFORM_LABEL,
+]);
+
+export const SKIPPED_EVENT_NAMES: ReadonlySet<string> = new Set([
+  'GasID',
+  'MassID Audit (BOLD Carbon)',
+  'MassID Audit (BOLD Recycling)',
+  'RecycledID',
+]);
+
+export const PRIVACY_REASON_CODES = {
+  ACTOR_PRESERVE_SENSITIVE_DATA: 'PRIVACY_ACTOR_PRESERVE_SENSITIVE_DATA',
+  ATTRIBUTE_IS_PUBLIC: 'PRIVACY_ATTRIBUTE_IS_PUBLIC_MISMATCH',
+  ATTRIBUTE_SENSITIVE: 'PRIVACY_ATTRIBUTE_SENSITIVE_MISMATCH',
+  EVENT_IS_PUBLIC: 'PRIVACY_EVENT_IS_PUBLIC_MISMATCH',
+} as const;
+
+export const RESULT_COMMENTS = {
+  passed: {
+    ALL_FLAGS_MATCH: (validatedEvents: number) =>
+      `All privacy flags match the methodology specification across ${String(validatedEvents)} validated event(s).`,
+  },
+  reviewRequired: {
+    ACTOR_IS_PUBLIC: (label: string, expected: boolean) =>
+      `The "${ACTOR}" event labeled "${label}" must declare "isPublic" as ${String(expected)}.`,
+    ACTOR_PRESERVE_SENSITIVE_DATA: (label: string) =>
+      `The "${ACTOR}" event labeled "${label}" must not declare "preserveSensitiveData" as true, because the methodology requires this participant to be publicly identifiable.`,
+    ATTRIBUTE_IS_PUBLIC: (
+      eventName: string,
+      attributeName: string,
+      expected: boolean,
+    ) =>
+      `The "${attributeName}" attribute of the "${eventName}" event must declare "isPublic" as ${String(expected)}.`,
+    ATTRIBUTE_SENSITIVE: (
+      eventName: string,
+      attributeName: string,
+      expected: boolean,
+    ) =>
+      `The "${attributeName}" attribute of the "${eventName}" event must declare "sensitive" as ${String(expected)}.`,
+    EVENT_IS_PUBLIC: (eventName: string, expected: boolean) =>
+      `The "${eventName}" event must declare "isPublic" as ${String(expected)}.`,
+  },
+} as const;

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.lambda.e2e.spec.ts
@@ -1,6 +1,9 @@
 import { toDocumentKey } from '@carrot-fndn/shared/helpers';
 import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
-import { BoldDocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
+import {
+  type BoldDocumentEvent,
+  BoldDocumentEventName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
 import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
 import {
   prepareEnvironmentTestE2E,
@@ -10,6 +13,7 @@ import {
 } from '@carrot-fndn/shared/testing';
 import { faker } from '@faker-js/faker';
 
+import { PRIVACY_REASON_CODES } from './privacy-flags.constants';
 import { privacyFlagsLambda } from './privacy-flags.lambda';
 import {
   conformantEvent,
@@ -21,48 +25,52 @@ const { PICK_UP } = BoldDocumentEventName;
 describe('PrivacyFlagsLambda E2E', () => {
   const documentKeyPrefix = faker.string.uuid();
 
-  it.each([
-    {
-      externalEventsMap: conformantExternalEventsMap(),
-      resultStatus: 'PASSED',
-      scenario: 'all privacy flags match the methodology specification',
-    },
-    {
-      externalEventsMap: {
-        ...conformantExternalEventsMap(),
-        [PICK_UP]: { ...conformantEvent(PICK_UP), isPublic: false },
-      },
-      resultStatus: 'FAILED',
-      scenario: 'the Pick-up event declares isPublic as false',
-    },
-  ])(
-    'should return $resultStatus when $scenario',
-    async ({ externalEventsMap, resultStatus }) => {
-      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
-        .createMassIDDocuments({ externalEventsMap })
-        .createMassIDAuditDocuments()
-        .build();
+  const runLambda = async (
+    externalEventsMap: Record<string, BoldDocumentEvent>,
+  ): Promise<RuleOutput> => {
+    const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+      .createMassIDDocuments({ externalEventsMap })
+      .createMassIDAuditDocuments()
+      .build();
 
-      prepareEnvironmentTestE2E(
-        [massIDDocument, massIDAuditDocument].map((document) => ({
-          document,
-          documentKey: toDocumentKey({
-            documentId: document.id,
-            documentKeyPrefix,
-          }),
-        })),
-      );
-
-      const response = (await privacyFlagsLambda(
-        stubRuleInput({
+    prepareEnvironmentTestE2E(
+      [massIDDocument, massIDAuditDocument].map((document) => ({
+        document,
+        documentKey: toDocumentKey({
+          documentId: document.id,
           documentKeyPrefix,
-          parentDocumentId: massIDDocument.id,
         }),
-        stubContext(),
-        () => stubRuleResponse(),
-      )) as RuleOutput;
+      })),
+    );
 
-      expect(response.resultStatus).toBe(resultStatus);
-    },
-  );
+    return (await privacyFlagsLambda(
+      stubRuleInput({
+        documentKeyPrefix,
+        parentDocumentId: massIDDocument.id,
+      }),
+      stubContext(),
+      () => stubRuleResponse(),
+    )) as RuleOutput;
+  };
+
+  it('should return PASSED when all privacy flags match the methodology specification', async () => {
+    const response = await runLambda(conformantExternalEventsMap());
+
+    expect(response.resultStatus).toBe('PASSED');
+  });
+
+  it('should return FAILED with the review reason that detected the violation when the Pick-up event declares isPublic as false', async () => {
+    const response = await runLambda({
+      ...conformantExternalEventsMap(),
+      [PICK_UP]: { ...conformantEvent(PICK_UP), isPublic: false },
+    });
+
+    expect(response.resultStatus).toBe('FAILED');
+    expect(response.resultContent?.['reviewReasons']).toContainEqual(
+      expect.objectContaining({
+        code: PRIVACY_REASON_CODES.EVENT_IS_PUBLIC,
+        eventName: PICK_UP,
+      }),
+    );
+  });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.lambda.e2e.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.lambda.e2e.spec.ts
@@ -1,0 +1,68 @@
+import { toDocumentKey } from '@carrot-fndn/shared/helpers';
+import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { BoldDocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
+import { type RuleOutput } from '@carrot-fndn/shared/rule/types';
+import {
+  prepareEnvironmentTestE2E,
+  stubContext,
+  stubRuleInput,
+  stubRuleResponse,
+} from '@carrot-fndn/shared/testing';
+import { faker } from '@faker-js/faker';
+
+import { privacyFlagsLambda } from './privacy-flags.lambda';
+import {
+  conformantEvent,
+  conformantExternalEventsMap,
+} from './privacy-flags.test-cases';
+
+const { PICK_UP } = BoldDocumentEventName;
+
+describe('PrivacyFlagsLambda E2E', () => {
+  const documentKeyPrefix = faker.string.uuid();
+
+  it.each([
+    {
+      externalEventsMap: conformantExternalEventsMap(),
+      resultStatus: 'PASSED',
+      scenario: 'all privacy flags match the methodology specification',
+    },
+    {
+      externalEventsMap: {
+        ...conformantExternalEventsMap(),
+        [PICK_UP]: { ...conformantEvent(PICK_UP), isPublic: false },
+      },
+      resultStatus: 'FAILED',
+      scenario: 'the Pick-up event declares isPublic as false',
+    },
+  ])(
+    'should return $resultStatus when $scenario',
+    async ({ externalEventsMap, resultStatus }) => {
+      const { massIDAuditDocument, massIDDocument } = new BoldStubsBuilder()
+        .createMassIDDocuments({ externalEventsMap })
+        .createMassIDAuditDocuments()
+        .build();
+
+      prepareEnvironmentTestE2E(
+        [massIDDocument, massIDAuditDocument].map((document) => ({
+          document,
+          documentKey: toDocumentKey({
+            documentId: document.id,
+            documentKeyPrefix,
+          }),
+        })),
+      );
+
+      const response = (await privacyFlagsLambda(
+        stubRuleInput({
+          documentKeyPrefix,
+          parentDocumentId: massIDDocument.id,
+        }),
+        stubContext(),
+        () => stubRuleResponse(),
+      )) as RuleOutput;
+
+      expect(response.resultStatus).toBe(resultStatus);
+    },
+  );
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.lambda.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.lambda.ts
@@ -1,0 +1,7 @@
+import { wrapRuleIntoLambdaHandler } from '@carrot-fndn/shared/lambda/wrapper';
+
+import { PrivacyFlagsProcessor } from './privacy-flags.processor';
+
+const instance = new PrivacyFlagsProcessor();
+
+export const privacyFlagsLambda = wrapRuleIntoLambdaHandler(instance);

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
@@ -5,6 +5,7 @@ import {
   stubDocumentEventAttribute,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
 import {
+  BoldActorType,
   BoldAttributeName,
   type BoldDocument,
   type BoldDocumentEvent,
@@ -17,13 +18,17 @@ import type { PrivacyFlagsResultContent } from './privacy-flags.result-content.t
 import { PRIVACY_REASON_CODES } from './privacy-flags.constants';
 import { PrivacyFlagsProcessor } from './privacy-flags.processor';
 import {
+  actorEventKey,
   conformantEvent,
   conformantExternalEventsMap,
 } from './privacy-flags.test-cases';
 
 const { DESCRIPTION, VEHICLE_LICENSE_PLATE } = BoldAttributeName;
-const { DROP_OFF, PICK_UP } = BoldDocumentEventName;
+const { ACTOR, DROP_OFF, PICK_UP } = BoldDocumentEventName;
+const { HAULER, INTEGRATOR, PROCESSOR, RECYCLER, WASTE_GENERATOR } =
+  BoldActorType;
 
+const METHODOLOGY_PLATFORM_LABEL = 'METHODOLOGY PLATFORM';
 const SKIPPED_EVENT_NAME = 'MassID Audit (BOLD Recycling)';
 const UNKNOWN_EVENT_NAME = 'Unlisted Event';
 const UNKNOWN_ATTRIBUTE_NAME = 'Unlisted Attribute';
@@ -268,5 +273,133 @@ describe('PrivacyFlagsProcessor', () => {
         field: 'sensitive',
       }),
     );
+  });
+
+  describe('ACTOR events', () => {
+    it.each([{ label: PROCESSOR }, { label: RECYCLER }])(
+      'should add a review reason when the $label actor declares preserveSensitiveData as true',
+      async ({ label }) => {
+        const massIDDocument = buildMassID({
+          [actorEventKey(label)]: stubDocumentEvent({
+            isPublic: true,
+            label,
+            name: ACTOR,
+            preserveSensitiveData: true,
+          }),
+        });
+
+        const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+        expect(resultStatus).toBe('REVIEW_REQUIRED');
+        expect(resultContent.reviewReasons).toContainEqual(
+          expect.objectContaining({
+            actual: true,
+            code: PRIVACY_REASON_CODES.ACTOR_PRESERVE_SENSITIVE_DATA,
+            eventLabel: label,
+            eventName: ACTOR,
+            expected: false,
+            field: 'preserveSensitiveData',
+          }),
+        );
+      },
+    );
+
+    it.each([
+      { label: HAULER, preserveSensitiveData: true },
+      { label: HAULER, preserveSensitiveData: false },
+      { label: HAULER, preserveSensitiveData: undefined },
+      { label: WASTE_GENERATOR, preserveSensitiveData: true },
+      { label: WASTE_GENERATOR, preserveSensitiveData: false },
+      { label: WASTE_GENERATOR, preserveSensitiveData: undefined },
+    ])(
+      'should not add a preserveSensitiveData review reason for the $label actor when preserveSensitiveData is $preserveSensitiveData',
+      async ({ label, preserveSensitiveData }) => {
+        const massIDDocument = buildMassID({
+          [actorEventKey(label)]: stubDocumentEvent({
+            isPublic: true,
+            label,
+            name: ACTOR,
+            preserveSensitiveData,
+          }),
+        });
+
+        const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+        expect(resultStatus).toBe('PASSED');
+        expect(resultContent.reviewReasons).not.toContainEqual(
+          expect.objectContaining({
+            eventLabel: label,
+            field: 'preserveSensitiveData',
+          }),
+        );
+      },
+    );
+
+    it('should add a review reason when the Processor actor declares isPublic as false', async () => {
+      const massIDDocument = buildMassID({
+        [actorEventKey(PROCESSOR)]: stubDocumentEvent({
+          isPublic: false,
+          label: PROCESSOR,
+          name: ACTOR,
+          preserveSensitiveData: false,
+        }),
+      });
+
+      const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+      expect(resultStatus).toBe('REVIEW_REQUIRED');
+      expect(resultContent.reviewReasons).toContainEqual(
+        expect.objectContaining({
+          actual: false,
+          code: PRIVACY_REASON_CODES.EVENT_IS_PUBLIC,
+          eventLabel: PROCESSOR,
+          eventName: ACTOR,
+          expected: true,
+          field: 'isPublic',
+        }),
+      );
+    });
+
+    it('should skip the Integrator and METHODOLOGY PLATFORM actors even with hostile privacy flags', async () => {
+      const massIDDocument = buildMassID({
+        [actorEventKey(INTEGRATOR)]: stubDocumentEvent({
+          isPublic: false,
+          label: INTEGRATOR,
+          name: ACTOR,
+          preserveSensitiveData: true,
+        }),
+        [actorEventKey(METHODOLOGY_PLATFORM_LABEL)]: stubDocumentEvent({
+          isPublic: false,
+          label: METHODOLOGY_PLATFORM_LABEL,
+          name: ACTOR,
+          preserveSensitiveData: true,
+        }),
+      });
+
+      const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+      expect(resultStatus).toBe('PASSED');
+      expect(resultContent.reviewReasons).toEqual([]);
+      expect(resultContent.notValidated).not.toContainEqual(
+        expect.objectContaining({ eventName: ACTOR }),
+      );
+    });
+
+    it('should skip an ACTOR event with no label even when isPublic is false', async () => {
+      const massIDDocument = buildMassID({
+        'ACTOR-unlabeled': stubDocumentEvent({
+          isPublic: false,
+          name: ACTOR,
+        }),
+      });
+
+      const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+      expect(resultStatus).toBe('PASSED');
+      expect(resultContent.reviewReasons).toEqual([]);
+      expect(resultContent.notValidated).not.toContainEqual(
+        expect.objectContaining({ eventName: ACTOR }),
+      );
+    });
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
@@ -1,0 +1,25 @@
+import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
+import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import { stubRuleInput } from '@carrot-fndn/shared/testing';
+
+import { PrivacyFlagsProcessor } from './privacy-flags.processor';
+
+vi.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
+
+describe('PrivacyFlagsProcessor', () => {
+  const ruleDataProcessor = new PrivacyFlagsProcessor();
+  const documentLoaderService = vi.mocked(loadDocument);
+
+  it('should return a result for a MassID document', async () => {
+    const ruleInput = stubRuleInput();
+    const { massIDDocument } = new BoldStubsBuilder()
+      .createMassIDDocuments()
+      .build();
+
+    documentLoaderService.mockResolvedValueOnce(massIDDocument);
+
+    const ruleOutput = await ruleDataProcessor.process(ruleInput);
+
+    expect(ruleOutput.resultStatus).toBe('PASSED');
+  });
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
@@ -25,7 +25,7 @@ import {
 
 const { DESCRIPTION, VEHICLE_LICENSE_PLATE } = BoldAttributeName;
 const { ACTOR, DROP_OFF, PICK_UP } = BoldDocumentEventName;
-const { HAULER, INTEGRATOR, PROCESSOR, RECYCLER, WASTE_GENERATOR } =
+const { AUDITOR, HAULER, INTEGRATOR, PROCESSOR, RECYCLER, WASTE_GENERATOR } =
   BoldActorType;
 
 const METHODOLOGY_PLATFORM_LABEL = 'METHODOLOGY PLATFORM';
@@ -51,6 +51,7 @@ describe('PrivacyFlagsProcessor', () => {
   const evaluate = async (
     massIDDocument: BoldDocument,
   ): Promise<{
+    resultComment: string | undefined;
     resultContent: PrivacyFlagsResultContent;
     resultStatus: string;
   }> => {
@@ -59,13 +60,43 @@ describe('PrivacyFlagsProcessor', () => {
     const ruleOutput = await ruleDataProcessor.process(stubRuleInput());
 
     return {
+      resultComment: ruleOutput.resultComment,
       resultContent: ruleOutput.resultContent as PrivacyFlagsResultContent,
       resultStatus: ruleOutput.resultStatus,
     };
   };
 
   it('should return PASSED with no review reasons for a conformant document', async () => {
-    const { resultContent, resultStatus } = await evaluate(buildMassID());
+    const { resultComment, resultContent, resultStatus } =
+      await evaluate(buildMassID());
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.reviewReasons).toEqual([]);
+    expect(resultComment).toBe(
+      'All privacy flags match the methodology specification across 11 validated event(s).',
+    );
+  });
+
+  it('should treat an attribute with the sensitive property omitted as sensitive: false', async () => {
+    const pickUpEvent = conformantEvent(PICK_UP);
+    const massIDDocument = buildMassID({
+      [PICK_UP]: {
+        ...pickUpEvent,
+        metadata: {
+          attributes: (pickUpEvent.metadata?.attributes ?? []).map(
+            (attribute) =>
+              attribute.name === DESCRIPTION
+                ? stubDocumentEventAttribute({
+                    isPublic: true,
+                    name: DESCRIPTION,
+                  })
+                : attribute,
+          ),
+        },
+      },
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
 
     expect(resultStatus).toBe('PASSED');
     expect(resultContent.reviewReasons).toEqual([]);
@@ -360,7 +391,7 @@ describe('PrivacyFlagsProcessor', () => {
       );
     });
 
-    it('should skip the Integrator and METHODOLOGY PLATFORM actors even with hostile privacy flags', async () => {
+    it('should skip the Integrator and METHODOLOGY PLATFORM labels even with hostile privacy flags, because they are outside the assertable actor allow-list', async () => {
       const massIDDocument = buildMassID({
         [actorEventKey(INTEGRATOR)]: stubDocumentEvent({
           isPublic: false,
@@ -380,6 +411,24 @@ describe('PrivacyFlagsProcessor', () => {
 
       expect(resultStatus).toBe('PASSED');
       expect(resultContent.reviewReasons).toEqual([]);
+    });
+
+    it('should skip a BoldActorType label outside the assertable actor allow-list, such as Auditor, even with hostile privacy flags', async () => {
+      const massIDDocument = buildMassID({
+        [actorEventKey(AUDITOR)]: stubDocumentEvent({
+          isPublic: false,
+          label: AUDITOR,
+          name: ACTOR,
+          preserveSensitiveData: true,
+        }),
+      });
+
+      const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+      expect(resultStatus).toBe('PASSED');
+      expect(resultContent.reviewReasons).not.toContainEqual(
+        expect.objectContaining({ eventLabel: AUDITOR }),
+      );
     });
 
     it('should skip an ACTOR event with no label even when isPublic is false', async () => {

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
@@ -380,9 +380,6 @@ describe('PrivacyFlagsProcessor', () => {
 
       expect(resultStatus).toBe('PASSED');
       expect(resultContent.reviewReasons).toEqual([]);
-      expect(resultContent.notValidated).not.toContainEqual(
-        expect.objectContaining({ eventName: ACTOR }),
-      );
     });
 
     it('should skip an ACTOR event with no label even when isPublic is false', async () => {
@@ -397,9 +394,6 @@ describe('PrivacyFlagsProcessor', () => {
 
       expect(resultStatus).toBe('PASSED');
       expect(resultContent.reviewReasons).toEqual([]);
-      expect(resultContent.notValidated).not.toContainEqual(
-        expect.objectContaining({ eventName: ACTOR }),
-      );
     });
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.spec.ts
@@ -1,8 +1,41 @@
 import { loadDocument } from '@carrot-fndn/shared/methodologies/bold/io-helpers';
-import { BoldStubsBuilder } from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  BoldStubsBuilder,
+  stubDocumentEvent,
+  stubDocumentEventAttribute,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  BoldAttributeName,
+  type BoldDocument,
+  type BoldDocumentEvent,
+  BoldDocumentEventName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
 import { stubRuleInput } from '@carrot-fndn/shared/testing';
 
+import type { PrivacyFlagsResultContent } from './privacy-flags.result-content.types';
+
+import { PRIVACY_REASON_CODES } from './privacy-flags.constants';
 import { PrivacyFlagsProcessor } from './privacy-flags.processor';
+import {
+  conformantEvent,
+  conformantExternalEventsMap,
+} from './privacy-flags.test-cases';
+
+const { DESCRIPTION, VEHICLE_LICENSE_PLATE } = BoldAttributeName;
+const { DROP_OFF, PICK_UP } = BoldDocumentEventName;
+
+const SKIPPED_EVENT_NAME = 'MassID Audit (BOLD Recycling)';
+const UNKNOWN_EVENT_NAME = 'Unlisted Event';
+const UNKNOWN_ATTRIBUTE_NAME = 'Unlisted Attribute';
+
+const buildMassID = (
+  overrides: Record<string, BoldDocumentEvent> = {},
+): BoldDocument =>
+  new BoldStubsBuilder()
+    .createMassIDDocuments({
+      externalEventsMap: { ...conformantExternalEventsMap(), ...overrides },
+    })
+    .build().massIDDocument;
 
 vi.mock('@carrot-fndn/shared/methodologies/bold/io-helpers');
 
@@ -10,16 +43,230 @@ describe('PrivacyFlagsProcessor', () => {
   const ruleDataProcessor = new PrivacyFlagsProcessor();
   const documentLoaderService = vi.mocked(loadDocument);
 
-  it('should return a result for a MassID document', async () => {
-    const ruleInput = stubRuleInput();
-    const { massIDDocument } = new BoldStubsBuilder()
-      .createMassIDDocuments()
-      .build();
-
+  const evaluate = async (
+    massIDDocument: BoldDocument,
+  ): Promise<{
+    resultContent: PrivacyFlagsResultContent;
+    resultStatus: string;
+  }> => {
     documentLoaderService.mockResolvedValueOnce(massIDDocument);
 
-    const ruleOutput = await ruleDataProcessor.process(ruleInput);
+    const ruleOutput = await ruleDataProcessor.process(stubRuleInput());
 
-    expect(ruleOutput.resultStatus).toBe('PASSED');
+    return {
+      resultContent: ruleOutput.resultContent as PrivacyFlagsResultContent,
+      resultStatus: ruleOutput.resultStatus,
+    };
+  };
+
+  it('should return PASSED with no review reasons for a conformant document', async () => {
+    const { resultContent, resultStatus } = await evaluate(buildMassID());
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.reviewReasons).toEqual([]);
+  });
+
+  it('should treat a missing externalEvents list as an empty list', async () => {
+    const massIDDocument: BoldDocument = {
+      ...buildMassID(),
+      externalEvents: undefined,
+    };
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent).toEqual({ notValidated: [], reviewReasons: [] });
+  });
+
+  it('should skip events whose name is in SKIPPED_EVENT_NAMES even when their flags are wrong', async () => {
+    const massIDDocument = buildMassID({
+      [SKIPPED_EVENT_NAME]: stubDocumentEvent({
+        isPublic: false,
+        name: SKIPPED_EVENT_NAME,
+      }),
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.reviewReasons).toEqual([]);
+    expect(resultContent.notValidated).not.toContainEqual(
+      expect.objectContaining({ eventName: SKIPPED_EVENT_NAME }),
+    );
+  });
+
+  it('should record notValidated when the event name has no entry in EVENT_PRIVACY_SPEC', async () => {
+    const massIDDocument = buildMassID({
+      [UNKNOWN_EVENT_NAME]: stubDocumentEvent({
+        isPublic: true,
+        name: UNKNOWN_EVENT_NAME,
+      }),
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.notValidated).toContainEqual(
+      expect.objectContaining({ eventName: UNKNOWN_EVENT_NAME }),
+    );
+  });
+
+  it('should add a review reason when an event isPublic does not match the spec', async () => {
+    const massIDDocument = buildMassID({
+      [PICK_UP]: { ...conformantEvent(PICK_UP), isPublic: false },
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('REVIEW_REQUIRED');
+    expect(resultContent.reviewReasons).toContainEqual(
+      expect.objectContaining({
+        actual: false,
+        code: PRIVACY_REASON_CODES.EVENT_IS_PUBLIC,
+        eventName: PICK_UP,
+        expected: true,
+        field: 'isPublic',
+      }),
+    );
+  });
+
+  it('should skip attribute validation when the event has no metadata', async () => {
+    const massIDDocument = buildMassID({
+      [DROP_OFF]: stubDocumentEvent({ isPublic: true, name: DROP_OFF }),
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.reviewReasons).toEqual([]);
+  });
+
+  it('should skip attribute validation when the event metadata has no attributes', async () => {
+    const massIDDocument = buildMassID({
+      [DROP_OFF]: stubDocumentEvent({
+        isPublic: true,
+        metadata: {},
+        name: DROP_OFF,
+      }),
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.reviewReasons).toEqual([]);
+  });
+
+  it('should record notValidated when an attribute has no entry in the event spec', async () => {
+    const pickUpEvent = conformantEvent(PICK_UP);
+    const massIDDocument = buildMassID({
+      [PICK_UP]: {
+        ...pickUpEvent,
+        metadata: {
+          attributes: [
+            ...(pickUpEvent.metadata?.attributes ?? []),
+            stubDocumentEventAttribute({
+              isPublic: true,
+              name: UNKNOWN_ATTRIBUTE_NAME,
+            }),
+          ],
+        },
+      },
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('PASSED');
+    expect(resultContent.notValidated).toContainEqual(
+      expect.objectContaining({
+        attributeName: UNKNOWN_ATTRIBUTE_NAME,
+        eventName: PICK_UP,
+      }),
+    );
+  });
+
+  it('should add a review reason when an attribute isPublic does not match the spec', async () => {
+    const pickUpEvent = conformantEvent(PICK_UP);
+    const massIDDocument = buildMassID({
+      [PICK_UP]: {
+        ...pickUpEvent,
+        metadata: {
+          attributes: (pickUpEvent.metadata?.attributes ?? []).map(
+            (attribute) =>
+              attribute.name === DESCRIPTION
+                ? { ...attribute, isPublic: false }
+                : attribute,
+          ),
+        },
+      },
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('REVIEW_REQUIRED');
+    expect(resultContent.reviewReasons).toContainEqual(
+      expect.objectContaining({
+        actual: false,
+        attributeName: DESCRIPTION,
+        code: PRIVACY_REASON_CODES.ATTRIBUTE_IS_PUBLIC,
+        eventName: PICK_UP,
+        expected: true,
+        field: 'isPublic',
+      }),
+    );
+  });
+
+  it('should add review reasons when an attribute sensitive flag does not match the spec, in both directions', async () => {
+    const pickUpEvent = conformantEvent(PICK_UP);
+    const massIDDocument = buildMassID({
+      [PICK_UP]: {
+        ...pickUpEvent,
+        metadata: {
+          attributes: (pickUpEvent.metadata?.attributes ?? []).map(
+            (attribute) => {
+              if (attribute.name === VEHICLE_LICENSE_PLATE) {
+                return stubDocumentEventAttribute({
+                  isPublic: true,
+                  name: VEHICLE_LICENSE_PLATE,
+                });
+              }
+
+              if (attribute.name === DESCRIPTION) {
+                return stubDocumentEventAttribute({
+                  isPublic: true,
+                  name: DESCRIPTION,
+                  sensitive: true,
+                });
+              }
+
+              return attribute;
+            },
+          ),
+        },
+      },
+    });
+
+    const { resultContent, resultStatus } = await evaluate(massIDDocument);
+
+    expect(resultStatus).toBe('REVIEW_REQUIRED');
+    expect(resultContent.reviewReasons).toContainEqual(
+      expect.objectContaining({
+        actual: undefined,
+        attributeName: VEHICLE_LICENSE_PLATE,
+        code: PRIVACY_REASON_CODES.ATTRIBUTE_SENSITIVE,
+        eventName: PICK_UP,
+        expected: true,
+        field: 'sensitive',
+      }),
+    );
+    expect(resultContent.reviewReasons).toContainEqual(
+      expect.objectContaining({
+        actual: true,
+        attributeName: DESCRIPTION,
+        code: PRIVACY_REASON_CODES.ATTRIBUTE_SENSITIVE,
+        eventName: PICK_UP,
+        expected: false,
+        field: 'sensitive',
+      }),
+    );
   });
 });

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
@@ -1,0 +1,21 @@
+import type { EvaluateResultOutput } from '@carrot-fndn/shared/rule/standard-data-processor';
+
+import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/bold/processors';
+import {
+  type BoldDocument,
+  type BoldDocumentEvent,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+interface RuleSubject {
+  events: BoldDocumentEvent[];
+}
+
+export class PrivacyFlagsProcessor extends ParentDocumentRuleProcessor<RuleSubject> {
+  protected override evaluateResult(): EvaluateResultOutput {
+    return { resultStatus: 'PASSED' };
+  }
+
+  protected override getRuleSubject(document: BoldDocument): RuleSubject {
+    return { events: document.externalEvents ?? [] };
+  }
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
@@ -4,6 +4,7 @@ import { ParentDocumentRuleProcessor } from '@carrot-fndn/shared/methodologies/b
 import {
   type BoldDocument,
   type BoldDocumentEvent,
+  BoldDocumentEventName,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
 import type {
@@ -15,10 +16,14 @@ import type {
 import {
   EVENT_PRIVACY_SPEC,
   type EventPrivacySpec,
+  OPEN_ACTOR_LABELS,
   PRIVACY_REASON_CODES,
   RESULT_COMMENTS,
+  SKIPPED_ACTOR_LABELS,
   SKIPPED_EVENT_NAMES,
 } from './privacy-flags.constants';
+
+const { ACTOR } = BoldDocumentEventName;
 
 interface RuleSubject {
   events: BoldDocumentEvent[];
@@ -34,6 +39,14 @@ export class PrivacyFlagsProcessor extends ParentDocumentRuleProcessor<RuleSubje
 
     for (const event of events) {
       if (SKIPPED_EVENT_NAMES.has(event.name)) {
+        continue;
+      }
+
+      if (event.name === ACTOR) {
+        if (this.validateActorEvent(event, reviewReasons)) {
+          validatedEvents += 1;
+        }
+
         continue;
       }
 
@@ -72,6 +85,47 @@ export class PrivacyFlagsProcessor extends ParentDocumentRuleProcessor<RuleSubje
 
   protected override getRuleSubject(document: BoldDocument): RuleSubject {
     return { events: document.externalEvents ?? [] };
+  }
+
+  private validateActorEvent(
+    event: BoldDocumentEvent,
+    reviewReasons: PrivacyReviewReason[],
+  ): boolean {
+    const { label } = event;
+
+    if (label === undefined || SKIPPED_ACTOR_LABELS.has(label)) {
+      return false;
+    }
+
+    if (!event.isPublic) {
+      reviewReasons.push({
+        actual: event.isPublic,
+        code: PRIVACY_REASON_CODES.EVENT_IS_PUBLIC,
+        description: RESULT_COMMENTS.reviewRequired.ACTOR_IS_PUBLIC(
+          label,
+          true,
+        ),
+        eventLabel: label,
+        eventName: event.name,
+        expected: true,
+        field: 'isPublic',
+      });
+    }
+
+    if (OPEN_ACTOR_LABELS.has(label) && event.preserveSensitiveData === true) {
+      reviewReasons.push({
+        actual: event.preserveSensitiveData,
+        code: PRIVACY_REASON_CODES.ACTOR_PRESERVE_SENSITIVE_DATA,
+        description:
+          RESULT_COMMENTS.reviewRequired.ACTOR_PRESERVE_SENSITIVE_DATA(label),
+        eventLabel: label,
+        eventName: event.name,
+        expected: false,
+        field: 'preserveSensitiveData',
+      });
+    }
+
+    return true;
   }
 
   private validateEvent(

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
@@ -6,16 +6,136 @@ import {
   type BoldDocumentEvent,
 } from '@carrot-fndn/shared/methodologies/bold/types';
 
+import type {
+  NotValidatedEntry,
+  PrivacyFlagsResultContent,
+  PrivacyReviewReason,
+} from './privacy-flags.result-content.types';
+
+import {
+  EVENT_PRIVACY_SPEC,
+  type EventPrivacySpec,
+  PRIVACY_REASON_CODES,
+  RESULT_COMMENTS,
+  SKIPPED_EVENT_NAMES,
+} from './privacy-flags.constants';
+
 interface RuleSubject {
   events: BoldDocumentEvent[];
 }
 
 export class PrivacyFlagsProcessor extends ParentDocumentRuleProcessor<RuleSubject> {
-  protected override evaluateResult(): EvaluateResultOutput {
-    return { resultStatus: 'PASSED' };
+  protected override evaluateResult({
+    events,
+  }: RuleSubject): EvaluateResultOutput {
+    const notValidated: NotValidatedEntry[] = [];
+    const reviewReasons: PrivacyReviewReason[] = [];
+    let validatedEvents = 0;
+
+    for (const event of events) {
+      if (SKIPPED_EVENT_NAMES.has(event.name)) {
+        continue;
+      }
+
+      const eventSpec = EVENT_PRIVACY_SPEC.get(event.name);
+
+      if (eventSpec === undefined) {
+        notValidated.push({ eventName: event.name });
+        continue;
+      }
+
+      validatedEvents += 1;
+      this.validateEvent(event, eventSpec, notValidated, reviewReasons);
+    }
+
+    const resultContent: PrivacyFlagsResultContent = {
+      notValidated,
+      reviewReasons,
+    };
+
+    if (reviewReasons.length > 0) {
+      return {
+        resultComment: reviewReasons
+          .map((reason) => reason.description)
+          .join(' '),
+        resultContent,
+        resultStatus: 'REVIEW_REQUIRED',
+      };
+    }
+
+    return {
+      resultComment: RESULT_COMMENTS.passed.ALL_FLAGS_MATCH(validatedEvents),
+      resultContent,
+      resultStatus: 'PASSED',
+    };
   }
 
   protected override getRuleSubject(document: BoldDocument): RuleSubject {
     return { events: document.externalEvents ?? [] };
+  }
+
+  private validateEvent(
+    event: BoldDocumentEvent,
+    eventSpec: EventPrivacySpec,
+    notValidated: NotValidatedEntry[],
+    reviewReasons: PrivacyReviewReason[],
+  ): void {
+    if (event.isPublic !== eventSpec.isPublic) {
+      reviewReasons.push({
+        actual: event.isPublic,
+        code: PRIVACY_REASON_CODES.EVENT_IS_PUBLIC,
+        description: RESULT_COMMENTS.reviewRequired.EVENT_IS_PUBLIC(
+          event.name,
+          eventSpec.isPublic,
+        ),
+        eventName: event.name,
+        expected: eventSpec.isPublic,
+        field: 'isPublic',
+      });
+    }
+
+    for (const attribute of event.metadata?.attributes ?? []) {
+      const attributeSpec = eventSpec.attributes.get(attribute.name);
+
+      if (attributeSpec === undefined) {
+        notValidated.push({
+          attributeName: attribute.name,
+          eventName: event.name,
+        });
+        continue;
+      }
+
+      if (attribute.isPublic !== attributeSpec.isPublic) {
+        reviewReasons.push({
+          actual: attribute.isPublic,
+          attributeName: attribute.name,
+          code: PRIVACY_REASON_CODES.ATTRIBUTE_IS_PUBLIC,
+          description: RESULT_COMMENTS.reviewRequired.ATTRIBUTE_IS_PUBLIC(
+            event.name,
+            attribute.name,
+            attributeSpec.isPublic,
+          ),
+          eventName: event.name,
+          expected: attributeSpec.isPublic,
+          field: 'isPublic',
+        });
+      }
+
+      if ((attribute.sensitive === true) !== attributeSpec.sensitive) {
+        reviewReasons.push({
+          actual: attribute.sensitive,
+          attributeName: attribute.name,
+          code: PRIVACY_REASON_CODES.ATTRIBUTE_SENSITIVE,
+          description: RESULT_COMMENTS.reviewRequired.ATTRIBUTE_SENSITIVE(
+            event.name,
+            attribute.name,
+            attributeSpec.sensitive,
+          ),
+          eventName: event.name,
+          expected: attributeSpec.sensitive,
+          field: 'sensitive',
+        });
+      }
+    }
   }
 }

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.processor.ts
@@ -14,12 +14,12 @@ import type {
 } from './privacy-flags.result-content.types';
 
 import {
+  ASSERTABLE_ACTOR_LABELS,
   EVENT_PRIVACY_SPEC,
   type EventPrivacySpec,
   OPEN_ACTOR_LABELS,
   PRIVACY_REASON_CODES,
   RESULT_COMMENTS,
-  SKIPPED_ACTOR_LABELS,
   SKIPPED_EVENT_NAMES,
 } from './privacy-flags.constants';
 
@@ -93,7 +93,7 @@ export class PrivacyFlagsProcessor extends ParentDocumentRuleProcessor<RuleSubje
   ): boolean {
     const { label } = event;
 
-    if (label === undefined || SKIPPED_ACTOR_LABELS.has(label)) {
+    if (label === undefined || !ASSERTABLE_ACTOR_LABELS.has(label)) {
       return false;
     }
 

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.result-content.types.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.result-content.types.ts
@@ -1,0 +1,25 @@
+import type { ReviewReason } from '@carrot-fndn/shared/document-extractor';
+
+export interface NotValidatedEntry {
+  attributeName?: string;
+  eventName: string;
+}
+
+export type PrivacyFlagField =
+  | 'isPublic'
+  | 'preserveSensitiveData'
+  | 'sensitive';
+
+export interface PrivacyFlagsResultContent {
+  notValidated: NotValidatedEntry[];
+  reviewReasons: PrivacyReviewReason[];
+}
+
+export interface PrivacyReviewReason extends ReviewReason {
+  actual: boolean | undefined;
+  attributeName?: string;
+  eventLabel?: string;
+  eventName: string;
+  expected: boolean;
+  field: PrivacyFlagField;
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.rule-definition.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.rule-definition.ts
@@ -1,0 +1,21 @@
+import type { BaseRuleDefinition } from '@carrot-fndn/shared/rule/types';
+
+import { BoldDocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
+
+export const ruleDefinition = {
+  description:
+    'Validates that the privacy flags declared on methodology-specified MassID events and attributes match the BOLD methodology specification.',
+  events: [
+    BoldDocumentEventName.ACTOR,
+    BoldDocumentEventName.DROP_OFF,
+    BoldDocumentEventName.PICK_UP,
+    BoldDocumentEventName.RECYCLED,
+    BoldDocumentEventName.RECYCLING_MANIFEST,
+    BoldDocumentEventName.SORTING,
+    BoldDocumentEventName.TRANSPORT_MANIFEST,
+    BoldDocumentEventName.WEIGHING,
+  ],
+  name: 'Privacy Flags',
+  slug: 'privacy-flags',
+  version: '1.0.0',
+} as const satisfies BaseRuleDefinition;

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.test-cases.ts
@@ -1,0 +1,71 @@
+import type { BoldDocumentEvent } from '@carrot-fndn/shared/methodologies/bold/types';
+
+import {
+  stubDocumentEvent,
+  stubDocumentEventAttribute,
+} from '@carrot-fndn/shared/methodologies/bold/testing';
+import {
+  BoldActorType,
+  BoldDocumentEventName,
+} from '@carrot-fndn/shared/methodologies/bold/types';
+
+import { EVENT_PRIVACY_SPEC } from './privacy-flags.constants';
+
+const { ACTOR } = BoldDocumentEventName;
+const { HAULER, PROCESSOR, RECYCLER, WASTE_GENERATOR } = BoldActorType;
+
+export const SPECIFIED_EVENT_NAMES = [...EVENT_PRIVACY_SPEC.keys()];
+
+export const ASSERTABLE_ACTOR_LABELS = [
+  HAULER,
+  PROCESSOR,
+  RECYCLER,
+  WASTE_GENERATOR,
+];
+
+export const actorEventKey = (label: string): string => `${ACTOR}-${label}`;
+
+export const conformantEvent = (eventName: string): BoldDocumentEvent => {
+  const eventSpec = EVENT_PRIVACY_SPEC.get(eventName);
+
+  return stubDocumentEvent({
+    isPublic: true,
+    metadata: {
+      attributes: [...(eventSpec?.attributes ?? [])].map(
+        ([attributeName, attributeSpec]) =>
+          stubDocumentEventAttribute({
+            isPublic: attributeSpec.isPublic,
+            name: attributeName,
+            sensitive: attributeSpec.sensitive,
+          }),
+      ),
+    },
+    name: eventName,
+  });
+};
+
+export const conformantActorEvent = (label: string): BoldDocumentEvent =>
+  stubDocumentEvent({
+    isPublic: true,
+    label,
+    name: ACTOR,
+    preserveSensitiveData: false,
+  });
+
+export const conformantExternalEventsMap = (): Record<
+  string,
+  BoldDocumentEvent
+> => ({
+  ...Object.fromEntries(
+    SPECIFIED_EVENT_NAMES.map((eventName) => [
+      eventName,
+      conformantEvent(eventName),
+    ]),
+  ),
+  ...Object.fromEntries(
+    ASSERTABLE_ACTOR_LABELS.map((label) => [
+      actorEventKey(label),
+      conformantActorEvent(label),
+    ]),
+  ),
+});

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.test-cases.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/privacy-flags.test-cases.ts
@@ -4,34 +4,30 @@ import {
   stubDocumentEvent,
   stubDocumentEventAttribute,
 } from '@carrot-fndn/shared/methodologies/bold/testing';
-import {
-  BoldActorType,
-  BoldDocumentEventName,
-} from '@carrot-fndn/shared/methodologies/bold/types';
+import { BoldDocumentEventName } from '@carrot-fndn/shared/methodologies/bold/types';
 
-import { EVENT_PRIVACY_SPEC } from './privacy-flags.constants';
+import {
+  ASSERTABLE_ACTOR_LABELS,
+  EVENT_PRIVACY_SPEC,
+} from './privacy-flags.constants';
 
 const { ACTOR } = BoldDocumentEventName;
-const { HAULER, PROCESSOR, RECYCLER, WASTE_GENERATOR } = BoldActorType;
 
 export const SPECIFIED_EVENT_NAMES = [...EVENT_PRIVACY_SPEC.keys()];
-
-export const ASSERTABLE_ACTOR_LABELS = [
-  HAULER,
-  PROCESSOR,
-  RECYCLER,
-  WASTE_GENERATOR,
-];
 
 export const actorEventKey = (label: string): string => `${ACTOR}-${label}`;
 
 export const conformantEvent = (eventName: string): BoldDocumentEvent => {
   const eventSpec = EVENT_PRIVACY_SPEC.get(eventName);
 
+  if (eventSpec === undefined) {
+    throw new Error(`No privacy spec found for event "${eventName}"`);
+  }
+
   return stubDocumentEvent({
     isPublic: true,
     metadata: {
-      attributes: [...(eventSpec?.attributes ?? [])].map(
+      attributes: [...eventSpec.attributes].map(
         ([attributeName, attributeSpec]) =>
           stubDocumentEventAttribute({
             isPublic: attributeSpec.isPublic,
@@ -63,7 +59,7 @@ export const conformantExternalEventsMap = (): Record<
     ]),
   ),
   ...Object.fromEntries(
-    ASSERTABLE_ACTOR_LABELS.map((label) => [
+    [...ASSERTABLE_ACTOR_LABELS].map((label) => [
       actorEventKey(label),
       conformantActorEvent(label),
     ]),

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/tsconfig.eslint.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest-globals", "node", "methodology-rules-vitest-matchers"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["vitest.config.ts", "vitest.e2e.config.ts"]
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/tsconfig.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.eslint.json"
+    }
+  ]
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/tsconfig.spec.json
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/tsconfig.spec.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../../../.tsconfig/tsconfig.spec.json"
+}

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/vitest.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/vitest.config.ts
@@ -1,0 +1,7 @@
+import { getVitestBaseConfig } from '../../../../../../.vitest/config/vitest.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/vitest.e2e.config.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/privacy-flags/vitest.e2e.config.ts
@@ -1,0 +1,7 @@
+import { getVitestE2EBaseConfig } from '../../../../../../.vitest/config/vitest.e2e.base.config';
+import { getVitestBasePlugins } from '../../../../../../.vitest/config/vitest.base.plugins';
+
+export default {
+  ...getVitestE2EBaseConfig(import.meta.dirname),
+  plugins: getVitestBasePlugins(),
+};

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -40,6 +40,9 @@
       "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/driver-identification": [
         "libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/index.ts"
       ],
+      "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/privacy-flags": [
+        "libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts"
+      ],
       "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler": [
         "libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/index.ts"
       ],

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -28,6 +28,9 @@
       "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/prevented-emissions": [
         "libs/methodologies/bold/rule-processors/mass-id/prevented-emissions/src/index.ts"
       ],
+      "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/privacy-flags": [
+        "libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts"
+      ],
       "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit": [
         "libs/methodologies/bold/rule-processors/mass-id/no-conflicting-certificate-or-credit/src/index.ts"
       ],
@@ -39,9 +42,6 @@
       ],
       "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/driver-identification": [
         "libs/methodologies/bold/rule-processors/mass-id/driver-identification/src/index.ts"
-      ],
-      "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/privacy-flags": [
-        "libs/methodologies/bold/rule-processors/mass-id/privacy-flags/src/index.ts"
       ],
       "@carrot-fndn/shared/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler": [
         "libs/methodologies/bold/rule-processors/mass-id/drop-off-at-recycler/src/index.ts"


### PR DESCRIPTION
Add a MassID rule processor that compares the privacy flags an integrator declares against a declarative table of what the BOLD methodology specifies, and reports every divergence as `REVIEW_REQUIRED`.

Nothing validated these flags before. `preserveSensitiveData` was read only by the two `rewards-distribution` processors, for payout logic; `isPublic` and `sensitive` appeared only in Zod schemas, getter/predicate validators and test builders. The cost was real: ten production MassIDs from one integrator carried 70 events and 100 attributes with wrong `isPublic`, hiding methodology-specified data from the public explorer. It was found by hand, months after ingestion, and fixed by data surgery.

## What the rule checks

| Field | Level | Effect when wrong |
|---|---|---|
| `isPublic` | event, attribute | `false` deletes the value from the public API |
| `sensitive` | attribute | with `isPublic: true`, publishes the value partially masked |
| `preserveSensitiveData` | event | `true` forces `{ isPublic: false }`, stripping participant `name` / `taxId` |

One walker iterates the document's events once and splits findings into `reviewReasons` and `notValidated`. All policy lives in two declarative tables in `privacy-flags.constants.ts` — there is no per-event validator code.

## The table, and where it comes from

Derived from the 2,038 cached production MassIDs in the document-extractor cache, re-run directly against those files. Seven events, all expecting `isPublic: true` (2038/2038):

| Event | Attributes | Also `sensitive: true` |
|---|---|---|
| `Pick-up` | Description, Vehicle Type, Local Waste Classification ID / Description, Driver Identifier Exemption Justification | Driver Identifier, Vehicle License Plate |
| `Weighing` | Description, Weighing Capture Method, Scale Type, Container Type, Gross Weight, Tare | Vehicle License Plate |
| `Sorting` | Description, Gross Weight, Deducted Weight | — |
| `Drop-off` | Description, Receiving Operator Identifier | — |
| `Recycled` | Description | — |
| `Transport Manifest` | Document Type, Document Number, Issue Date, Exemption Justification | — |
| `Recycling Manifest` | Document Type, Document Number, Issue Date | — |

Actors are an **allow-list** — `Hauler`, `Processor`, `Recycler`, `Waste Generator`. Everything else is skipped, including `Integrator` and `METHODOLOGY PLATFORM`. That matters: `METHODOLOGY PLATFORM` exists in no enum yet appears on 2038/2038 documents at `isPublic: false`, which is the evidence that a deny-list would eventually fire on every document carrying the next such label.

`preserveSensitiveData: true` is a violation only for `Processor` and `Recycler`, which are explicitly `false` on 2038/2038. `Hauler` and `Waste Generator` are genuinely bimodal (1773 false / 265 true) — asserting there would fire `REVIEW_REQUIRED` on 87% of production and drown the real signal.

## Invariants

- Only what the methodology specifies is validated. Anything else is reported separately as `notValidated`, never as a violation.
- Absence is never a violation — an attribute the methodology specifies but the integrator omitted is ignored. Completeness belongs to rules like `document-manifest-data`.
- Carrot-generated events (`MassID Audit (BOLD Recycling)`, `MassID Audit (BOLD Carbon)`, `GasID`, `RecycledID`) and non-specified actors emit nothing at all, so they cannot be mistaken for integrator error.
- The rule reports; it never blocks.

`reviewReasons` entries extend the repo's existing `ReviewReason` contract, so `pnpm run-rule`'s batch summary aggregates privacy findings by reason code exactly as it does for `document-manifest-data`. No result field carries an attribute *value* — only event names, actor role labels, attribute names and booleans.

## Live test against real production data

Run offline through `pnpm run-rule run … --input-file`, which serves documents from the local production cache (`Using cached document` logged for both entries, no S3 access):

- An unmodified cached production MassID → `PASSED`, 11 validated events, empty `reviewReasons` and `notValidated`.
- A copy mutated to carry the integrator's original flags (`Pick-up`, `Transport Manifest`, `Recycling Manifest` at `isPublic: false`; `Processor` ACTOR at `preserveSensitiveData: true`) → `REVIEW_REQUIRED` with exactly four findings:

```
=== Batch Execution Summary ===
Total documents: 2
Passed: 1
Review required: 1
Failed (rule): 0
Errors: 0

Review Reason Codes (Review Required):
  PRIVACY_EVENT_IS_PUBLIC_MISMATCH: 3
  PRIVACY_ACTOR_PRESERVE_SENSITIVE_DATA: 1
```

## Scope

Library only. No app/lambda project, no `rules.config.ts` entry, no new `MethodologyFrameworkRuleSlug`. Deploying needs a framework-rule slug and none of the existing ones covers data privacy — inventing one is a methodology decision, not an engineering one, so deployment is a deliberate follow-up.

Two files outside the new project change: `tsconfig.paths.json` (the import alias) and `codecov.yml` (one flag block, written by hand to match `generateCodecovYaml()` byte-for-byte — that file is generated from the lib directory listing, so a new rule directory drifts it).

## Known gaps, recorded rather than silently left

- **`Vehicle ID`** — present on 265/2038 documents carrying a `Vehicle License Plate` at `sensitive: true`, so the rule sees a masked plate it does not check. It falls to `notValidated`. Adding it needs `Vehicle ID`, `LPR Software` and `LPR Supplier` added to the shared enums first, and a decision on whether the event is integrator-sent or Carrot-generated.
- **`preserveSensitiveData` on non-ACTOR events is not validated.** Five events (`Drop-off`, `Recycled`, `Recycling Manifest`, `Sorting`, `Weighing`) carry a Processor participant and are never `true` — but the corpus shows `undefined` 2038/2038 rather than an explicit `false`, i.e. the producer never writes the field there. Inferring "must not be true" from silence is weaker evidence than the ACTOR case, and it collides with this rule's own "absence is not a violation" invariant. Settle with the methodology, then add it.

Both belong to the deploy decision, not this merge.

## Verification

- 27 unit tests, `privacy-flags.processor.ts` at 100% statements / branches / functions / lines (the repo gate).
- 2 e2e tests through the lambda handler.
- `nx affected` vs `main` resolves to this project alone; lint, typecheck, test and test-e2e all pass locally.
- The spec table is asserted as hand-written literal data, independently of `EVENT_PRIVACY_SPEC`, because the processor fixtures are built *from* that table and so cannot police it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Privacy Flags rule for BOLD Mass ID documents.
  - Validates event and attribute visibility, sensitivity, actor privacy, and sensitive-data handling.
  - Provides clear pass or review-required results with privacy-specific reasons.
  - Supports configured event privacy specifications and excluded events.

- **Tests**
  - Added comprehensive unit and end-to-end coverage for valid, invalid, skipped, unknown, and incomplete privacy data scenarios.

- **Documentation**
  - Added initial version 1.0.0 changelog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->