### PR TITLE
Fix MassID Sorting rule when all events share the same timestamp

### DIFF
--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.spec.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.spec.ts
@@ -203,6 +203,40 @@ describe('mass-id-sorting helpers', () => {
       expect(result.priorEventWithValue?.value).toBe(120);
     });
 
+    it('should select the prior value event when every event shares the same externalCreatedAt', () => {
+      const sameCreatedAt = '2026-01-01T00:00:00.000Z';
+      const actorEvent = {
+        externalCreatedAt: sameCreatedAt,
+        name: 'ACTOR',
+        value: undefined,
+      } as unknown as BoldDocumentEvent;
+      const weighingEvent = stubBoldMassIDWeighingEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: sameCreatedAt,
+          value: 1400,
+        },
+      });
+      const sortingEvent = stubBoldMassIDSortingEvent({
+        partialDocumentEvent: {
+          externalCreatedAt: sameCreatedAt,
+          value: 1386,
+        },
+      });
+
+      const result = findSortingEvents([
+        actorEvent,
+        weighingEvent,
+        sortingEvent,
+      ]);
+
+      if ('isError' in result) {
+        throw new Error('Expected SortingEvents, got ValidationError');
+      }
+
+      expect(result.priorEventWithValue).toBe(weighingEvent);
+      expect(result.priorEventWithValue?.value).toBe(1400);
+    });
+
     it('should leave priorEventWithValue undefined when no value event precedes Sorting in time', () => {
       const sortingEvent = stubBoldMassIDSortingEvent({
         partialDocumentEvent: {

--- a/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.ts
+++ b/libs/methodologies/bold/rule-processors/mass-id/mass-id-sorting/src/mass-id-sorting.helpers.ts
@@ -109,7 +109,7 @@ export const findSortingEvents = (
       (event) =>
         event !== sortingEvent &&
         event.value !== undefined &&
-        new Date(event.externalCreatedAt).getTime() < sortingCreatedAt,
+        new Date(event.externalCreatedAt).getTime() <= sortingCreatedAt,
     )
     .sort(
       (a, b) =>


### PR DESCRIPTION
### 🧾 Summary

`findSortingEvents` selected "the value before Sorting" as the latest value-bearing event whose `externalCreatedAt` is **strictly** before the Sorting event's `externalCreatedAt`. This PR relaxes that comparison to `<=`, so an event sharing the Sorting event's timestamp is still eligible.

### 🧩 Context

When a source system emits day-granularity timestamps, every event on a MassID carries the identical `externalCreatedAt`. The value-bearing Weighing event then has the same timestamp as the Sorting event, strict `<` excludes it, `priorEventWithValue` becomes `undefined`, and the rule fails with:

```
The value before the "Sorting" must be greater than 0, but "undefined" was provided.
```

The rule only ever worked because most source systems emit sub-day timestamps, where Weighing and Sorting land on distinct times.

The `"undefined"` in the message is misleading: `EVENT_BEFORE_SORTING_UNDEFINED` (no prior event found at all) and `INVALID_VALUE_BEFORE_SORTING` (prior event found, value not positive) both render through `INVALID_VALUE_BEFORE_SORTING(priorEventWithValue?.value)` in the processor, so the "no prior event" case reports as a bad value rather than a missing event.

### 🧱 Scope of this PR

**Included:** the `<` → `<=` change in `findSortingEvents`, plus a regression test for the all-events-share-one-timestamp case.

**Not included:** splitting the two error codes into distinct result comments so `EVENT_BEFORE_SORTING_UNDEFINED` no longer renders as `"undefined" was provided`. That is a message-only concern and is left for a follow-up.

### 🧪 How to test

```bash
pnpm nx test methodologies-bold-rule-processors-mass-id-mass-id-sorting
pnpm nx lint methodologies-bold-rule-processors-mass-id-mass-id-sorting
pnpm nx ts methodologies-bold-rule-processors-mass-id-mass-id-sorting
```

The new helpers-spec case (`should select the prior value event when every event shares the same externalCreatedAt`) **fails before** the production change with `priorEventWithValue` = `undefined`, and passes after. Verified locally: 29/29 tests pass, lint and typecheck clean.

### 🧠 Considerations for Review

- **The Sorting event cannot select itself.** The existing `event !== sortingEvent` identity guard in the same filter already excludes it, so `<=` widens the candidate set without letting the Sorting event become its own prior value.
- **Tie resolution.** `Array.prototype.sort` is stable (ES2019), so when several candidates share the Sorting timestamp, `.at(-1)` resolves to the **last such event in array order**. That is the only behavioural difference beyond eligibility.
  - Worth a look during review: if a document has more than one valued event at the Sorting timestamp and they sit *after* Sorting in array order, the later one wins the tie. Selection stays purely timestamp-based — deliberately, see below — so array position is not consulted as a constraint, only as the stable-sort tiebreak that falls out of it.
- **No array-index selection is reintroduced.** 9e7c748d replaced the old `.slice(0, sortingEventIndex).reverse().find(...)` because production stores `externalEvents` in non-chronological array order — Sorting can sit at a lower array index than chronologically earlier value-bearing events. That regression case is still in the spec and still green.

### 🔗 Related Links

- Previous PR in this area: #408 (`9e7c748d`) — moved prior-value selection from array index to timestamp.

---

- [ ] **I, the PR author, confirm that this PR works as expected and does not break any service. I also confirm that I applied best practices and improved the codebase quality.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event sorting when weighing and sorting events share the same timestamp.
  * Ensures the immediately preceding weighing event is selected correctly in these cases.

* **Tests**
  * Added coverage for events with identical timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->